### PR TITLE
silence compiler warning

### DIFF
--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -91,7 +91,8 @@ static inline int __attribute__ ((__format__(printf, 2, 3)))
 	return ret;
 }
 
-static inline int xvasprintf(char **strp, const char *fmt, va_list ap)
+static inline int  __attribute__ ((__format__(printf, 2, 0)))
+xvasprintf(char **strp, const char *fmt, va_list ap)
 {
 	int ret = vasprintf(&(*strp), fmt, ap);
 	if (ret < 0)


### PR DESCRIPTION
Now that I got my CFLAGS fixed, I see some unncessary warnings.

This is primarily cosmetic, albeit it also provides an (only very slight) improvement in compile time error checking.

If you like this patch, I could check for some other occurences - I have seen some more when building all tools. Just don't wanted to waste time if you are not interested in that kind of patch...