### PR TITLE
fix issues in RFC5425 formatter

### DIFF
--- a/misc-utils/logger.1
+++ b/misc-utils/logger.1
@@ -95,6 +95,12 @@ will display MESSAGE field.  Use
 .B journalctl --output json-pretty
 to see rest of the fields.
 .TP
+.BR \-\-msgid " \fIMSGID
+Sets the RFC5424 MSGID field. Note that the space character is not permitted
+inside of \fIMSGID\fR. This option is only used if \fB\-\-rfc5424\fR is
+specified as well. Otherwise, it is silently ignored.
+
+.TP
 .BR \-\--size " \fIsize
 Sets the maximum permitted message size to \fIsize\fR. The default
 is 1KiB characters, which is the limit traditionally used and specified

--- a/misc-utils/logger.1
+++ b/misc-utils/logger.1
@@ -101,7 +101,7 @@ inside of \fIMSGID\fR. This option is only used if \fB\-\-rfc5424\fR is
 specified as well. Otherwise, it is silently ignored.
 
 .TP
-.BR \-\--size " \fIsize
+.BR \-\-size " \fIsize
 Sets the maximum permitted message size to \fIsize\fR. The default
 is 1KiB characters, which is the limit traditionally used and specified
 in RFC 3164. With RFC 5424, this limit has become flexible. A good assumption


### PR DESCRIPTION
rfc5424 was seriously broken.

This patch set:
1. fixes the issues
2. introduces a new capability to set the RFC5424 MSGID
3. fixes an unrelated issue in the man page

I thought 2. is good to have for users of RFC5424, but you can leave it out without side effects if you want.

closes https://github.com/karelzak/util-linux/issues/170