### PR TITLE
kill: Add verbose to man page.

### DIFF
--- a/misc-utils/kill.1
+++ b/misc-utils/kill.1
@@ -97,6 +97,9 @@ is invoked with the name of
 .BR pid .
 This functionality is deprecated, and will be removed in March 2016.
 .TP
+\fB\-\-verbose\fR
+Print pid(s) that will be signaled with kill along with the signal.
+.TP
 \fB\-q\fR, \fB\-\-queue\fR \fIvalue\fR
 Use
 .BR sigqueue (2)


### PR DESCRIPTION
kill adds a verbose option to print the pid(s) and the signal. It is
added to man page here.