### PR TITLE
python-libmount: add setup.py

### DIFF
--- a/libmount/python/MANIFEST.in
+++ b/libmount/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include pylibmount.h

--- a/libmount/python/libmount/__init__.py
+++ b/libmount/python/libmount/__init__.py
@@ -1,0 +1,1 @@
+from pylibmount import *

--- a/libmount/python/setup.py
+++ b/libmount/python/setup.py
@@ -1,0 +1,31 @@
+from setuptools import setup, Extension
+
+pylibmount = Extension(
+    'pylibmount',
+    sources = [
+        'pylibmount.c',
+        'fs.c',
+        'tab.c',
+        'context.c'
+    ],
+    libraries = ['mount'],
+    include_dirs = ['/usr/include/libmount']
+)
+
+setup(
+    name='libmount',
+    version='2.27',
+    description = ('parse /etc/fstab, /etc/mtab and /proc/self/mountinfo files, '
+                   'manage the mtab file, evaluate mount options, etc'),
+    license = 'LGPLv2.1',
+    keywords = 'fstab mtab mount',
+    url = 'https://www.kernel.org/pub/linux/utils/util-linux/',
+    ext_modules = [pylibmount],
+    packages = ['libmount'],
+
+    classifiers = [
+        "Development Status :: 6 - Mature",
+        "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
+        "Topic :: Utilities"
+    ]
+)


### PR DESCRIPTION
The idea is to be able to use python-libmount on distributions that have ancient versions util-linux or don't package python-libmount correctly.

The hope I suppose is to be able to also python-libmount to the pypi--replacing the aweful/abandoned [not-libmount](https://pypi.python.org/pypi/libmount) that's currently there.

Then only thing I'm worried about is the version metadata in setup.py--I thought maybe a `setup.py.in` might be smarter, so that the build system can fill that in. Thoughts?