### PR TITLE
buildsys: fix static configuration and building

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -394,7 +394,14 @@ AC_CHECK_FUNCS([timer_create],
 	[AC_CHECK_LIB([rt], [timer_create], [
 		have_timer="yes"
 		REALTIME_LIBS="-lrt"
-	])]
+	],[
+		AC_SEARCH_LIBS([timer_create], [rt], [
+			AC_MSG_RESULT(yes)
+			have_timer="yes"
+			REALTIME_LIBS="-lrt -lpthread"
+		],[], [-lpthread]
+		)
+		])]
 )
 
 AC_SUBST([REALTIME_LIBS])


### PR DESCRIPTION
This pull request is a new version of pull request #234 by Alexey Brodkin.

In case of uClibc librt depends on libpthread. In particular
timer_create() function uses pthread_XXX(). That means in case of static
builds it's required to link not librt alone but together with libpthread. So
if checking timer_create function in librt fails, it is necessary to check if
timer_create function successfully links with "-lpthread".

That issues was spotted in Buldroot autobuilder failures:
http://autobuild.buildroot.net/results/759/75960db671807091fe9155aee9e46a6245e32590/
http://autobuild.buildroot.org/results/112/112e8b85783f5aaba42a937a6eb064317615a21b/

Signed-off-by: Lada Trimasova <ltrimas@synopsys.com>