### PR TITLE
tests: parallel results output again

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -15,6 +15,7 @@ fi
 # travis docs say we get 1.5 CPUs
 MAKE="make -j2"
 DUMP_CONFIG_LOG="short"
+export TS_OPT_parsable="yes"
 
 function xconfigure
 {

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -46,11 +46,22 @@ function ts_cd {
 }
 
 function ts_report {
-	if [ "$TS_PARALLEL" == "yes" ]; then
-		echo "$TS_TITLE $1"
-	else
-		echo "$1"
+	local desc=
+
+	if [ "$TS_PARALLEL" != "yes" ]; then
+		if [ $TS_NSUBTESTS -ne 0 ] && [ -z "$TS_SUBNAME" ]; then
+			desc=$(printf "%11s...")
+		fi
+		echo "$desc$1"
+		return
 	fi
+
+	if [ -n "$TS_SUBNAME" ]; then
+		desc=$(printf "%s: [%02d] %s" "$TS_DESC" "$TS_NSUBTESTS" "$TS_SUBNAME")
+	else
+		desc=$TS_DESC
+	fi
+	printf "%13s: %-45s ...%s\n" "$TS_COMPONENT" "$desc" "$1"
 }
 
 function ts_check_test_command {
@@ -170,6 +181,7 @@ function ts_option_argument {
 }
 
 function ts_init_core_env {
+	TS_SUBNAME=""
 	TS_NS="$TS_COMPONENT/$TS_TESTNAME"
 	TS_OUTPUT="$TS_OUTDIR/$TS_TESTNAME"
 	TS_VGDUMP="$TS_OUTDIR/$TS_TESTNAME.vgdump"
@@ -294,17 +306,12 @@ function ts_init_env {
 function ts_init_subtest {
 
 	TS_SUBNAME="$1"
-
 	ts_init_core_subtest_env
-
-	[ $TS_NSUBTESTS -eq 0 ] && echo
 	TS_NSUBTESTS=$(( $TS_NSUBTESTS + 1 ))
 
-	if [ "$TS_PARALLEL" == "yes" ]; then
-		TS_TITLE=$(printf "%13s: %-30s ...\n%16s: %-27s ..." "$TS_COMPONENT" "$TS_DESC" "" "$TS_SUBNAME")
-	else
-		TS_TITLE=$(printf "%16s: %-27s ..." "" "$TS_SUBNAME")
-		echo -n "$TS_TITLE"
+	if [ "$TS_PARALLEL" != "yes" ]; then
+		[ $TS_NSUBTESTS -eq 1 ] && echo
+		printf "%16s: %-27s ..." "" "$TS_SUBNAME"
 	fi
 }
 
@@ -314,11 +321,8 @@ function ts_init {
 	local is_fake=$( ts_has_option "fake" "$*")
 	local is_force=$( ts_has_option "force" "$*")
 
-	if [ "$TS_PARALLEL" == "yes" ]; then
-		TS_TITLE=$(printf "%13s: %-30s ..." "$TS_COMPONENT" "$TS_DESC")
-	else
-		TS_TITLE=$(printf "%13s: %-30s ..." "$TS_COMPONENT" "$TS_DESC")
-		echo -n "$TS_TITLE"
+	if [ "$TS_PARALLEL" != "yes" ]; then
+		printf "%13s: %-30s ..." "$TS_COMPONENT" "$TS_DESC"
 	fi
 
 	[ "$is_fake" == "yes" ] && ts_skip "fake mode"
@@ -420,7 +424,6 @@ function ts_finalize {
 	ts_cleanup_on_exit
 
 	if [ $TS_NSUBTESTS -ne 0 ]; then
-		printf "%11s..."
 		if [ $TS_NSUBFAILED -ne 0 ]; then
 			ts_failed "$TS_NSUBFAILED from $TS_NSUBTESTS sub-tests"
 		else

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -48,7 +48,7 @@ function ts_cd {
 function ts_report {
 	local desc=
 
-	if [ "$TS_PARALLEL" != "yes" ]; then
+	if [ "$TS_PARSABLE" != "yes" ]; then
 		if [ $TS_NSUBTESTS -ne 0 ] && [ -z "$TS_SUBNAME" ]; then
 			desc=$(printf "%11s...")
 		fi
@@ -169,7 +169,14 @@ function ts_has_option {
 	fi
 
 	# or just check the global command line options
-	if [[ $ALL =~ ([$' \t\n']|^)--$NAME([$'= \t\n']|$) ]]; then echo yes; fi
+	if [[ $ALL =~ ([$' \t\n']|^)--$NAME([$'= \t\n']|$) ]]; then
+		echo yes
+		return
+	fi
+
+	# or the _global_ env, e.g TS_OPT_parsable="yes"
+	eval local env_opt=\$TS_OPT_${v_name}
+	if [ "$env_opt" = "yes" ]; then echo "yes"; fi
 }
 
 function ts_option_argument {
@@ -259,6 +266,8 @@ function ts_init_env {
 	TS_PARALLEL=$(ts_has_option "parallel" "$*")
 	TS_KNOWN_FAIL=$(ts_has_option "known-fail" "$*")
 	TS_SKIP_LOOPDEVS=$(ts_has_option "skip-loopdevs" "$*")
+	TS_PARSABLE=$(ts_has_option "parsable" "$*")
+	[ "$TS_PARSABLE" = "yes" ] || TS_PARSABLE="$TS_PARALLEL"
 
 	tmp=$( ts_has_option "memcheck" "$*")
 	if [ "$tmp" == "yes" -a -f /usr/bin/valgrind ]; then
@@ -309,7 +318,7 @@ function ts_init_subtest {
 	ts_init_core_subtest_env
 	TS_NSUBTESTS=$(( $TS_NSUBTESTS + 1 ))
 
-	if [ "$TS_PARALLEL" != "yes" ]; then
+	if [ "$TS_PARSABLE" != "yes" ]; then
 		[ $TS_NSUBTESTS -eq 1 ] && echo
 		printf "%16s: %-27s ..." "" "$TS_SUBNAME"
 	fi
@@ -321,7 +330,7 @@ function ts_init {
 	local is_fake=$( ts_has_option "fake" "$*")
 	local is_force=$( ts_has_option "force" "$*")
 
-	if [ "$TS_PARALLEL" != "yes" ]; then
+	if [ "$TS_PARSABLE" != "yes" ]; then
 		printf "%13s: %-30s ..." "$TS_COMPONENT" "$TS_DESC"
 	fi
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -43,20 +43,14 @@ function find_test_scripts()
 
 while [ -n "$1" ]; do
 	case "$1" in
-	--force)
-		OPTS="$OPTS --force"
-		;;
-	--fake)
-		OPTS="$OPTS --fake"
-		;;
-	--memcheck)
-		OPTS="$OPTS --memcheck"
-		;;
-	--verbose)
-		OPTS="$OPTS --verbose"
-		;;
-	--skip-loopdevs)
-		OPTS="$OPTS --skip-loopdevs"
+	--force |\
+	--fake |\
+	--memcheck |\
+	--verbose  |\
+	--skip-loopdevs |\
+	--parsable)
+		# these options are simply forwarded to the test scripts
+		OPTS="$OPTS $1"
 		;;
 	--nonroot)
 		if [ $(id -ru) -eq 0 ]; then

--- a/tests/ts/blkid/low-probe
+++ b/tests/ts/blkid/low-probe
@@ -17,7 +17,7 @@
 #
 
 TS_TOPDIR="${0%/*}/../.."
-TS_DESC="low-level superblocks probing"
+TS_DESC="superblocks probing"
 
 . $TS_TOPDIR/functions.sh
 


### PR DESCRIPTION
Regarding the declined patches from pull request #244 I try it again without changing the default non-parallel case.

On 05 January 2016, karelzak wrote:
> Applied, but without:
> * tests: remove non-parallel case for result output
> * tests: print test name instead of description …
> 
> I really want to have human friendly structured non-parallel output where I have information what test is just running (so output in ts_init and ts_init_subtest).

Yes, it looks really good if nothing goes wrong. But it's a real mess if there is a mix with stdout/stderr from a test script. This happens usually very often if a test fails or if test progs produce warnings or if you add debugging output.  

Note that due to a (fixed) bug we have never seen the nice non-parallel output for some years. (--parallel=1 was showing the ugly parallel-2-line results where both lines were printed at once.)

Here an example of such messed up output:
```
        fdisk: align 512/4K +alignment_offset ... SKIPPED (no root permissions)
        fdisk: align 512/4K +MD               ... SKIPPED (fake mode)
        fdisk: align 512/512                  ... SKIPPED (no root permissions)
        fdisk: align 512/512 +topology        ... SKIPPED (no root permissions)
        fdisk: nested BSD                     ...Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
 OK
        fdisk: GPT                            ... KNOWN FAILED (fdisk/gpt)
        fdisk: MBR - id                       ...Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
 OK
        fdisk: MBR - dos mode                 ...Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
 OK
        fdisk: MBR - non-dos mode             ...Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
 OK
        fdisk: MBR - sort                     ...Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
 OK
        fdisk: invalid input tests            ... KNOWN FAILED (fdisk/oddinput)
        fdisk: sunlabel tests                 ...Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
Unsupported ioctl: cmd=0x80200204 (20)
 KNOWN FAILED (fdisk/sunlabel)
         fsck: is mounted                     ... SKIPPED (no root permissions)
      hexdump: format-strings                 ...
                : empty-format                ... OK
                : 1b_octal                    ... OK
                : 1b_char                     ... OK

```


> If we want to support easy to parse output than it would be better to add
> --quiet --parsable=<filename>

I've added --parsable to be able to force the new one-line-parallel mode. As said the non-parallel default mode is untouched

For quick review:
old parallel test log:
https://travis-ci.org/karelzak/util-linux/jobs/111489457

new parallel test log:
https://travis-ci.org/rudimeier/util-linux/jobs/113910137
new non-parallel test log with --parsable
https://travis-ci.org/rudimeier/util-linux/jobs/113910141