### PR TITLE
sulogin: Don't ask for password when it is locked/disabled

### DIFF
--- a/login-utils/sulogin.8
+++ b/login-utils/sulogin.8
@@ -33,6 +33,9 @@ Give root password for system maintenance
 .br
 (or type Control\-D for normal startup):
 .PP
+If the root account is locked, no password
+prompt is displayed and \fIsulogin\fR starts a root shell immediately.
+.PP
 .B sulogin
 will be connected to the current terminal, or to the optional \fItty\fR device that
 can be specified on the command line (typically


### PR DESCRIPTION
Some installations and distributions don't use a root account password for security reasons and use sudo instead. In that case, asking for the password makes no sense, and it is not even considered as valid as it's just "*" or "!".

In these cases, just start a root shell. As both sulogin and getting into single user  mode/emergency.target require root access or physical hardware access anyway, this is not a privilege escalation.

This has been applied to sysvinit's sulogin in 2005 in Debian. Debian/Ubuntu recently dropped sulogin from sysvinit and moved to util-linux' implementation. This patch got ported alongside, but IMHO this  really belongs upstream as having a locked root account is in no way distro specific.

Thanks for considering!

Martin

https://bugs.debian.org/326678