### PR TITLE
Properly order install dependencies of pylibmount (take 2)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,14 @@ include bash-completion/Makemodule.am
 
 include tests/Makemodule.am
 
+# pylibmountexec module must be installed after usrlib_exec libraries,
+# otherwise the libtool relink step will fail to find libmount.la and
+# will try -lmount which is possibly not available.
+#
+# So introduce this dependency rule:
+# install-pylibmountexecLTLIBRARIES: install-usrlib_execLTLIBRARIES
+@verbatim_pylibmount_dependency@
+
 #
 # Don't rely on configure.ac AC_CONFIG_FILES for install paths.
 #

--- a/configure.ac
+++ b/configure.ac
@@ -1918,6 +1918,18 @@ UL_REQUIRES_HAVE([pylibmount], [libpython], [libpython])
 UL_REQUIRES_BUILD([pylibmount], [libmount])
 AM_CONDITIONAL([BUILD_PYLIBMOUNT], [test "x$build_pylibmount" = "xyes"])
 
+# We need to introduce a verbatim dependency into the Makefile, without automake
+# trying to interpret it, so push it as a AM_SUBST_NOTMAKE variable.
+verbatim_pylibmount_dependency='
+
+# pylibmountexec module must be installed after usrlib_exec libraries,
+# otherwise the libtool relink step will fail to find libmount.la and
+# will try -lmount which is possibly not available.
+install-pylibmountexecLTLIBRARIES: install-usrlib_execLTLIBRARIES
+
+'
+AC_SUBST([verbatim_pylibmount_dependency])
+AM_SUBST_NOTMAKE([verbatim_pylibmount_dependency])
 
 AC_ARG_ENABLE([pg-bell],
   AS_HELP_STRING([--disable-pg-bell], [let pg not ring the bell on invalid keys]),

--- a/libmount/python/Makemodule.am
+++ b/libmount/python/Makemodule.am
@@ -2,21 +2,11 @@ if BUILD_PYLIBMOUNT
 
 pylibmountexecdir = $(pyexecdir)/libmount
 
-# Use a zz_ prefix to ensure this is last on `make install` (automake orders
-# the entries in alphabetical order) since we need to ensure that the
-# install-zz_pylibmountexecLTLIBRARIES step is only executed after the
-# install-usrlib_execLTLIBRARIES step, otherwise libtool fails to find
-# libmount under DESTDIR when it tries to relink pylibmount.so.
-#
-# Keep the pylibmountexecdir variable, in order to be backwards compatible with
-# invocation of `make install` that override that variable in the command line.
-zz_pylibmountexecdir = $(pylibmountexecdir)
-
 # Please, don't use $pythondir for the scripts. We have to use the same
 # directory for binary stuff as well as for the scripts otherwise it's
 # not possible to install 32-bit and 64-bit version on the same system.
-zz_pylibmountexec_LTLIBRARIES = pylibmount.la
-zz_pylibmountexec_PYTHON = libmount/python/__init__.py
+pylibmountexec_LTLIBRARIES = pylibmount.la
+pylibmountexec_PYTHON = libmount/python/__init__.py
 
 pylibmount_la_SOURCES = \
 	libmount/python/pylibmount.c \


### PR DESCRIPTION
@karelzak @rudimeier 

This is possibly a better fix than the one introduced in #247 (so I'm reverting that one here since it's no longer necessary.)

It uses a workaround suggested in http://stackoverflow.com/a/8643550 to introduce the make rule without having automake try to interpret it.

I tested the issues that tripped me up before in https://github.com/filbranden/util-linux/commit/9aeb4952cce8495843f82895a279c202dcbdf778
