### PR TITLE
libsmartcols: be consistent, use 'sy' for symbols

### DIFF
--- a/libsmartcols/src/libsmartcols.h.in
+++ b/libsmartcols/src/libsmartcols.h.in
@@ -113,12 +113,12 @@ extern int scols_get_library_version(const char **ver_string);
 extern struct libscols_symbols *scols_new_symbols(void);
 extern void scols_ref_symbols(struct libscols_symbols *sy);
 extern void scols_unref_symbols(struct libscols_symbols *sy);
-extern struct libscols_symbols *scols_copy_symbols(const struct libscols_symbols *sb);
-extern int scols_symbols_set_branch(struct libscols_symbols *sb, const char *str);
-extern int scols_symbols_set_vertical(struct libscols_symbols *sb, const char *str);
-extern int scols_symbols_set_right(struct libscols_symbols *sb, const char *str);
-extern int scols_symbols_set_title_padding(struct libscols_symbols *sb, const char *str);
-extern int scols_symbols_set_cell_padding(struct libscols_symbols *sb, const char *str);
+extern struct libscols_symbols *scols_copy_symbols(const struct libscols_symbols *sy);
+extern int scols_symbols_set_branch(struct libscols_symbols *sy, const char *str);
+extern int scols_symbols_set_vertical(struct libscols_symbols *sy, const char *str);
+extern int scols_symbols_set_right(struct libscols_symbols *sy, const char *str);
+extern int scols_symbols_set_title_padding(struct libscols_symbols *sy, const char *str);
+extern int scols_symbols_set_cell_padding(struct libscols_symbols *sy, const char *str);
 
 /* cell.c */
 extern int scols_reset_cell(struct libscols_cell *ce);

--- a/libsmartcols/src/symbols.c
+++ b/libsmartcols/src/symbols.c
@@ -70,43 +70,43 @@ void scols_unref_symbols(struct libscols_symbols *sy)
 
 /**
  * scols_symbols_set_branch:
- * @sb: a pointer to a struct libscols_symbols instance
+ * @sy: a pointer to a struct libscols_symbols instance
  * @str: a string which will represent the branch part of a tree output
  *
  * Returns: 0, a negative value in case of an error.
  */
-int scols_symbols_set_branch(struct libscols_symbols *sb, const char *str)
+int scols_symbols_set_branch(struct libscols_symbols *sy, const char *str)
 {
-	return strdup_to_struct_member(sb, branch, str);
+	return strdup_to_struct_member(sy, branch, str);
 }
 
 /**
  * scols_symbols_set_vertical:
- * @sb: a pointer to a struct libscols_symbols instance
+ * @sy: a pointer to a struct libscols_symbols instance
  * @str: a string which will represent the vertical part of a tree output
  *
  * Returns: 0, a negative value in case of an error.
  */
-int scols_symbols_set_vertical(struct libscols_symbols *sb, const char *str)
+int scols_symbols_set_vertical(struct libscols_symbols *sy, const char *str)
 {
-	return strdup_to_struct_member(sb, vert, str);
+	return strdup_to_struct_member(sy, vert, str);
 }
 
 /**
  * scols_symbols_set_right:
- * @sb: a pointer to a struct libscols_symbols instance
+ * @sy: a pointer to a struct libscols_symbols instance
  * @str: a string which will represent the right part of a tree output
  *
  * Returns: 0, a negative value in case of an error.
  */
-int scols_symbols_set_right(struct libscols_symbols *sb, const char *str)
+int scols_symbols_set_right(struct libscols_symbols *sy, const char *str)
 {
-	return strdup_to_struct_member(sb, right, str);
+	return strdup_to_struct_member(sy, right, str);
 }
 
 /**
  * scols_symbols_set_title_padding:
- * @sb: a pointer to a struct libscols_symbols instance
+ * @sy: a pointer to a struct libscols_symbols instance
  * @str: a string which will represent the symbols which fill title output
  *
  * The current implementation uses only the first byte from the padding string.
@@ -116,14 +116,14 @@ int scols_symbols_set_right(struct libscols_symbols *sb, const char *str)
  *
  * Since: 2.28
  */
-int scols_symbols_set_title_padding(struct libscols_symbols *sb, const char *str)
+int scols_symbols_set_title_padding(struct libscols_symbols *sy, const char *str)
 {
-	return strdup_to_struct_member(sb, title_padding, str);
+	return strdup_to_struct_member(sy, title_padding, str);
 }
 
 /**
  * scols_symbols_set_cell_padding:
- * @sb: a pointer to a struct libscols_symbols instance
+ * @sy: a pointer to a struct libscols_symbols instance
  * @str: a string which will represent the symbols which fill cells
  *
  * The padding char has to take up just one cell on the terminal.
@@ -132,39 +132,39 @@ int scols_symbols_set_title_padding(struct libscols_symbols *sb, const char *str
  *
  * Since: 2.29
  */
-int scols_symbols_set_cell_padding(struct libscols_symbols *sb, const char *str)
+int scols_symbols_set_cell_padding(struct libscols_symbols *sy, const char *str)
 {
-	return strdup_to_struct_member(sb, cell_padding, str);
+	return strdup_to_struct_member(sy, cell_padding, str);
 }
 
 /**
  * scols_copy_symbols:
- * @sb: a pointer to a struct libscols_symbols instance
+ * @sy: a pointer to a struct libscols_symbols instance
  *
- * Returns: a newly allocated copy of the @sb symbol group or NULL in case of an error.
+ * Returns: a newly allocated copy of the @sy symbol group or NULL in case of an error.
  */
-struct libscols_symbols *scols_copy_symbols(const struct libscols_symbols *sb)
+struct libscols_symbols *scols_copy_symbols(const struct libscols_symbols *sy)
 {
 	struct libscols_symbols *ret;
 	int rc;
 
-	assert(sb);
-	if (!sb)
+	assert(sy);
+	if (!sy)
 		return NULL;
 
 	ret = scols_new_symbols();
 	if (!ret)
 		return NULL;
 
-	rc = scols_symbols_set_branch(ret, sb->branch);
+	rc = scols_symbols_set_branch(ret, sy->branch);
 	if (!rc)
-		rc = scols_symbols_set_vertical(ret, sb->vert);
+		rc = scols_symbols_set_vertical(ret, sy->vert);
 	if (!rc)
-		rc = scols_symbols_set_right(ret, sb->right);
+		rc = scols_symbols_set_right(ret, sy->right);
 	if (!rc)
-		rc = scols_symbols_set_title_padding(ret, sb->title_padding);
+		rc = scols_symbols_set_title_padding(ret, sy->title_padding);
 	if (!rc)
-		rc = scols_symbols_set_cell_padding(ret, sb->cell_padding);
+		rc = scols_symbols_set_cell_padding(ret, sy->cell_padding);
 	if (!rc)
 		return ret;
 


### PR DESCRIPTION
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>