### PR TITLE
fsck: fix warning, gcc 5.0

### DIFF
--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -1471,7 +1471,7 @@ static void parse_argv(int argc, char *argv[])
 					else
 						goto next_arg;
 				} else if ((i+1) < argc &&
-					   !strncmp(argv[i+1], "-", 1) == 0) {
+					   strncmp(argv[i+1], "-", 1) != 0) {
 					progress_fd = string_to_int(argv[i]);
 					if (progress_fd < 0)
 						progress_fd = 0;


### PR DESCRIPTION
disk-utils/fsck.c:1474:37: warning: logical not is only applied to
the left hand side of comparison [-Wlogical-not-parentheses]
         !strncmp(argv[i+1], "-", 1) == 0) {
                                     ^

Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>