### PR TITLE
libsmartcols: print title only with SCOLS_FMT_HUMAN

### DIFF
--- a/libsmartcols/src/table_print.c
+++ b/libsmartcols/src/table_print.c
@@ -1299,7 +1299,8 @@ int scols_print_table(struct libscols_table *tb)
 
 	fput_table_open(tb);
 
-	print_title(tb);
+	if (tb->format == SCOLS_FMT_HUMAN)
+		print_title(tb);
 
 	rc = print_header(tb, buf);
 	if (rc)


### PR DESCRIPTION
Reference: https://github.com/karelzak/util-linux/issues/279
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>