### PR TITLE
travis: Remove workaround for libtool install of pylibmount

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -103,10 +103,6 @@ function travis_before_script
 	./autogen.sh
 	ret=$?
 
-	# workaround for broken pylibmount install relink
-	[ $ret -eq 0 ] && \
-		sed -i 's/\(link_all_deplibs\)=no/\1=unknown/' ./configure
-
 	set +o xtrace
 	popd
 	return $ret


### PR DESCRIPTION
Commit 324330aca6443d ("build-sys: Properly order install dependencies of pylibmount") from PR #274 introduces a proper make dependency for the install rules, in a way that the workaround is no longer necessary.

Let's check that this PR commit passes Travis-CI, that means it should be good to submit...

@rudimeier @karelzak 