### PR TITLE
build-sys: Properly order install dependencies of pylibmount

### DIFF
--- a/libmount/python/Makemodule.am
+++ b/libmount/python/Makemodule.am
@@ -2,11 +2,21 @@ if BUILD_PYLIBMOUNT
 
 pylibmountexecdir = $(pyexecdir)/libmount
 
+# Use a zz_ prefix to ensure this is last on `make install` (automake orders
+# the entries in alphabetical order) since we need to ensure that the
+# install-zz_pylibmountexecLTLIBRARIES step is only executed after the
+# install-usrlib_execLTLIBRARIES step, otherwise libtool fails to find
+# libmount under DESTDIR when it tries to relink pylibmount.so.
+#
+# Keep the pylibmountexecdir variable, in order to be backwards compatible with
+# invocation of `make install` that override that variable in the command line.
+zz_pylibmountexecdir = $(pylibmountexecdir)
+
 # Please, don't use $pythondir for the scripts. We have to use the same
 # directory for binary stuff as well as for the scripts otherwise it's
 # not possible to install 32-bit and 64-bit version on the same system.
-pylibmountexec_LTLIBRARIES = pylibmount.la
-pylibmountexec_PYTHON = libmount/python/__init__.py
+zz_pylibmountexec_LTLIBRARIES = pylibmount.la
+zz_pylibmountexec_PYTHON = libmount/python/__init__.py
 
 pylibmount_la_SOURCES = \
 	libmount/python/pylibmount.c \


### PR DESCRIPTION
This fixes a failure of `make install DESTDIR=...` when trying to relink pylibmount against libmount.la.

libtool will look for libmount.so under ${DESTDIR}/${libdir} just fine, but if it is not yet present, it will assume it is a system installed library and use -lmount instead.

But this means it depends on the install order. And, considering that pylibmountexec < usrlib_exec (in lexicographic order), the Makefile will be generated to process pylibmountexec first, which will typically generate the failure below on the `make install` step:

```shell
  libtool: install: warning: relinking `pylibmount.la'
  libtool: install: (... libtool --mode=relink gcc -o pylibmount.la \
        -rpath /usr/lib/python2.7/dist-packages/libmount \
        libmount/python/*.lo libmount.la ... -lpython2.7 \
        -inst-prefix-dir /path/to/destdir)
  /usr/bin/ld: cannot find -lmount
  collect2: error: ld returned 1 exit status
  libtool: install: error: relink `pylibmount.la' ...
  make[3]: *** [install-pylibmountexecLTLIBRARIES] Error 1
```

A workaround could be achieved by renaming the rules so that automake would generate them in the expected order (for instance, using "lib" instead of "usrlib_exec" for libmount?) but this would still be fragile and break when using parallel install...

A better solution is to add an explicit dependency so that the usrlib libraries are always installed before the pylibmountexec install is attempted.

This seems to be a previously encountered issue, since automake includes a hack to insert such a dependency rule to install all libLTLIBRARIES before attempting to install binPROGRAMS, initially introduced in the commit below:
http://git.savannah.gnu.org/cgit/automake.git/commit/?id=bd4a1d5ad1a72fa780a8b7fd6c365a5dad2e6220

Also related bug from Ubuntu tracker:
https://bugs.launchpad.net/ubuntu/+source/util-linux/+bug/1442076

Tested that `make install` starts working again after this commit, even when libmount-dev is not installed on the system. Also confirmed that `make distcheck` is now functional.

@karelzak 