### PR TITLE
Introduce no-fork / exec-only option.

### DIFF
--- a/sys-utils/flock.1
+++ b/sys-utils/flock.1
@@ -70,6 +70,14 @@ The exit code used when the \fB\-n\fP option is in use, and the
 conflicting lock exists, or the \fB\-w\fP option is in use,
 and the timeout is reached.  The default value is \fB1\fR.
 .TP
+.BR \-F , " \-\-no\-fork"
+Do not fork before executing
+.IR command .
+Upon execution the flock process is replaced by
+.IR command
+which continues to hold the lock. This option is incompatible with
+\fB\-\-close\fR as there would otherwise be nothing left to hold the lock.
+.TP
 .BR \-e , " \-x" , " \-\-exclusive"
 Obtain an exclusive lock, sometimes called a write lock.  This is the
 default.


### PR DESCRIPTION
When guarding a command with flock it is sometimes preferable to not leave a flock process waiting around for the command to exit.

Karel,

Would you be prepared to accept a patch along the lines of this RFC?

If so, I'll work up the options handling and documentation updates.

Design decision: Would you prefer that we refer to this as "no-fork" or "exec-only" or something else. What options flag? Perhaps -F/--no-fork?

Thanks.