### PR TITLE
tests: consolidate rmmod scsi_debug

### DIFF
--- a/tests/ts/blkid/mbr-wholedisk
+++ b/tests/ts/blkid/mbr-wholedisk
@@ -39,5 +39,4 @@ udevadm settle
 $TS_CMD_BLKID -p -o udev ${TS_DEVICE} >> $TS_OUTPUT
 ts_finalize_subtest
 
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/blkid/md-raid1-part
+++ b/tests/ts/blkid/md-raid1-part
@@ -79,8 +79,6 @@ $TS_CMD_BLKID -p -o udev ${TS_DEVICE}2 2>&1 | sort >> $TS_OUTPUT
 
 mdadm -q -S ${MD_DEVICE} >> $TS_OUTPUT 2>&1
 
-udevadm settle
-rmmod scsi_debug
 
 ts_fdisk_clean $TS_DEVICE
 # substitue UUIDs and major/minor number before comparison

--- a/tests/ts/eject/umount
+++ b/tests/ts/eject/umount
@@ -55,8 +55,7 @@ EOF
 }
 
 function deinit_device {
-	udevadm settle
-	rmmod scsi_debug
+	ts_scsi_debug_rmmod
 }
 
 

--- a/tests/ts/fdisk/align-512-4K
+++ b/tests/ts/fdisk/align-512-4K
@@ -73,8 +73,6 @@ udevadm settle
 ts_log "Alignment offsets:"
 cat /sys/block/${DEVNAME}/${DEVNAME}{1,2,3,4,5,6,7}/alignment_offset >> $TS_OUTPUT 2>&1
 
-rmmod scsi_debug
-
 ts_fdisk_clean $TS_DEVICE
 
 ts_finalize

--- a/tests/ts/fdisk/align-512-4K-63
+++ b/tests/ts/fdisk/align-512-4K-63
@@ -73,7 +73,6 @@ udevadm settle
 ts_log "Alignment offsets:"
 cat /sys/block/${DEVNAME}/${DEVNAME}{1,2,3,4,5,6,7}/alignment_offset >> $TS_OUTPUT 2>&1
 
-rmmod scsi_debug
 
 ts_fdisk_clean $TS_DEVICE
 

--- a/tests/ts/fdisk/align-512-4K-md
+++ b/tests/ts/fdisk/align-512-4K-md
@@ -87,9 +87,6 @@ cat /sys/block/${MD_DEVNAME}/${MD_DEVNAME}p{1,2}/alignment_offset >> $TS_OUTPUT 
 
 mdadm -q -S ${MD_DEVICE} >> $TS_OUTPUT 2>&1
 
-udevadm settle
-rmmod scsi_debug
-
 ts_fdisk_clean $TS_DEVICE
 ts_fdisk_clean $MD_DEVICE
 

--- a/tests/ts/fdisk/align-512-512-topology
+++ b/tests/ts/fdisk/align-512-512-topology
@@ -73,8 +73,6 @@ udevadm settle
 ts_log "Alignment offsets:"
 cat /sys/block/${DEVNAME}/${DEVNAME}{1,2,3,4,5,6,7}/alignment_offset >> $TS_OUTPUT 2>&1
 
-rmmod scsi_debug
-
 ts_fdisk_clean $TS_DEVICE
 
 ts_finalize

--- a/tests/ts/libmount/context
+++ b/tests/ts/libmount/context
@@ -58,7 +58,6 @@ udevadm settle
 
 grep -q $DEVNAME /proc/partitions
 if [ $? -ne 0 ]; then
-	rmmod scsi_debug
 	ts_skip "no partition!"
 fi
 
@@ -157,5 +156,4 @@ $TS_CMD_UMOUNT $TS_NOEXIST
 rmdir $TS_NOEXIST
 
 ts_log "...done."
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/libmount/context-py
+++ b/tests/ts/libmount/context-py
@@ -60,7 +60,6 @@ udevadm settle
 
 grep -q $DEVNAME /proc/partitions
 if [ $? -ne 0 ]; then
-	rmmod scsi_debug
 	ts_skip "no partition!"
 fi
 
@@ -159,5 +158,4 @@ $TS_CMD_UMOUNT $TS_NOEXIST
 rmdir $TS_NOEXIST
 
 ts_log "...done."
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/libmount/context-utab
+++ b/tests/ts/libmount/context-utab
@@ -46,7 +46,6 @@ udevadm settle
 
 grep -q $DEVNAME /proc/partitions
 if [ $? -ne 0 ]; then
-	rmmod scsi_debug
 	ts_skip "no partition!"
 fi
 
@@ -130,5 +129,4 @@ if type "mkfs.btrfs" &>/dev/null && mkfs.btrfs --version &>/dev/null; then
 fi
 
 ts_log "...done."
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/libmount/context-utab-py
+++ b/tests/ts/libmount/context-utab-py
@@ -47,7 +47,6 @@ udevadm settle
 
 grep -q $DEVNAME /proc/partitions
 if [ $? -ne 0 ]; then
-	rmmod scsi_debug
 	ts_skip "no partition!"
 fi
 
@@ -131,5 +130,4 @@ if type "mkfs.btrfs" &>/dev/null && mkfs.btrfs --version &>/dev/null; then
 fi
 
 ts_log "...done."
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/libmount/tabfiles-tags
+++ b/tests/ts/libmount/tabfiles-tags
@@ -83,6 +83,4 @@ sed -i -e 's/fs: 0x.*/fs:/g' $TS_OUTPUT
 sed -i -e 's/source: .*//g' $TS_OUTPUT		# devname is generated, remove it
 ts_finalize_subtest
 
-udevadm settle
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/libmount/tabfiles-tags-py
+++ b/tests/ts/libmount/tabfiles-tags-py
@@ -87,6 +87,4 @@ sed -i -e 's/fs: 0x.*/fs:/g' $TS_OUTPUT
 sed -i -e 's/source: .*//g' $TS_OUTPUT		# devname is generated, remove it
 ts_finalize_subtest
 
-udevadm settle
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/losetup/losetup-blkdev
+++ b/tests/ts/losetup/losetup-blkdev
@@ -78,8 +78,4 @@ udevadm settle
 $TS_CMD_LOSETUP -d $LODEV
 ts_finalize_subtest
 
-udevadm settle
-
-rmmod scsi_debug
-
 ts_finalize

--- a/tests/ts/minix/mkfs
+++ b/tests/ts/minix/mkfs
@@ -51,7 +51,5 @@ mkfs_and_mount_minix 'v2c14' '-2 -n 14'
 mkfs_and_mount_minix 'v2c30' '-2 -n 30'
 mkfs_and_mount_minix 'v3c60' '-3 -n 60'
 
-udevadm settle
-rmmod scsi_debug &>/dev/null
 ts_finalize
 

--- a/tests/ts/mount/umount-alltargets
+++ b/tests/ts/mount/umount-alltargets
@@ -118,9 +118,5 @@ $TS_CMD_UMOUNT --recursive --all-targets ${TS_DEVICE}1 >> $TS_OUTPUT 2>&1
 [ $? == 0 ] || ts_log "umount failed"
 ts_finalize_subtest
 
-udevadm settle
-rmmod scsi_debug >> $TS_OUTPUT 2>&1
-[ $? == 0 ] || ts_die "device busy (umount failed?)"
-
 ts_log "Success"
 ts_finalize

--- a/tests/ts/mount/umount-recursive
+++ b/tests/ts/mount/umount-recursive
@@ -90,10 +90,6 @@ $TS_CMD_MOUNT --bind $TS_MOUNTPOINT/mntB/mntC $TS_MOUNTPOINT/bindC
 $TS_CMD_UMOUNT --recursive $TS_MOUNTPOINT >> $TS_OUTPUT 2>&1
 [ $? == 0 ] || ts_die "umount failed"
 
-udevadm settle
-rmmod scsi_debug >> $TS_OUTPUT 2>&1
-[ $? == 0 ] || ts_die "device busy (umount failed?)"
-
 ts_log "Success"
 ts_finalize
 

--- a/tests/ts/partx/partx
+++ b/tests/ts/partx/partx
@@ -59,8 +59,7 @@ $TS_CMD_DELPART ${TS_DEVICE} 1
 [ "$?" == 0 ] && echo OK >> $TS_OUTPUT 2>&1 || ts_die "Unable to remove partition" >> $TS_OUTPUT 2>&1
 ts_finalize_subtest
 
-udevadm settle
-rmmod scsi_debug &> /dev/null
+ts_scsi_debug_rmmod
 
 # set global variable TS_DEVICE
 ts_scsi_debug_init dev_size_mb=50 num_parts=$PARTS
@@ -135,6 +134,4 @@ $TS_CMD_PARTX -a --nr 0 $TS_DEVICE
 [ $(ls -d /sys/block/${DEVNAME}/${DEVNAME}* 2>/dev/null | wc -l) -eq $PARTS ] && echo "partitions added" >> $TS_OUTPUT 2>&1 || echo "Failed to add $TS_DEVICE partitions" >> $TS_OUTPUT 2>&1
 ts_finalize_subtest
 
-udevadm settle
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/sfdisk/dos
+++ b/tests/ts/sfdisk/dos
@@ -151,6 +151,4 @@ ts_fdisk_clean $TS_DEVICE
 udevadm settle
 ts_finalize_subtest
 
-
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/sfdisk/gpt
+++ b/tests/ts/sfdisk/gpt
@@ -165,5 +165,4 @@ udevadm settle
 ts_finalize_subtest
 
 
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/sfdisk/movedata
+++ b/tests/ts/sfdisk/movedata
@@ -72,5 +72,4 @@ checksum ${TS_DEVICE}1
 ts_finalize_subtest
 
 
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/sfdisk/resize
+++ b/tests/ts/sfdisk/resize
@@ -122,5 +122,4 @@ test_label_resize dos
 # GPT
 test_label_resize gpt
 
-rmmod scsi_debug
 ts_finalize

--- a/tests/ts/wipefs/wipefs
+++ b/tests/ts/wipefs/wipefs
@@ -30,5 +30,4 @@ $TS_CMD_WIPEFS -a ${TS_DEVICE} > $TS_OUTDIR/out 2>/dev/null
 # check for output
 [ -s $TS_OUTDIR/out ] && echo "OK" &> $TS_OUTPUT || exit 1
 
-rmmod scsi_debug &>/dev/null
 ts_finalize


### PR DESCRIPTION
 - auto cleanup on test exit
 - Add smart timeout: Newer openSUSE systems on OBS failed to rmmod
   almost always. udevadm settle does not seem to have any affect.
 - now tests will fail if rmmod fails

Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>