### PR TITLE
hwclock: Remove TZUTC

### DIFF
--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -400,15 +400,8 @@ mktime_tz(struct tm tm, const bool universal,
 	 */
 	zone = getenv("TZ");	/* remember original time zone */
 	if (universal) {
-		/* Set timezone to UTC as defined by the environment
-		 * variable TZUTC.  TZUTC undefined gives the default UTC
-		 * zonefile which usually does not take into account leap
-		 * seconds.  Define TZUTC to select your UTC zonefile which
-		 * does include leap seconds.  For example, with recent GNU
-		 * libc's:
-		 *    TZUTC=:/usr/share/zoneinfo/right/UTC
-		 */
-		setenv("TZ", getenv("TZUTC"), TRUE);
+		/* Set timezone to UTC */
+		setenv("TZ", "", TRUE);
 		/*
 		 * Note: tzset() gets called implicitly by the time code,
 		 * but only the first time. When changing the environment


### PR DESCRIPTION
commit d53f8ecfbf036eddb2aef737dc0973a613d80ced
introduced the TZUTC environment variable to
facilitate use of the zoneinfo 'right' database.
This was incorrect. Either the TZDIR environment
variable should be used or a system-wide
configuration for the 'right' database should be
used.

See hwclock(8) POSIX vs 'RIGHT' for more details.

TZUTC was undocumented and should be safe to remove.

The commit also caused a regression when using
musl libc, because when TZUTC is unset getenv()
returns a NULL pointer.
Reported-by: Isaac Dunham <ibid.ag@gmail.com>

Signed-off-by: J William Piggott <elseifthen@gmx.com>