### PR TITLE
Revert "tests: start script/race test only when --force specified"

### DIFF
--- a/tests/ts/script/race
+++ b/tests/ts/script/race
@@ -19,9 +19,6 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="race conditions"
 
-# Don't execute this test by default, --force required
-TS_OPTIONAL="yes"
-
 . $TS_TOPDIR/functions.sh
 ts_init "$*"
 


### PR DESCRIPTION
This reverts commit 8ba3f35e07f736a0165669ac787b016b4311eb29.

This test is not too slow anymore and BTW since last script refactoring
it does work now even on slow/heavy-loaded systems.

Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>