### PR TITLE
Fix configure to work with multiarch distributions.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ AC_SUBST([localstatedir])
 # will not work as separator. eg: n \ ? ( { ) }
 sed_quote()
 {
-        echo -n "$2" | sed -e 's/\n/\\n/' -e 's|\([][*.$|'"$1"']\)|\\\1|g'
+        echo -n "$2" | sed -e 's/\n/\\n/' -e 's|\(@<:@@:>@@<:@*.$|'"$1"'@:>@\)|\\\1|g'
 }
 
 # remove_dir_prefix prefix path

--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,30 @@ case $prefix:$localstatedir in
 esac
 AC_SUBST([localstatedir])
 
-libdirname=`basename "$libdir"`
+# sed_quote separator string
+# Prefixes occurences of sed special characters and separator with \ in string.
+# Suggested separators: , / (space) .
+# Note that the character is prefixed with \ so characters that get special meaning
+# will not work as separator. eg: n \ ? ( { ) }
+sed_quote()
+{
+        echo -n "$2" | sed -e 's/\n/\\n/' -e 's|\([][*.$|'"$1"']\)|\\\1|g'
+}
+
+# remove_dir_prefix prefix path
+# Remove leading path prefix.
+# Return directory name without leading slash (basename drop-in).
+# Handle prefix trailing slash.
+# // (double slash) is not handled.
+remove_dir_prefix(){
+    local prefix="$(sed_quote "," "$1")"
+    echo "$1" | grep -q '/$' || prefix="${prefix}/"
+    local re="^$(sed_quote "," "$prefix")"
+    echo "$2" | grep -q "$re" || re=/
+    echo "$2" | sed -e "s,${re},,"
+}
+
+libdirname=`remove_dir_prefix '${exec_prefix}' "$libdir"`
 AC_SUBST([libdirname])
 
 # The original default values of {bin,sbin,lib}dir

--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,15 @@ remove_dir_prefix(){
     echo "$2" | sed -e "s,${re},,"
 }
 
-libdirname=`remove_dir_prefix '${exec_prefix}' "$libdir"`
+libdirname1=`remove_dir_prefix '${exec_prefix}' "$libdir"`
+libdirname2=`remove_dir_prefix "${exec_prefix}" "$libdir"`
+# pick the shorter - a prefix was removed there
+if [ $(echo "$libdirname1" | wc -c) -lt $(echo "$libdirname2" | wc -c) ] ; then
+    libdirname=libdirname1
+else
+    libdirname=libdirname2
+fi
+
 AC_SUBST([libdirname])
 
 # The original default values of {bin,sbin,lib}dir


### PR DESCRIPTION
On multiarch distributions configure is run with arguments like --libdir=/lib/x86_64-linux-gnu --libexecdir=\${prefix}/lib/x86_64-linux-gnu

Running basename on such directory obviously does not produce desirable results.