### PR TITLE
Change of output format and documentation.

### DIFF
--- a/sys-utils/hwclock.8.in
+++ b/sys-utils/hwclock.8.in
@@ -94,6 +94,10 @@ in UTC.  See the
 .B \%\-\-localtime
 option.
 .sp
+The time shown is in same format as that of 
+.BR \%date (1)
+by default, and additionally, the number of microseconds is shown.
+.sp 
 Showing the Hardware Clock time is the default when no function is specified.
 .sp
 The
@@ -298,7 +302,7 @@ The value of this option is used as an argument to the
 option.  For example:
 .RS
 .IP "" 4
-.B "hwclock\ \-\-set\ \-\-date='2011-08-14\ 16:45:05'
+.B "hwclock\ \-\-set\ \-\-date='2011-08-14\ 16:45:05'"
 .PP
 The argument must be in local time, even if you keep your Hardware Clock in
 UTC.  See the

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -693,7 +693,7 @@ display_time(const bool hclock_valid, struct timeval hwctime)
 
 		lt = localtime(&hwctime.tv_sec);
 		strftime(ctime_now, sizeof(ctime_now), format, lt);
-		printf(_("%s  .%06d seconds\n"), ctime_now, (int)hwctime.tv_usec);
+		printf(_("%s  and %06d microseconds\n"), ctime_now, (int)hwctime.tv_usec);
 	}
 }
 


### PR DESCRIPTION
Me and my colleguae were rather confused by the output of version 2.25.2 so I started looking at the code. The addition of microseconds or fractions of a second is undocumented until now. 
The proposed change in code, is an attempt to better conform to I18n of decimal separators. It usually gives I18n problems to assemble parts of a meaning in C code. Just my 2 € . 