### PR TITLE
travis: fix OSX, glibtoolize could not find sed

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -118,6 +118,9 @@ function osx_install_script
 		--disable-ipcs \
 		--disable-write \
 	"
+
+	# workaround: glibtoolize could not find sed
+	export SED="sed"
 }
 
 function osx_prepare_check


### PR DESCRIPTION
Since a few days travis OSX seems to have a bad libtool package:
$ glibtoolize --version
/usr/local/bin/glibtoolize: line 406: /usr/local/Library/ENV/4.3/sed: No such file or directory

Exporting SED is a simple fix. Otherwise we could have also re-installed libtool:
  brew uninstall libtool
  brew install libtool

Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>