### PR TITLE
logger tests do not need /dev/log but socat

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -86,6 +86,13 @@ function travis_install_script
 		gtk-doc-tools \
 		ntp \
 		|| return
+
+	# install/upgrade custom stuff from non-official sources
+	sudo add-apt-repository -y ppa:malcscott/socat || return
+	sudo apt-get -qq update || return
+	sudo apt-get install -qq >/dev/null \
+		socat \
+		|| return
 }
 
 function travis_before_script

--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -914,10 +914,9 @@ int main(int argc, char **argv)
 		ctl.unix_socket_errors = 1;
 		break;
 	case AF_UNIX_ERRORS_AUTO:
+		ctl.unix_socket_errors = ctl.noact || ctl.stderr_printout;
 #ifdef HAVE_LIBSYSTEMD
-		ctl.unix_socket_errors = sd_booted();
-#else
-		ctl.unix_socket_errors = 0;
+		ctl.unix_socket_errors |= !!sd_booted();
 #endif
 		break;
 	default:

--- a/tests/expected/logger/errors-check_socket
+++ b/tests/expected/logger/errors-check_socket
@@ -1,0 +1,1 @@
+Check written socket data of all subtests.

--- a/tests/expected/logger/errors-check_socket
+++ b/tests/expected/logger/errors-check_socket
@@ -1,1 +1,19 @@
 Check written socket data of all subtests.
+socket data, kern_priority:
+<8>Feb 13 23:31:30 prio: message
+socket data, kern_priority_numeric:
+<8>Feb 13 23:31:30 prio: message
+socket data, invalid_prio:
+
+socket data, rfc5424_exceed_size:
+<13>1 2009-02-13T23:31:30.123456+00:00 test-hostname rfc5424_exceed_size - - [timeQuality tzKnown="1" isSynced="0"] abc
+socket data, id_with_space:
+
+socket data, id_with_space:
+
+socket data, tag_with_space:
+<13>Feb 13 23:31:30 A B: tag_with_space
+socket data, tag_with_space:
+<13>1 2009-02-13T23:31:30.123456+00:00 test-hostname A B - - [timeQuality tzKnown="1" isSynced="0"] tag_with_space_rfc5424
+socket data, rfc5424_msgid_with_space:
+

--- a/tests/expected/logger/errors-check_socket
+++ b/tests/expected/logger/errors-check_socket
@@ -17,3 +17,5 @@ socket data, tag_with_space:
 <13>1 2009-02-13T23:31:30.123456+00:00 test-hostname A B - - [timeQuality tzKnown="1" isSynced="0"] tag_with_space_rfc5424
 socket data, rfc5424_msgid_with_space:
 
+socket data, invalid_socket:
+

--- a/tests/expected/logger/errors-invalid_socket
+++ b/tests/expected/logger/errors-invalid_socket
@@ -1,0 +1,2 @@
+test_logger: socket /bad/boy: No such file or directory
+ret: 1

--- a/tests/expected/logger/formats-check_socket
+++ b/tests/expected/logger/formats-check_socket
@@ -1,0 +1,1 @@
+Check written socket data of all subtests.

--- a/tests/expected/logger/options-check_socket
+++ b/tests/expected/logger/options-check_socket
@@ -1,0 +1,1 @@
+Check written socket data of all subtests.

--- a/tests/ts/logger/errors
+++ b/tests/ts/logger/errors
@@ -72,7 +72,12 @@ ts_init_subtest "rfc5424_msgid_with_space"
 logger_fun -t "rfc5424_msgid_with_space" --rfc5424 --msgid="A B" "message"
 ts_finalize_subtest
 
+ts_init_subtest "check_socket"
+ts_log "Check written socket data of all subtests."
 sleep 1
 kill $SOCAT_PID
+wait $SOCAT_PID &>/dev/null
+cat "$SOCKIN" >> "$TS_OUTPUT" 2>&1
+ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/logger/errors
+++ b/tests/ts/logger/errors
@@ -36,8 +36,11 @@ ts_init_socket_to_file $DEVLOG $SOCKIN
 SOCAT_PID="$!"
 
 function logger_fun {
-	$TS_HELPER_LOGGER -u $DEVLOG -s --no-act "$@" >> "$TS_OUTPUT" 2>&1
+	# logger without --no-act to write all data to the socket
+	echo "socket data, ${TS_SUBNAME}:" |socat -u - UNIX-CONNECT:$DEVLOG
+	$TS_HELPER_LOGGER -u $DEVLOG --stderr "$@" >> "$TS_OUTPUT" 2>&1
 	echo "ret: $?" >> "$TS_OUTPUT"
+	echo |socat -u - UNIX-CONNECT:$DEVLOG
 }
 
 ts_init_subtest "kern_priority"

--- a/tests/ts/logger/errors
+++ b/tests/ts/logger/errors
@@ -30,8 +30,13 @@ export LOGGER_TEST_TIMEOFDAY="1234567890.123456"
 export LOGGER_TEST_HOSTNAME="test-hostname"
 export LOGGER_TEST_GETPID="98765"
 
+DEVLOG="${TS_OUTDIR}/${TS_TESTNAME}_devlog"
+SOCKIN="${TS_OUTDIR}/${TS_TESTNAME}_socketin"
+ts_init_socket_to_file $DEVLOG $SOCKIN
+SOCAT_PID="$!"
+
 function logger_fun {
-	$TS_HELPER_LOGGER -s --no-act "$@" >> "$TS_OUTPUT" 2>&1
+	$TS_HELPER_LOGGER -u $DEVLOG -s --no-act "$@" >> "$TS_OUTPUT" 2>&1
 	echo "ret: $?" >> "$TS_OUTPUT"
 }
 
@@ -66,5 +71,8 @@ ts_finalize_subtest
 ts_init_subtest "rfc5424_msgid_with_space"
 logger_fun -t "rfc5424_msgid_with_space" --rfc5424 --msgid="A B" "message"
 ts_finalize_subtest
+
+sleep 1
+kill $SOCAT_PID
 
 ts_finalize

--- a/tests/ts/logger/errors
+++ b/tests/ts/logger/errors
@@ -30,45 +30,41 @@ export LOGGER_TEST_TIMEOFDAY="1234567890.123456"
 export LOGGER_TEST_HOSTNAME="test-hostname"
 export LOGGER_TEST_GETPID="98765"
 
+function logger_fun {
+	$TS_HELPER_LOGGER -s --no-act "$@" >> "$TS_OUTPUT" 2>&1
+	echo "ret: $?" >> "$TS_OUTPUT"
+}
+
 ts_init_subtest "kern_priority"
-$TS_HELPER_LOGGER --no-act -s -t "prio" -p kern.emerg "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "prio" -p kern.emerg "message"
 ts_finalize_subtest
 
 ts_init_subtest "kern_priority_numeric"
-$TS_HELPER_LOGGER --no-act -s -t "prio" -p 0 "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "prio" -p 0 "message"
 ts_finalize_subtest
 
 ts_init_subtest "invalid_prio"
-$TS_HELPER_LOGGER --no-act -s -t "prio" -p 8 "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "prio" -p 8 "message"
 ts_finalize_subtest
 
 # should truncate
 ts_init_subtest "rfc5424_exceed_size"
-$TS_HELPER_LOGGER --no-act -s -t "rfc5424_exceed_size" --rfc5424 --size 3 "abcd" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "rfc5424_exceed_size" --rfc5424 --size 3 "abcd"
 ts_finalize_subtest
 
 ts_init_subtest "id_with_space"
-$TS_HELPER_LOGGER --no-act -s -t "id_with_space" --id="A B" "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
-$TS_HELPER_LOGGER --no-act -s -t "rfc5424_id_with_space" --rfc5424 --id="A B" "message" >> "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "id_with_space" --id="A B" "message"
+logger_fun -t "rfc5424_id_with_space" --rfc5424 --id="A B" "message"
 ts_finalize_subtest
 
 # should not fail
 ts_init_subtest "tag_with_space"
-$TS_HELPER_LOGGER --no-act -s -t "A B" "tag_with_space" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
-$TS_HELPER_LOGGER --no-act -s -t "A B" --rfc5424 "tag_with_space_rfc5424" >> "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "A B" "tag_with_space"
+logger_fun -t "A B" --rfc5424 "tag_with_space_rfc5424"
 ts_finalize_subtest
 
 ts_init_subtest "rfc5424_msgid_with_space"
-$TS_HELPER_LOGGER --no-act -s -t "rfc5424_msgid_with_space" --rfc5424 --msgid="A B" "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "rfc5424_msgid_with_space" --rfc5424 --msgid="A B" "message"
 ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/logger/errors
+++ b/tests/ts/logger/errors
@@ -75,6 +75,10 @@ ts_init_subtest "rfc5424_msgid_with_space"
 logger_fun -t "rfc5424_msgid_with_space" --rfc5424 --msgid="A B" "message"
 ts_finalize_subtest
 
+ts_init_subtest "invalid_socket"
+logger_fun -u /bad/boy -t "invalid_socket" "message"
+ts_finalize_subtest
+
 ts_init_subtest "check_socket"
 ts_log "Check written socket data of all subtests."
 sleep 1

--- a/tests/ts/logger/formats
+++ b/tests/ts/logger/formats
@@ -30,8 +30,13 @@ export LOGGER_TEST_TIMEOFDAY="1234567890.123456"
 export LOGGER_TEST_HOSTNAME="test-hostname"
 export LOGGER_TEST_GETPID="98765"
 
+DEVLOG="${TS_OUTDIR}/${TS_TESTNAME}_devlog"
+SOCKIN="${TS_OUTDIR}/${TS_TESTNAME}_socketin"
+ts_init_socket_to_file $DEVLOG $SOCKIN
+SOCAT_PID="$!"
+
 function logger_fun {
-	$TS_HELPER_LOGGER -s --no-act "$@" >> "$TS_OUTPUT" 2>&1
+	$TS_HELPER_LOGGER -u $DEVLOG -s --no-act "$@" >> "$TS_OUTPUT" 2>&1
 	echo "ret: $?" >> "$TS_OUTPUT"
 }
 
@@ -62,5 +67,8 @@ for facility in auth authpriv cron daemon ftp lpr mail news syslog user uucp loc
 	done
 done
 ts_finalize_subtest
+
+sleep 1
+kill $SOCAT_PID
 
 ts_finalize

--- a/tests/ts/logger/formats
+++ b/tests/ts/logger/formats
@@ -30,33 +30,35 @@ export LOGGER_TEST_TIMEOFDAY="1234567890.123456"
 export LOGGER_TEST_HOSTNAME="test-hostname"
 export LOGGER_TEST_GETPID="98765"
 
+function logger_fun {
+	$TS_HELPER_LOGGER -s --no-act "$@" >> "$TS_OUTPUT" 2>&1
+	echo "ret: $?" >> "$TS_OUTPUT"
+}
+
 ts_init_subtest "rfc3164"
-$TS_HELPER_LOGGER -s --no-act -t "rfc3164" --rfc3164 "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "rfc3164" --rfc3164 "message"
 ts_finalize_subtest
 
 ts_init_subtest "rfc5424_simple"
-$TS_HELPER_LOGGER -s --no-act -t "rfc5424" --rfc5424 "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "rfc5424" --rfc5424 "message"
 ts_finalize_subtest
+
 ts_init_subtest "rfc5424_notime"
-$TS_HELPER_LOGGER -s --no-act -t "rfc5424" --rfc5424=notime "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "rfc5424" --rfc5424=notime "message"
 ts_finalize_subtest
+
 ts_init_subtest "rfc5424_nohost"
-$TS_HELPER_LOGGER -s --no-act -t "rfc5424" --rfc5424=nohost "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "rfc5424" --rfc5424=nohost "message"
 ts_finalize_subtest
+
 ts_init_subtest "rfc5424_msgid"
-$TS_HELPER_LOGGER -s --no-act -t "rfc5424" --rfc5424 --msgid "MSGID" "message" > "$TS_OUTPUT" 2>&1
-echo "ret: $?" >> "$TS_OUTPUT"
+logger_fun -t "rfc5424" --rfc5424 --msgid "MSGID" "message"
 ts_finalize_subtest
 
 ts_init_subtest "priorities"
 for facility in auth authpriv cron daemon ftp lpr mail news syslog user uucp local{0..7}; do
 	for level in emerg alert crit err warning notice info debug; do
-		$TS_HELPER_LOGGER -s --no-act -t "prio" -p "$facility.$level" "$facility.$level" >> "$TS_OUTPUT" 2>&1
-		echo "ret: $?" >> "$TS_OUTPUT"
+		logger_fun -t "prio" -p "$facility.$level" "$facility.$level"
 	done
 done
 ts_finalize_subtest

--- a/tests/ts/logger/formats
+++ b/tests/ts/logger/formats
@@ -68,7 +68,12 @@ for facility in auth authpriv cron daemon ftp lpr mail news syslog user uucp loc
 done
 ts_finalize_subtest
 
+ts_init_subtest "check_socket"
+ts_log "Check written socket data of all subtests."
 sleep 1
 kill $SOCAT_PID
+wait $SOCAT_PID &>/dev/null
+cat "$SOCKIN" >> "$TS_OUTPUT" 2>&1
+ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/logger/journald
+++ b/tests/ts/logger/journald
@@ -30,6 +30,6 @@ if ! $TS_HELPER_LOGGER --help | grep -q journald; then
 fi
 
 printf "%s\n%s\n%s\n" MESSAGE_ID=b8f74e14bc714bfc8040a5106dc9376a MESSAGE="a b c 1 2 3" |
-$TS_HELPER_LOGGER --no-act --journald --stderr > "$TS_OUTPUT" 2>&1
+$TS_HELPER_LOGGER -u /bad/boy --no-act --journald --stderr > "$TS_OUTPUT" 2>&1
 echo "ret: $?" >> "$TS_OUTPUT"
 ts_finalize

--- a/tests/ts/logger/options
+++ b/tests/ts/logger/options
@@ -69,7 +69,12 @@ for i in "${tests_array[@]}"; do
 	ts_finalize_subtest
 done
 
+ts_init_subtest "check_socket"
+ts_log "Check written socket data of all subtests."
 sleep 1
 kill $SOCAT_PID
+wait $SOCAT_PID &>/dev/null
+cat "$SOCKIN" >> "$TS_OUTPUT" 2>&1
+ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/logger/options
+++ b/tests/ts/logger/options
@@ -50,14 +50,26 @@ export LOGGER_TEST_TIMEOFDAY="1234567890.123456"
 export LOGGER_TEST_HOSTNAME="test-hostname"
 export LOGGER_TEST_GETPID="98765"
 
+DEVLOG="${TS_OUTDIR}/${TS_TESTNAME}_devlog"
+SOCKIN="${TS_OUTDIR}/${TS_TESTNAME}_socketin"
+ts_init_socket_to_file $DEVLOG $SOCKIN
+SOCAT_PID="$!"
+
+function logger_fun {
+	$TS_HELPER_LOGGER -u $DEVLOG --stderr --no-act "$@" >> "$TS_OUTPUT" 2>&1
+	echo "ret: $?" >> "$TS_OUTPUT"
+}
+
 for i in "${tests_array[@]}"; do
 	name="${i%%:*}"
 	options="${i##*:}"
 
 	ts_init_subtest "$name"
-	$TS_HELPER_LOGGER --stderr --no-act -t "test_tag" $options > "$TS_OUTPUT" 2>&1
-	echo "ret: $?" >> "$TS_OUTPUT" 
+	logger_fun -t "test_tag" $options
 	ts_finalize_subtest
 done
+
+sleep 1
+kill $SOCAT_PID
 
 ts_finalize


### PR DESCRIPTION
Maybe later we could consolidate the socket initialization into a common function inclusive netcat fallback.