### PR TITLE
[Issue #330] Corrected JSON escaping for lsblk -J

### DIFF
--- a/include/carefulputc.h
+++ b/include/carefulputc.h
@@ -69,7 +69,7 @@ static inline void fputs_quoted_case(const char *data, FILE *out, int dir, int j
 				// Handle short-hand cases to reduce output size.  C has most of
 				// the same stuff here, so if there's an "Escape for C" function
 				// somewhere in the STL, we should probably be using it.
-				else if (c == '\b') { fputs("\\b", out); }
+				     if (c == '\b') { fputs("\\b", out); }
 				else if (c == '\t') { fputs("\\t", out); }
 				else if (c == '\n') { fputs("\\n", out); }
 				else if (c == '\f') { fputs("\\f", out); }

--- a/include/carefulputc.h
+++ b/include/carefulputc.h
@@ -53,7 +53,7 @@ static inline void fputs_quoted_case(const char *data, FILE *out, int dir, int j
 			 * var charsToEscape = [];
 			 * for (var i = 0; i < 65535; i += 1) {
 			 * 	try {
-			 * 		JSON.parse('{"sample": " + String.fromCodePoint(i) + "}');
+			 * 		JSON.parse('{"sample": "' + String.fromCodePoint(i) + '"}');
 			 * 	} catch (e) {
 			 * 		charsToEscape.push(i);
 			 * 	}

--- a/include/carefulputc.h
+++ b/include/carefulputc.h
@@ -35,11 +35,12 @@ static inline void fputs_quoted_case(const char *data, FILE *out, int dir, int j
 		if (json == 0) {
 			// Looks like the original here is intended for escaping Bash
 			// strings; will leave alone for non-json output.
-			if ((unsigned char) *p == 0x22 ||		/* " */
-				(unsigned char) *p == 0x5c ||		/* \ */
-				(unsigned char) *p == 0x60 ||		/* ` */
-				(unsigned char) *p == 0x24)			/* $ */
-			{
+			if ((unsigned char) *p == 0x22   ||		/* " */
+			    (unsigned char) *p == 0x5c   ||		/* \ */
+			    (unsigned char) *p == 0x60   ||		/* ` */
+			    (unsigned char) *p == 0x24   ||		/* $ */
+			    !isprint((unsigned char) *p) ||
+-			    iscntrl((unsigned char) *p)) {
 				fprintf(out, "\\x%02x", (unsigned char) *p);
 			} else {
 				fputc(dir ==  1 ? toupper(*p) :

--- a/include/carefulputc.h
+++ b/include/carefulputc.h
@@ -26,31 +26,59 @@ static inline int fputc_careful(int c, FILE *fp, const char fail)
 	return (ret < 0) ? EOF : 0;
 }
 
-static inline void fputs_quoted_case(const char *data, FILE *out, int dir)
+static inline void fputs_quoted_case(const char *data, FILE *out, int dir, int json)
 {
 	const char *p;
 
 	fputc('"', out);
 	for (p = data; p && *p; p++) {
-		if ((unsigned char) *p == 0x22 ||		/* " */
-		    (unsigned char) *p == 0x5c ||		/* \ */
-		    (unsigned char) *p == 0x60 ||		/* ` */
-		    (unsigned char) *p == 0x24 ||		/* $ */
-		    !isprint((unsigned char) *p) ||
-		    iscntrl((unsigned char) *p)) {
-
-			fprintf(out, "\\x%02x", (unsigned char) *p);
-		} else
-			fputc(dir ==  1 ? toupper(*p) :
-			      dir == -1 ? tolower(*p) :
-			      *p, out);
+		if (json == 0) {
+			if ((unsigned char) *p == 0x22 ||		/* " */
+				(unsigned char) *p == 0x5c ||		/* \ */
+				(unsigned char) *p == 0x60 ||		/* ` */
+				(unsigned char) *p == 0x24)			/* $ */
+			{
+				fprintf(out, "\\x%02x", (unsigned char) *p);
+			} else {
+				fputc(dir ==  1 ? toupper(*p) :
+					  dir == -1 ? tolower(*p) :
+					  *p, out);
+			}
+		} else {
+			unsigned char c = (unsigned char) *p;
+			// From http://www.json.org
+			if (((unsigned char) *p) < 0x20) {
+				if (c == '"' || c == '\\') { fputc('\\', out); fputc(c, out); }
+				else if (c == '\r') { fputs("\\r", out); }
+				else if (c == '\n') { fputs("\\n", out); }
+				else if (c == '\t') { fputs("\\t", out); }
+				else if (c == '\v') { fputs("\\v", out); }
+				else if (c == '\b') { fputs("\\b", out); }
+				else if (c == '\f') { fputs("\\f", out); }
+				// single-quotes don't break double-quoted strings; readability better without escapes.
+				//else if (c == '\'') { fputs("\\'", out); }
+				// forward-slashes don't break double-quoted strings; readability better without escapes.
+				//else if (c == '/') { fputs("\\/", out); }
+				else {
+					// Other assorted control characters
+					fprintf(out, "\\u00%02x", (unsigned char) *p);
+				}
+			} else {
+				// All other characters OK
+				fputc(dir ==  1 ? toupper(*p) :
+					  dir == -1 ? tolower(*p) :
+					  *p, out);
+			}
+		}
 	}
 	fputc('"', out);
 }
 
-#define fputs_quoted(_d, _o)		fputs_quoted_case(_d, _o, 0)
-#define fputs_quoted_upper(_d, _o)	fputs_quoted_case(_d, _o, 1)
-#define fputs_quoted_lower(_d, _o)	fputs_quoted_case(_d, _o, -1)
+#define fputs_quoted(_d, _o)		fputs_quoted_case(_d, _o, 0, 0)
+#define fputs_quoted_json(_d, _o)		fputs_quoted_case(_d, _o, 0, 1)
+#define fputs_quoted_upper(_d, _o)	fputs_quoted_case(_d, _o, 1, 0)
+#define fputs_quoted_lower(_d, _o)	fputs_quoted_case(_d, _o, -1, 0)
+#define fputs_quoted_lower_json(_d, _o)	fputs_quoted_case(_d, _o, -1, 1)
 
 static inline void fputs_nonblank(const char *data, FILE *out)
 {

--- a/include/carefulputc.h
+++ b/include/carefulputc.h
@@ -65,7 +65,7 @@ static inline void fputs_quoted_case(const char *data, FILE *out, int dir, int j
 			if (c == '"' || c == '\\') { fputc('\\', out); fputc(c, out); }
 			// In addition, all chars under ' ' break Node's/V8/Chrome's, and
 			// 	Firefox's JSON.parse function
-			else if (c < 0x20 || c == '"' || c == '\\') {
+			else if (c < 0x20) {
 				// Handle short-hand cases to reduce output size.  C has most of
 				// the same stuff here, so if there's an "Escape for C" function
 				// somewhere in the STL, we should probably be using it.

--- a/include/carefulputc.h
+++ b/include/carefulputc.h
@@ -69,12 +69,11 @@ static inline void fputs_quoted_case(const char *data, FILE *out, int dir, int j
 				// Handle short-hand cases to reduce output size.  C has most of
 				// the same stuff here, so if there's an "Escape for C" function
 				// somewhere in the STL, we should probably be using it.
-				else if (c == '\r') { fputs("\\r", out); }
-				else if (c == '\n') { fputs("\\n", out); }
-				else if (c == '\t') { fputs("\\t", out); }
-				else if (c == '\v') { fputs("\\v", out); }
 				else if (c == '\b') { fputs("\\b", out); }
+				else if (c == '\t') { fputs("\\t", out); }
+				else if (c == '\n') { fputs("\\n", out); }
 				else if (c == '\f') { fputs("\\f", out); }
+				else if (c == '\r') { fputs("\\r", out); }
 				// single-quotes and forward slashes, while they're in the JSON
 				//	spec, don't break double-quoted strings, aren't below 0x20,
 				//	and are more redable without the leading backslashes anyway

--- a/libsmartcols/src/table_print.c
+++ b/libsmartcols/src/table_print.c
@@ -421,12 +421,12 @@ static int print_data(struct libscols_table *tb,
 		return 0;
 
 	case SCOLS_FMT_JSON:
-		fputs_quoted_lower(scols_cell_get_data(&cl->header), tb->out);
+		fputs_quoted_lower_json(scols_cell_get_data(&cl->header), tb->out);
 		fputs(": ", tb->out);
 		if (!data || !*data)
 			fputs("null", tb->out);
 		else
-			fputs_quoted(data, tb->out);
+			fputs_quoted_json(data, tb->out);
 		if (!is_last_column(cl))
 			fputs(", ", tb->out);
 		return 0;


### PR DESCRIPTION
I've implemented a fix for the bad JSON escaping in lsblk's output that also handles the shorthand cases for JSON escape sequences.  In non-JSON output, the old escaping method is used, though, since \u00## and all escape sequences I've handled in JSON here are also valid for both Bash and C99, you might combine them into a single impl that's compatible with all three target specs (e.g. escaped outputs would include, \u0001..\u0007, \b, \t, \n, \u000b, \f, \r, \u000e..\u001f, \", \u0024, \\\\, \u0060).