### PR TITLE
libsmartcols: add scols_column_is_hidden into sym file

### DIFF
--- a/libsmartcols/src/libsmartcols.sym
+++ b/libsmartcols/src/libsmartcols.sym
@@ -1,7 +1,7 @@
 /*
  * symbols since util-linux 2.25
  *
- * Copyright (C) 2014-2015 Karel Zak <kzak@redhat.com>
+ * Copyright (C) 2014-2016 Karel Zak <kzak@redhat.com>
  */
 SMARTCOLS_2.25 {
 global:
@@ -116,6 +116,7 @@ local:
 
 SMARTCOLS_2.27 {
 global:
+	scols_column_is_hidden;
 	scols_table_enable_json;
 	scols_table_is_json;
 	scols_table_set_name;


### PR DESCRIPTION
In commit 6d6b6d185e7427e2b5590349edd76d019b0fe920 we forgot to
add this function to sym file and now we are getting
undefined symbol: scols_column_is_hidden

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>