### PR TITLE
scriptreplay/newgrp: use signed int to store return of getopt_long

### DIFF
--- a/login-utils/newgrp.c
+++ b/login-utils/newgrp.c
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
 	struct passwd *pw_entry;
 	struct group *gr_entry;
 	char *shell;
-	char ch;
+	int ch;
 	static const struct option longopts[] = {
 		{"version", no_argument, NULL, 'V'},
 		{"help", no_argument, NULL, 'h'},

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -138,7 +138,7 @@ main(int argc, char *argv[])
 	double divi = 1, maxdelay = 0;
 	int c, diviopt = FALSE, maxdelayopt = FALSE, idx;
 	unsigned long line;
-	char ch;
+	int ch;
 
 	static const struct option longopts[] = {
 		{ "timing",	required_argument,	0, 't' },


### PR DESCRIPTION
The `char` type is not guaranteed to be signed and is not appropriate to store the return value of getopt_long which may be negative at the end of the options.

Without this fix, the code breaks when building with `-funsigned-char`.

@karelzak 
