### PR TITLE
lib/tty: Pass default width to get_terminal_width()

### DIFF
--- a/disk-utils/fdisk-list.c
+++ b/disk-utils/fdisk-list.c
@@ -405,9 +405,7 @@ void list_available_columns(FILE *out)
 	if (!cxt)
 		return;
 
-	termwidth = get_terminal_width();
-	if (termwidth <= 0)
-		termwidth = 80;
+	termwidth = get_terminal_width(80);
 
 	fprintf(out, _("\nAvailable columns (for -o):\n"));
 

--- a/include/ttyutils.h
+++ b/include/ttyutils.h
@@ -50,7 +50,7 @@ struct chardata {
 	        (ptr)->capslock = 0;         \
 	} while (0)
 
-extern int get_terminal_width(void);
+extern int get_terminal_width(int default_width);
 extern int get_terminal_name(int fd, const char **path, const char **name,
 			     const char **number);
 

--- a/libsmartcols/src/table_print.c
+++ b/libsmartcols/src/table_print.c
@@ -1009,9 +1009,7 @@ int scols_print_table(struct libscols_table *tb)
 		scols_table_set_symbols(tb, NULL);	/* use default */
 
 	tb->is_term = isatty(STDOUT_FILENO) ? 1 : 0;
-	tb->termwidth = tb->is_term ? get_terminal_width() : 0;
-	if (tb->termwidth <= 0)
-		tb->termwidth = 80;
+	tb->termwidth = tb->is_term ? get_terminal_width(80) : 0;
 	tb->termwidth -= tb->termreduce;
 
 	bufsz = tb->termwidth;

--- a/misc-utils/blkid.c
+++ b/misc-utils/blkid.c
@@ -154,9 +154,7 @@ static void pretty_print_line(const char *device, const char *fs_type,
 	int len, w;
 
 	if (term_width < 0) {
-		term_width = get_terminal_width();
-		if (term_width <= 0)
-			term_width = 80;
+		term_width = get_terminal_width(80);
 	}
 	if (term_width > 80) {
 		term_width -= 80;
@@ -192,7 +190,7 @@ static void pretty_print_dev(blkid_dev dev)
 	if (dev == NULL) {
 		pretty_print_line("device", "fs_type", "label",
 				  "mount point", "UUID");
-		for (len=get_terminal_width()-1; len > 0; len--)
+		for (len=get_terminal_width(0)-1; len > 0; len--)
 			fputc('-', stdout);
 		fputc('\n', stdout);
 		return;

--- a/misc-utils/kill.c
+++ b/misc-utils/kill.c
@@ -218,11 +218,7 @@ static void print_all_signals(FILE *fp, int pretty)
 	}
 
 	/* pretty print */
-	width = get_terminal_width();
-	if (width == 0)
-		width = KILL_OUTPUT_WIDTH;
-	else
-		width -= 1;
+	width = get_terminal_width(KILL_OUTPUT_WIDTH + 1) - 1;
 	for (n = 0; n < ARRAY_SIZE(sys_signame); n++)
 		pretty_print_signal(fp, width, &lpos,
 				    sys_signame[n].val, sys_signame[n].name);

--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -142,9 +142,7 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
-	termwidth = get_terminal_width();
-	if (termwidth <= 0)
-		termwidth = 80;
+	termwidth = get_terminal_width(80);
 	colsep = mbs_to_wcs("  ");
 
 	while ((ch = getopt_long(argc, argv, "hVc:s:txo:", longopts, NULL)) != -1)


### PR DESCRIPTION
Almost any code calling get_terminal_width() checks returned width for
non-positive values and sets it to some default value (say, 80). So,
let's pass this default value directly to the function.