### PR TITLE
buildsys: fix static configuration and building

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -391,8 +391,8 @@ AC_CHECK_FUNCS([timer_createx],
 	[have_time="yes"],
 	[AC_CHECK_LIB([rt], [timer_create], [
 		have_timer="yes"
-		REALTIME_LIBS="-lrt"
-	])]
+		REALTIME_LIBS="-lrt -lpthread"
+	],[],[-lpthread])]
 )
 
 


### PR DESCRIPTION
In case of uClibc librt depends on libpthread.

In particular timer_create() function uses pthread_XXX().

That means in case of static builds it's required to link
not librt alone but together with libpthread.

That issues was spotted in Buldroot autobuilder failures:
http://autobuild.buildroot.net/results/759/75960db671807091fe9155aee9e46a6245e32590/
http://autobuild.buildroot.org/results/112/112e8b85783f5aaba42a937a6eb064317615a21b/

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>