### PR TITLE
libmount: Preserve empty string value in optstr parsing

### DIFF
--- a/libmount/src/optstr.c
+++ b/libmount/src/optstr.c
@@ -185,7 +185,7 @@ static int __mnt_optstr_append_option(char **optstr,
 	sz = osz + nsz + 1;		/* 1: '\0' */
 	if (osz)
 		sz++;			/* ',' options separator */
-	if (vsz)
+	if (value)
 		sz += vsz + 1;		/* 1: '=' */
 
 	p = realloc(*optstr, sz);
@@ -201,7 +201,7 @@ static int __mnt_optstr_append_option(char **optstr,
 	memcpy(p, name, nsz);
 	p += nsz;
 
-	if (vsz) {
+	if (value) {
 		*p++ = '=';
 		memcpy(p, value, vsz);
 		p += vsz;

--- a/tests/expected/libmount/optstr-append-empty-value
+++ b/tests/expected/libmount/optstr-append-empty-value
@@ -1,0 +1,1 @@
+result: >aaa,bbb=BBB,ccc,ddd=<

--- a/tests/expected/libmount/optstr-deduplicate-empty
+++ b/tests/expected/libmount/optstr-deduplicate-empty
@@ -1,0 +1,1 @@
+result: >bbb,ccc,xxx,ddd,AAA=,fff=eee<

--- a/tests/expected/libmount/optstr-prepend-empty-value
+++ b/tests/expected/libmount/optstr-prepend-empty-value
@@ -1,0 +1,1 @@
+result: >ddd=,aaa,bbb=BBB,ccc<

--- a/tests/expected/libmount/optstr-remove-empty-value
+++ b/tests/expected/libmount/optstr-remove-empty-value
@@ -1,0 +1,1 @@
+result: >aaa,ccc<

--- a/tests/expected/libmount/optstr-set-empty
+++ b/tests/expected/libmount/optstr-set-empty
@@ -1,0 +1,1 @@
+result: >aaa,bbb=,ccc<

--- a/tests/expected/libmount/optstr-set-new-empty
+++ b/tests/expected/libmount/optstr-set-new-empty
@@ -1,0 +1,1 @@
+result: >aaa=,bbb=BBB,ccc<

--- a/tests/expected/libmount/optstr-set-new-end-empty
+++ b/tests/expected/libmount/optstr-set-new-end-empty
@@ -1,0 +1,1 @@
+result: >aaa,bbb=BBB,ccc=<

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -367,11 +367,11 @@ function ts_init_py {
 
 function ts_valgrind {
 	if [ -z "$TS_VALGRIND_CMD" ]; then
-		$*
+		"$@"
 	else
 		$TS_VALGRIND_CMD --tool=memcheck --leak-check=full \
 				 --leak-resolution=high --num-callers=20 \
-				 --log-file="$TS_VGDUMP" $*
+				 --log-file="$TS_VGDUMP" "$@"
 	fi
 }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -117,7 +117,7 @@ declare -a comps
 if [ -n "$SUBTESTS" ]; then
 	# selected tests only
 	for s in $SUBTESTS; do
-		if [ -d "$top_srcdir/tests/ts/$s" ]; then
+		if [ -e "$top_srcdir/tests/ts/$s" ]; then
 			comps+=( $(find_test_scripts "$top_srcdir/tests/ts/$s") ) || exit 1
 		else
 			echo "Unknown test component '$s'"

--- a/tests/ts/libmount/optstr
+++ b/tests/ts/libmount/optstr
@@ -20,12 +20,20 @@ ts_init_subtest "append-value"
 ts_valgrind $TESTPROG --append "aaa,bbb=BBB,ccc" "ddd" "DDD" &> $TS_OUTPUT
 ts_finalize_subtest
 
+ts_init_subtest "append-empty-value"
+ts_valgrind $TESTPROG --append "aaa,bbb=BBB,ccc" "ddd" "" &> $TS_OUTPUT
+ts_finalize_subtest
+
 ts_init_subtest "prepend"
 ts_valgrind $TESTPROG --prepend "aaa,bbb=BBB,ccc" "ddd" &> $TS_OUTPUT
 ts_finalize_subtest
 
 ts_init_subtest "prepend-value"
 ts_valgrind $TESTPROG --prepend "aaa,bbb=BBB,ccc" "ddd" "DDD" &> $TS_OUTPUT
+ts_finalize_subtest
+
+ts_init_subtest "prepend-empty-value"
+ts_valgrind $TESTPROG --prepend "aaa,bbb=BBB,ccc" "ddd" "" &> $TS_OUTPUT
 ts_finalize_subtest
 
 ts_init_subtest "set-remove"
@@ -40,12 +48,24 @@ ts_init_subtest "set-large"
 ts_valgrind $TESTPROG --set "aaa,bbb=BBB,ccc" "bbb" "XXX-YYY-ZZZ" &> $TS_OUTPUT
 ts_finalize_subtest
 
+ts_init_subtest "set-empty"
+ts_valgrind $TESTPROG --set "aaa,bbb=BBB,ccc" "bbb" "" &> $TS_OUTPUT
+ts_finalize_subtest
+
 ts_init_subtest "set-new"
 ts_valgrind $TESTPROG --set "aaa,bbb=BBB,ccc" "aaa" "XXX" &> $TS_OUTPUT
 ts_finalize_subtest
 
+ts_init_subtest "set-new-empty"
+ts_valgrind $TESTPROG --set "aaa,bbb=BBB,ccc" "aaa" "" &> $TS_OUTPUT
+ts_finalize_subtest
+
 ts_init_subtest "set-new-end"
 ts_valgrind $TESTPROG --set "aaa,bbb=BBB,ccc" "ccc" "XXX" &> $TS_OUTPUT
+ts_finalize_subtest
+
+ts_init_subtest "set-new-end-empty"
+ts_valgrind $TESTPROG --set "aaa,bbb=BBB,ccc" "ccc" "" &> $TS_OUTPUT
 ts_finalize_subtest
 
 ts_init_subtest "get"
@@ -66,6 +86,10 @@ ts_finalize_subtest
 
 ts_init_subtest "remove-value"
 ts_valgrind $TESTPROG --remove "aaa,bbb=BBB,ccc" "bbb" &> $TS_OUTPUT
+ts_finalize_subtest
+
+ts_init_subtest "remove-empty-value"
+ts_valgrind $TESTPROG --remove "aaa,bbb=,ccc" "bbb" &> $TS_OUTPUT
 ts_finalize_subtest
 
 ts_init_subtest "split"
@@ -90,6 +114,10 @@ ts_finalize_subtest
 
 ts_init_subtest "deduplicate"
 ts_valgrind $TESTPROG --dedup bbb,ccc,AAA,xxx,AAA=a,AAA=bbb,ddd,AAA=ccc,fff=eee AAA &> $TS_OUTPUT
+ts_finalize_subtest
+
+ts_init_subtest "deduplicate-empty"
+ts_valgrind $TESTPROG --dedup bbb,ccc,AAA,xxx,AAA=a,AAA=bbb,ddd,AAA=,fff=eee AAA &> $TS_OUTPUT
 ts_finalize_subtest
 
 ts_finalize


### PR DESCRIPTION
Recent mount (since the switch to libmount in v2.22) drops the '=' in mount options that are set to an empty value.  For example, the command line below will be affected:

```
# mount -o rw,myopt='' -t tmpfs tmpfs /mnt/tmp
```

Fix that by preserving an empty string in the options passed to the mount(2) syscall when they are present on the command line.

Add test cases to ensure empty string handling is working as expected and in order to prevent regressions in the future.

Also tested manually by stracing mount commands (on a kernel which accepts a special extra option, for testing purposes.)

Before this commit:

```    
# strace -e mount ./mount -t tmpfs -o rw,myopt='' tmpfs /mnt/tmp
mount("tmpfs", "/mnt/tmp", "tmpfs", MS_MGC_VAL, "myarg") = -1 EINVAL (Invalid argument)
```
    
After this commit:

```
# strace -e mount ./mount -t tmpfs -o rw,myopt='' tmpfs /mnt/tmp
mount("tmpfs", "/mnt/tmp", "tmpfs", MS_MGC_VAL, "myopt=") = 0
```
    
All test cases pass, including newly added test cases.  Also checked them with valgrind using:

```
$ tests/run.sh --memcheck libmount/optstr
```

Fixes #332.

@karelzak 
