### PR TITLE
tests: fix logger device pathname too long

### DIFF
--- a/tests/ts/logger/errors
+++ b/tests/ts/logger/errors
@@ -30,7 +30,8 @@ export LOGGER_TEST_TIMEOFDAY="1234567890.123456"
 export LOGGER_TEST_HOSTNAME="test-hostname"
 export LOGGER_TEST_GETPID="98765"
 
-DEVLOG="${TS_OUTDIR}/${TS_TESTNAME}_devlog"
+DEVLOG="$(mktemp "/tmp/ultest-$TS_COMPONENT-$TS_TESTNAME-XXXXXX")" \
+	|| ts_die "mktemp failed"
 SOCKIN="${TS_OUTDIR}/${TS_TESTNAME}_socketin"
 ts_init_socket_to_file $DEVLOG $SOCKIN
 SOCAT_PID="$!"
@@ -85,6 +86,7 @@ sleep 1
 kill $SOCAT_PID
 wait $SOCAT_PID &>/dev/null
 cat "$SOCKIN" >> "$TS_OUTPUT" 2>&1
+rm -f "$DEVLOG" "$SOCKIN"
 ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/logger/formats
+++ b/tests/ts/logger/formats
@@ -30,7 +30,8 @@ export LOGGER_TEST_TIMEOFDAY="1234567890.123456"
 export LOGGER_TEST_HOSTNAME="test-hostname"
 export LOGGER_TEST_GETPID="98765"
 
-DEVLOG="${TS_OUTDIR}/${TS_TESTNAME}_devlog"
+DEVLOG="$(mktemp "/tmp/ultest-$TS_COMPONENT-$TS_TESTNAME-XXXXXX")" \
+	|| ts_die "mktemp failed"
 SOCKIN="${TS_OUTDIR}/${TS_TESTNAME}_socketin"
 ts_init_socket_to_file $DEVLOG $SOCKIN
 SOCAT_PID="$!"
@@ -74,6 +75,7 @@ sleep 1
 kill $SOCAT_PID
 wait $SOCAT_PID &>/dev/null
 cat "$SOCKIN" >> "$TS_OUTPUT" 2>&1
+rm -f "$DEVLOG" "$SOCKIN"
 ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/logger/options
+++ b/tests/ts/logger/options
@@ -50,7 +50,8 @@ export LOGGER_TEST_TIMEOFDAY="1234567890.123456"
 export LOGGER_TEST_HOSTNAME="test-hostname"
 export LOGGER_TEST_GETPID="98765"
 
-DEVLOG="${TS_OUTDIR}/${TS_TESTNAME}_devlog"
+DEVLOG="$(mktemp "/tmp/ultest-$TS_COMPONENT-$TS_TESTNAME-XXXXXX")" \
+	|| ts_die "mktemp failed"
 SOCKIN="${TS_OUTDIR}/${TS_TESTNAME}_socketin"
 ts_init_socket_to_file $DEVLOG $SOCKIN
 SOCAT_PID="$!"
@@ -75,6 +76,7 @@ sleep 1
 kill $SOCAT_PID
 wait $SOCAT_PID &>/dev/null
 cat "$SOCKIN" >> "$TS_OUTPUT" 2>&1
+rm -f "$DEVLOG" "$SOCKIN"
 ts_finalize_subtest
 
 ts_finalize


### PR DESCRIPTION
$TS_OUTDIR may be too long for sockaddr_un.sun_path. Noticed on travis
in distcheck.

Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>