### PR TITLE
logger: fix inconsistent format regression when logging locally

### DIFF
--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -481,14 +481,12 @@ static void logger_open(struct logger_ctl *ctl)
 			ctl->syslogfp = syslog_rfc5424;
 		return;
 	}
-	if (ctl->unix_socket) {
-		ctl->fd = unix_socket(ctl, ctl->unix_socket, ctl->socket_type);
-		if (!ctl->syslogfp)
-			ctl->syslogfp = syslog_rfc5424;
-		return;
-	}
-	ctl->fd = unix_socket(ctl, _PATH_DEVLOG, ctl->socket_type);
-	ctl->syslogfp = syslog_local;
+	if (!ctl->unix_socket)
+		ctl->unix_socket = _PATH_DEVLOG;
+
+	ctl->fd = unix_socket(ctl, ctl->unix_socket, ctl->socket_type);
+	if (!ctl->syslogfp)
+		ctl->syslogfp = syslog_local;
 }
 
 static void logger_command_line(const struct logger_ctl *ctl, char **argv)


### PR DESCRIPTION
The message format when writing to local sockets is inconsistent. Example:
```
$ ./logger --stderr test
<5>Mär  4 11:03:30 logger: test
$ ./logger -u /dev/log --stderr test
<5>1 2015-03-04T11:03:31.699841+0100 ubuntu1404esp rger - [timeQuality tzKnown="1" isSynced="1" syncAccuracy="29000"] test
```
The regression was introduced with 4de2e8a03859aaab2c25dc98f33409cd28de6acc
As far as the commit comments and man page indicates, this was meant to affect
remote system logging only, but it also affects local logging when the -u
option is given.

This causes problems with receivers who do not expect full-blown RFC format
on the log socket, like rsyslog. In consequence, this can also affect
log analysis programs and invalidate some of their results.

The patch corrects the behaviour so that the same old-style format is used for
any type of local logging. New-style can always be selected by command line-options.
RFC5424 is still the default for remote logging, as intended in the orignal
commit.

Result with the patch:
```
$ ./logger --stderr test
<5>Mär  4 11:15:35 logger: test
$ ./logger -u /dev/log --stderr test
<5>Mär  4 11:15:40 logger: test
$ ./logger -u /dev/log --rfc5424 --stderr test
<5>1 2015-03-04T11:21:28.796170+0100 ubuntu1404esp rger - [timeQuality tzKnown="1" isSynced="1" syncAccuracy="27500"] test
```
closes https://github.com/karelzak/util-linux/issues/157