### PR TITLE
setarch: test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.so
 *.so.*
 *.static
+*.swp
 *.vim
 *.[ao]
 *~

--- a/sys-utils/setarch.c
+++ b/sys-utils/setarch.c
@@ -391,8 +391,11 @@ int main(int argc, char *argv[])
 	if (set_arch(arch, options, 0))
 		err(EXIT_FAILURE, _("failed to set personality to %s"), arch);
 
-	/* flush all output streams before exec */
-	fflush(NULL);
+	if (verbose) {
+		printf(_("Execute command `%s'.\n"), argc ? argv[0] : "/bin/sh");
+		/* flush all output streams before exec */
+		fflush(NULL);
+	}
 
 	if (!argc) {
 		execl("/bin/sh", "-sh", NULL);

--- a/tests/expected/misc/setarch
+++ b/tests/expected/misc/setarch
@@ -9,4 +9,5 @@ Switching on WHOLE_SECONDS.
 Switching on STICKY_TIMEOUTS.
 Switching on ADDR_LIMIT_3GB.
 Switching on UNAME26.
+Execute command `echo'.
 success

--- a/tests/expected/misc/setarch-options
+++ b/tests/expected/misc/setarch-options
@@ -1,3 +1,14 @@
+###### unknown arch
+setarch: qubit: Unrecognized architecture
+exit: 1
+###### unknown command
+Execute command `/das/gibs/nicht'.
+setarch: /das/gibs/nicht: No such file or directory
+exit: 1
+###### noop uname -a
+Execute command `uname'.
+uname -a unchanged
+###### almost all options
 Switching on ADDR_NO_RANDOMIZE.
 Switching on FDPIC_FUNCPTRS.
 Switching on MMAP_PAGE_ZERO.
@@ -8,6 +19,5 @@ Switching on SHORT_INODE.
 Switching on WHOLE_SECONDS.
 Switching on STICKY_TIMEOUTS.
 Switching on ADDR_LIMIT_3GB.
-Switching on UNAME26.
 Execute command `echo'.
 success

--- a/tests/expected/misc/setarch-uname26
+++ b/tests/expected/misc/setarch-uname26
@@ -1,0 +1,6 @@
+###### --uname-2.6 echo
+Switching on UNAME26.
+Execute command `echo'.
+2.6 works or kernel too old
+###### --uname-2.6 true, non-verbose
+2.6 works or kernel too old

--- a/tests/expected/misc/setarch-uname26-version
+++ b/tests/expected/misc/setarch-uname26-version
@@ -1,0 +1,1 @@
+kernel version changed to 2.6

--- a/tests/ts/misc/setarch
+++ b/tests/ts/misc/setarch
@@ -21,13 +21,71 @@ ts_init "$*"
 ts_check_test_command "$TS_CMD_SETARCH"
 
 ARCH=$(uname -m)
-case $ARCH in
-	#  setarch --uname-2.6 fails on platforms without VDS
-	*sparc* )
-		ts_skip "unsupported arch"
-		;;
-esac
 
-$TS_CMD_SETARCH $(uname -m) -vRFZLXBIST3 --uname-2.6 echo "success" >$TS_OUTPUT 2>&1
+ts_init_subtest options
+echo "###### unknown arch" >>$TS_OUTPUT
+$TS_CMD_SETARCH qubit -v echo "success" >>$TS_OUTPUT 2>&1
+echo "exit: $?" >>$TS_OUTPUT
+
+echo "###### unknown command" >>$TS_OUTPUT
+$TS_CMD_SETARCH $ARCH -v /das/gibs/nicht >>$TS_OUTPUT 2>&1
+echo "exit: $?" >>$TS_OUTPUT
+
+echo "###### noop uname -a" >>$TS_OUTPUT
+uname_a=$(uname -srm)
+$TS_CMD_SETARCH $ARCH -v uname -srm >>$TS_OUTPUT 2>&1
+sed -i "$ s@${uname_a}@uname -a unchanged@" $TS_OUTPUT
+
+echo "###### almost all options" >>$TS_OUTPUT
+$TS_CMD_SETARCH $ARCH -vRFZLXBIST3 echo "success" >>$TS_OUTPUT 2>&1
+ts_finalize_subtest
+
+
+ts_init_subtest uname26
+finmsg="" # for debugging 2.6 issues
+
+echo "###### --uname-2.6 echo" >>$TS_OUTPUT
+$TS_CMD_SETARCH $ARCH -v --uname-2.6 echo "2.6 worked" >>$TS_OUTPUT 2>&1
+if [ $? -eq 0 ]; then
+	expected='^2.6 worked$'
+else
+	# this may happen after execvp
+	expected="^FATAL: kernel too old$"
+	finmsg+=" echo"
+fi
+sed -i "$ s/$expected/2.6 works or kernel too old/" $TS_OUTPUT
+
+echo "###### --uname-2.6 true, non-verbose" >>$TS_OUTPUT
+$TS_CMD_SETARCH $ARCH --uname-2.6 true >>$TS_OUTPUT 2>&1
+if [ $? -eq 0 ]; then
+	echo "2.6 works or kernel too old" >> $TS_OUTPUT
+else
+	# this may happen after execvp
+	expected="^FATAL: kernel too old$"
+	sed -i "$ s/$expected/2.6 works or kernel too old/" $TS_OUTPUT
+	finmsg+=" true"
+fi
+
+if [ -n "$finmsg" ]; then
+	finmsg=$(echo unsupported --uname-2.6: $finmsg)
+else
+	uname26_seems_supported=yes
+fi
+ts_finalize_subtest "$finmsg"
+
+
+# conditional subtest
+if [ "$uname26_seems_supported" = "yes" ]; then
+ts_init_subtest uname26-version
+	tmp=$($TS_CMD_SETARCH $ARCH --uname-2.6 uname -r)
+	if echo "$tmp" | grep -q "^2\.6\."; then
+		echo "kernel version changed to 2.6" >> $TS_OUTPUT
+	else
+		echo "uname26 failed" >> $TS_OUTPUT
+		echo "original kernel: $(uname -r)" >> $TS_OUTPUT
+		echo "uname26 kernel:  $tmp" >> $TS_OUTPUT
+	fi
+ts_finalize_subtest
+fi # conditional subtest
 
 ts_finalize


### PR DESCRIPTION
As discussed on mailing list this patch-set tries to fix tests if --uname-2.6 is not
supported.