### PR TITLE
logger: link libsystemd-daemon.so

### DIFF
--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -23,8 +23,8 @@ usrbin_exec_PROGRAMS += logger
 dist_man_MANS += misc-utils/logger.1
 logger_SOURCES = misc-utils/logger.c lib/strutils.c
 if HAVE_SYSTEMD
-logger_LDADD = $(SYSTEMD_LIBS) $(SYSTEMD_JOURNAL_LIBS)
-logger_CFLAGS = $(SYSTEMD_CFLAGS) $(SYSTEMD_JOURNAL_CFLAGS)
+logger_LDADD = $(SYSTEMD_LIBS) $(SYSTEMD_DAEMON_LIBS) $(SYSTEMD_JOURNAL_LIBS)
+logger_CFLAGS = $(SYSTEMD_CFLAGS) $(SYSTEMD_DAEMON_CFLAGS) $(SYSTEMD_JOURNAL_CFLAGS)
 endif
 endif # BUILD_LOGGER
 


### PR DESCRIPTION
Noticed on openSUSE 13.1:
util-linux-2.26/misc-utils/logger.c:735: undefined reference to `sd_booted'

Introduced in d77dc29e.

CC: Sami Kerola <kerolasa@iki.fi>
Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>