### PR TITLE
Use inttypes.h macros when formatting uint64_t, int64_t values

### DIFF
--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -91,6 +91,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>
@@ -627,7 +628,7 @@ read_tables(void) {
 	if (show) {
 		printf(_("%ld inodes\n"), inodes);
 		printf(_("%ld blocks\n"), zones);
-		printf(_("Firstdatazone=%jd (%jd)\n"), first_zone, norm_first_zone);
+		printf(_("Firstdatazone=%jd (%jd)\n"), (intmax_t)first_zone, (intmax_t)norm_first_zone);
 		printf(_("Zonesize=%d\n"), MINIX_BLOCK_SIZE << get_zone_size());
 		printf(_("Maxsize=%zu\n"), get_max_size());
 		printf(_("Filesystem state=%d\n"), Super.s_state);

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -543,7 +543,7 @@ static void setup_tables(void) {
 	memset(inode_buffer,0, get_inode_buffer_size());
 	printf(_("%lu inodes\n"), inodes);
 	printf(_("%lu blocks\n"), zones);
-	printf(_("Firstdatazone=%jd (%jd)\n"), get_first_zone(), first_zone_data());
+	printf(_("Firstdatazone=%jd (%jd)\n"), (intmax_t)get_first_zone(), (intmax_t)first_zone_data());
 	printf(_("Zonesize=%zu\n"), (size_t) MINIX_BLOCK_SIZE << get_zone_size());
 	printf(_("Maxsize=%zu\n\n"),get_max_size());
 }

--- a/fdisks/fdiskdoslabel.c
+++ b/fdisks/fdiskdoslabel.c
@@ -118,7 +118,7 @@ static void read_pte(struct fdisk_context *cxt, int pno, sector_t offset)
 	pe->sectorbuffer = xcalloc(1, cxt->sector_size);
 
 	if (read_sector(cxt, offset, pe->sectorbuffer) != 0)
-		fprintf(stderr, _("Failed to read extended partition table (offset=%jd)\n"),
+		fprintf(stderr, _("Failed to read extended partition table (offset=%ju)\n"),
 					(uintmax_t) offset);
 	pe->changed = 0;
 	pe->part_table = pe->ext_pointer = NULL;
@@ -850,7 +850,7 @@ static int write_sector(struct fdisk_context *cxt, sector_t secno,
 
 	rc = seek_sector(cxt, secno);
 	if (rc != 0) {
-		fprintf(stderr, _("write sector %jd failed: seek failed"),
+		fprintf(stderr, _("write sector %ju failed: seek failed"),
 				(uintmax_t) secno);
 		return rc;
 	}

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -19,9 +19,13 @@
  *  - old LOOP_{SET,GET}_STATUS (32bit) ioctls are unsupported
  *  - extendible
  */
+
+#define __STDC_FORMAT_MACROS
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <inttypes.h>
 #include <ctype.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -1012,7 +1016,7 @@ int loopcxt_set_offset(struct loopdev_cxt *lc, uint64_t offset)
 		return -EINVAL;
 	lc->info.lo_offset = offset;
 
-	DBG(lc, loopdev_debug("set offset=%jd", offset));
+	DBG(lc, loopdev_debug("set offset=%" PRIu64, offset));
 	return 0;
 }
 
@@ -1025,7 +1029,7 @@ int loopcxt_set_sizelimit(struct loopdev_cxt *lc, uint64_t sizelimit)
 		return -EINVAL;
 	lc->info.lo_sizelimit = sizelimit;
 
-	DBG(lc, loopdev_debug("set sizelimit=%jd", sizelimit));
+	DBG(lc, loopdev_debug("set sizelimit=%" PRIu64, sizelimit));
 	return 0;
 }
 
@@ -1428,10 +1432,10 @@ static void test_loop_info(const char *device, int flags, int debug)
 	free(p);
 
 	if (loopcxt_get_offset(&lc, &u64) == 0)
-		printf("\tOFFSET: %jd\n", u64);
+		printf("\tOFFSET: %" PRIu64 "\n", u64);
 
 	if (loopcxt_get_sizelimit(&lc, &u64) == 0)
-		printf("\tSIZE LIMIT: %jd\n", u64);
+		printf("\tSIZE LIMIT: %" PRIu64 "\n", u64);
 
 	printf("\tAUTOCLEAR: %s\n", loopcxt_is_autoclear(&lc) ? "YES" : "NOT");
 

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -3,6 +3,8 @@
  * Copyright (C) 2010 Davidlohr Bueso <dave@gnu.org>
  */
 
+#define __STDC_FORMAT_MACROS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -404,7 +406,7 @@ char *size_to_human_string(int options, uint64_t bytes)
 
 	*psuf = '\0';
 
-	/* fprintf(stderr, "exp: %d, unit: %c, dec: %d, frac: %jd\n",
+	/* fprintf(stderr, "exp: %d, unit: %c, dec: %d, frac: %" PRIu64 "\n",
 	 *                 exp, suffix[0], dec, frac);
 	 */
 
@@ -421,7 +423,7 @@ char *size_to_human_string(int options, uint64_t bytes)
 
 		if (!dp || !*dp)
 			dp = ".";
-		snprintf(buf, sizeof(buf), "%d%s%jd%s", dec, dp, frac, suffix);
+		snprintf(buf, sizeof(buf), "%d%s%" PRIu64 "%s", dec, dp, frac, suffix);
 	} else
 		snprintf(buf, sizeof(buf), "%d%s", dec, suffix);
 

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -4,6 +4,10 @@
  *
  * Written by Karel Zak <kzak@redhat.com>
  */
+
+#define __STDC_FORMAT_MACROS
+
+#include <inttypes.h>
 #include <ctype.h>
 
 #include "c.h"
@@ -829,7 +833,7 @@ int main(int argc, char *argv[])
 	if (sysfs_read_u64(&cxt, "size", &u64))
 		printf("read SIZE failed\n");
 	else
-		printf("SIZE: %jd\n", u64);
+		printf("SIZE: %" PRIu64 "\n", u64);
 
 	if (sysfs_read_int(&cxt, "queue/hw_sector_size", &i))
 		printf("read SECTOR failed\n");

--- a/libblkid/samples/partitions.c
+++ b/libblkid/samples/partitions.c
@@ -5,8 +5,11 @@
  * GNU Lesser General Public License.
  */
 
+#define __STDC_FORMAT_MACROS
+
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -48,7 +51,7 @@ int main(int argc, char *argv[])
 		errx(EXIT_FAILURE, "%s: does not contains any "
 				 "known partition table\n", devname);
 
-	printf("size: %jd, sector size: %u, PT: %s, offset: %jd\n---\n",
+	printf("size: %" PRId64 ", sector size: %u, PT: %s, offset: %" PRId64 "\n---\n",
 		blkid_probe_get_size(pr),
 		blkid_probe_get_sectorsize(pr),
 		blkid_parttable_get_type(root_tab),

--- a/libblkid/src/partitions/partitions.c
+++ b/libblkid/src/partitions/partitions.c
@@ -7,6 +7,9 @@
  * GNU Lesser General Public License.
  *
  */
+
+#define __STDC_FORMAT_MACROS
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -759,9 +762,9 @@ static int blkid_partitions_probe_partition(blkid_probe pr)
 		blkid_probe_sprintf_value(pr, "PART_ENTRY_NUMBER",
 				"%d", blkid_partition_get_partno(par));
 
-		blkid_probe_sprintf_value(pr, "PART_ENTRY_OFFSET", "%jd",
+		blkid_probe_sprintf_value(pr, "PART_ENTRY_OFFSET", "%" PRId64,
 				blkid_partition_get_start(par));
-		blkid_probe_sprintf_value(pr, "PART_ENTRY_SIZE", "%jd",
+		blkid_probe_sprintf_value(pr, "PART_ENTRY_SIZE", "%" PRId64,
 				blkid_partition_get_size(par));
 
 		blkid_probe_sprintf_value(pr, "PART_ENTRY_DISK", "%u:%u",
@@ -785,7 +788,7 @@ int blkid_probe_is_covered_by_pt(blkid_probe pr,
 	int nparts, i, rc = 0;
 
 	DBG(DEBUG_LOWPROBE, printf(
-		"=> checking if off=%jd size=%jd covered by PT\n",
+		"=> checking if off=%" PRId64 " size=%" PRId64 " covered by PT\n",
 		offset, size));
 
 	prc = blkid_clone_probe(pr);

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -84,6 +84,8 @@
  * The probing result is set of NAME=value pairs (the NAME is always unique).
  */
 
+#define __STDC_FORMAT_MACROS
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -551,7 +553,7 @@ unsigned char *blkid_probe_get_buffer(blkid_probe pr,
 
 		if (x->off <= off && off + len <= x->off + x->len) {
 			DBG(DEBUG_LOWPROBE,
-				printf("\treuse buffer: off=%jd len=%jd pr=%p\n",
+				printf("\treuse buffer: off=%" PRId64 " len=%" PRId64 " pr=%p\n",
 							x->off, x->len, pr));
 			bf = x;
 			break;
@@ -574,7 +576,7 @@ unsigned char *blkid_probe_get_buffer(blkid_probe pr,
 		INIT_LIST_HEAD(&bf->bufs);
 
 		DBG(DEBUG_LOWPROBE,
-			printf("\tbuffer read: off=%jd len=%jd pr=%p\n",
+			printf("\tbuffer read: off=%" PRId64 " len=%" PRId64 " pr=%p\n",
 				off, len, pr));
 
 		ret = read(pr->fd, bf->data, len);
@@ -719,7 +721,7 @@ int blkid_probe_set_device(blkid_probe pr, int fd,
 		pr->flags |= BLKID_FL_CDROM_DEV;
 #endif
 
-	DBG(DEBUG_LOWPROBE, printf("ready for low-probing, offset=%jd, size=%jd\n",
+	DBG(DEBUG_LOWPROBE, printf("ready for low-probing, offset=%" PRId64 ", size=%" PRId64 "\n",
 				pr->off, pr->size));
 	DBG(DEBUG_LOWPROBE, printf("whole-disk: %s, regfile: %s\n",
 		blkid_probe_is_wholedisk(pr) ?"YES" : "NO",
@@ -1642,7 +1644,7 @@ void blkid_probe_set_wiper(blkid_probe pr, blkid_loff_t off, blkid_loff_t size)
 	pr->wipe_chain = chn;
 
 	DBG(DEBUG_LOWPROBE,
-		printf("wiper set to %s::%s off=%jd size=%jd\n",
+		printf("wiper set to %s::%s off=%" PRId64 " size=%" PRId64 "\n",
 			chn->driver->name,
 			chn->driver->idinfos[chn->idx]->name,
 			pr->wipe_off, pr->wipe_size));

--- a/libblkid/src/superblocks/drbdproxy_datalog.c
+++ b/libblkid/src/superblocks/drbdproxy_datalog.c
@@ -4,6 +4,9 @@
  * This file may be redistributed under the terms of the
  * GNU Lesser General Public License.
  */
+
+#define __STDC_FORMAT_MACROS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -36,7 +39,7 @@ static int probe_drbdproxy_datalog(blkid_probe pr,
 		return -1;
 
 	blkid_probe_set_uuid(pr, lh->uuid);
-	blkid_probe_sprintf_version(pr, "v%jd", le64_to_cpu(lh->version));
+	blkid_probe_sprintf_version(pr, "v%" PRIu64, le64_to_cpu(lh->version));
 
 	return 0;
 }

--- a/libblkid/src/superblocks/ntfs.c
+++ b/libblkid/src/superblocks/ntfs.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <unistd.h>
 #include <string.h>
 #include <inttypes.h>
@@ -154,7 +155,7 @@ static int probe_ntfs(blkid_probe pr, const struct blkid_idmag *mag)
 			"cluster_offset=%jd\n",
 			(int) sector_size, mft_record_size,
 			sectors_per_cluster, nr_clusters,
-			off));
+			(intmax_t)off));
 
 	buf_mft = blkid_probe_get_buffer(pr, off, mft_record_size);
 	if (!buf_mft)

--- a/libblkid/src/superblocks/vfat.c
+++ b/libblkid/src/superblocks/vfat.c
@@ -8,8 +8,12 @@
  * This file may be redistributed under the terms of the
  * GNU Lesser General Public License.
  */
+
+#define __STDC_FORMAT_MACROS
+
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
@@ -125,7 +129,7 @@ static unsigned char *search_fat_label(blkid_probe pr,
 
 	DBG(DEBUG_LOWPROBE,
 		printf("\tlook for label in root-dir "
-			"(entries: %d, offset: %jd)\n", entries, offset));
+			"(entries: %d, offset: %" PRIu64 ")\n", entries, offset));
 
 	if (!blkid_probe_is_tiny(pr)) {
 		/* large disk, read whole root directory */

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -14,6 +14,7 @@
 #include <ctype.h>
 #include <blkid.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include "mountP.h"
 #include "strutils.h"
@@ -1452,9 +1453,9 @@ int mnt_fs_print_debug(struct libmnt_fs *fs, FILE *file)
 	if (mnt_fs_get_swaptype(fs))
 		fprintf(file, "swaptype: %s\n", mnt_fs_get_swaptype(fs));
 	if (mnt_fs_get_size(fs))
-		fprintf(file, "size: %jd\n", mnt_fs_get_size(fs));
+		fprintf(file, "size: %jd\n", (intmax_t)mnt_fs_get_size(fs));
 	if (mnt_fs_get_usedsize(fs))
-		fprintf(file, "usedsize: %jd\n", mnt_fs_get_usedsize(fs));
+		fprintf(file, "usedsize: %jd\n", (intmax_t)mnt_fs_get_usedsize(fs));
 	if (mnt_fs_get_priority(fs))
 		fprintf(file, "priority: %d\n", mnt_fs_get_priority(fs));
 

--- a/libmount/src/tab_parse.c
+++ b/libmount/src/tab_parse.c
@@ -281,8 +281,8 @@ static int mnt_parse_swaps_line(struct libmnt_fs *fs, char *s)
 
 	rc = sscanf(s,	UL_SCNsA" "	/* (1) source */
 			UL_SCNsA" "	/* (2) type */
-			"%jd"		/* (3) size */
-			"%jd"		/* (4) used */
+			"%ju"		/* (3) size */
+			"%ju"		/* (4) used */
 			"%d",		/* priority */
 
 			&src,

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -20,6 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#define __STDC_FORMAT_MACROS
+
 #include <stdio.h>
 #include <errno.h>
 #include <getopt.h>
@@ -790,7 +792,7 @@ static void set_tt_data(struct blkdev_cxt *cxt, int col, int id, struct tt_line 
 	case COL_SIZE:
 		if (cxt->size) {
 			if (lsblk->bytes)
-				xasprintf(&p, "%jd", cxt->size);
+				xasprintf(&p, "%" PRIu64, cxt->size);
 			else
 				p = size_to_human_string(SIZE_SUFFIX_1LETTER, cxt->size);
 			if (p)

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 #include <getopt.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -415,10 +416,10 @@ static void add_tt_line(struct tt *tt, struct lock *l)
 			xasprintf(&str, "%d", l->mandatory);
 			break;
 		case COL_START:
-			xasprintf(&str, "%jd", l->start);
+			xasprintf(&str, "%jd", (intmax_t)l->start);
 			break;
 		case COL_END:
-			xasprintf(&str, "%jd", l->end);
+			xasprintf(&str, "%jd", (intmax_t)l->end);
 			break;
 		case COL_PATH:
 			xasprintf(&str, "%s", l->path ? l->path : notfnd);

--- a/mount-deprecated/mount.c
+++ b/mount-deprecated/mount.c
@@ -1211,7 +1211,7 @@ parse_offset(const char **opt, uintmax_t *val)
 		return -1;
 
 	tmp = xmalloc(32);
-	snprintf(tmp, 32, "%jd", *val);
+	snprintf(tmp, 32, "%ju", *val);
 	my_free(*opt);
 	*opt = tmp;
 	return 0;

--- a/sys-utils/ipcs.c
+++ b/sys-utils/ipcs.c
@@ -15,9 +15,12 @@
  * - added Native Language Support
  */
 
+#define __STDC_FORMAT_MACROS
+
 #include <errno.h>
 #include <features.h>
 #include <getopt.h>
+#include <inttypes.h>
 
 #include "c.h"
 #include "nls.h"
@@ -570,7 +573,7 @@ static void print_shm(int shmid, int unit)
 	       shmdata->shm_perm.mode & 0777);
 	ipc_print_size(unit, unit == IPC_UNIT_HUMAN ? _("size=") : _("bytes="),
 		       shmdata->shm_segsz, "\t", 0);
-	printf(_("lpid=%u\tcpid=%u\tnattch=%jd\n"),
+	printf(_("lpid=%u\tcpid=%u\tnattch=%" PRIu64 "\n"),
 	       shmdata->shm_lprid, shmdata->shm_cprid,
 	       shmdata->shm_nattch);
 	printf(_("att_time=%-26.24s\n"),
@@ -601,7 +604,7 @@ void print_msg(int msgid, int unit)
 		       msgdata->q_cbytes, "\t", 0);
 	ipc_print_size(unit, unit == IPC_UNIT_HUMAN ? _("qsize=") : _("qbytes="),
 		       msgdata->q_qbytes, "\t", 0);
-	printf("qnum=%jd\tlspid=%d\tlrpid=%d\n",
+	printf("qnum=%" PRIu64 "\tlspid=%d\tlrpid=%d\n",
 	       msgdata->q_qnum,
 	       msgdata->q_lspid, msgdata->q_lrpid);
 	printf(_("send_time=%-26.24s\n"),

--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -4,6 +4,9 @@
  *
  * losetup.c - setup and control loop devices
  */
+
+#define __STDC_FORMAT_MACROS
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -236,13 +239,13 @@ static int set_tt_data(struct loopdev_cxt *lc, struct tt_line *ln)
 			break;
 		case COL_OFFSET:
 			if (loopcxt_get_offset(lc, &x) == 0)
-				xasprintf(&np, "%jd", x);
+				xasprintf(&np, "%" PRIu64, x);
 			if (np)
 				tt_line_set_data(ln, i, np);
 			break;
 		case COL_SIZELIMIT:
 			if (loopcxt_get_sizelimit(lc, &x) == 0)
-				xasprintf(&np, "%jd", x);
+				xasprintf(&np, "%" PRIu64, x);
 			if (np)
 				tt_line_set_data(ln, i, np);
 			break;

--- a/sys-utils/swapon.c
+++ b/sys-utils/swapon.c
@@ -154,7 +154,7 @@ static void add_tt_line(struct tt *tt, struct libmnt_fs *fs, int bytes)
 			size = mnt_fs_get_size(fs);
 			size *= 1024;	/* convert to bytes */
 			if (bytes)
-				xasprintf(&str, "%jd", size);
+				xasprintf(&str, "%jd", (intmax_t)size);
 			else
 				str = size_to_human_string(SIZE_SUFFIX_1LETTER, size);
 			break;
@@ -162,7 +162,7 @@ static void add_tt_line(struct tt *tt, struct libmnt_fs *fs, int bytes)
 			size = mnt_fs_get_usedsize(fs);
 			size *= 1024;	/* convert to bytes */
 			if (bytes)
-				xasprintf(&str, "%jd", size);
+				xasprintf(&str, "%jd", (intmax_t)size);
 			else
 				str = size_to_human_string(SIZE_SUFFIX_1LETTER, size);
 			break;


### PR DESCRIPTION
I was attempting to compile util-linux on Mac OS 10.7.5 (to build the `rename` utility), and I was seeing warnings about possibly incompatible printf specifiers being used.

Disclaimer: I have not tested these changes.