### PR TITLE
logger: fix invalid timestamp in rfc5425 format

### DIFF
--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -359,8 +359,12 @@ static void syslog_rfc5424(const  struct logger_ctl *ctl, const char *msg)
 		if ((tm = localtime(&tv.tv_sec)) != NULL) {
 			char fmt[64];
 
-			strftime(fmt, sizeof(fmt), " %Y-%m-%dT%H:%M:%S.%%06u%z",
-				 tm);
+			const size_t i = strftime(fmt, sizeof(fmt),
+					" %Y-%m-%dT%H:%M:%S.%%06u%z ", tm);
+			/* patch TZ info to comply with RFC3339 (we left SP at end) */
+			fmt[i-1] = fmt[i-2];
+			fmt[i-2] = fmt[i-3];
+			fmt[i-3] = ':';
 			snprintf(time, sizeof(time), fmt, tv.tv_usec);
 		} else
 			err(EXIT_FAILURE, _("localtime() failed"));


### PR DESCRIPTION
The timestamp is written as

2015-03-04T15:02:02.566782+0100

unfortunately, this is not an RFC3339 timestamp as demanded by rfc5424.
The colon in the time offset field is missing. The correct timestamp is

2015-03-04T15:02:02.566782+01:00

(Note "+0100" vs. "+01:00")

closes https://github.com/karelzak/util-linux/issues/159