### PR TITLE
test: fix raid1 minimum I/O size

### DIFF
--- a/tests/expected/blkid/md-raid1-whole
+++ b/tests/expected/blkid/md-raid1-whole
@@ -24,7 +24,7 @@ Created a new <removed>.
 Command (m for help): Disk /dev/md8: 50 MiB, 52363264 bytes, 102272 sectors
 Units: sectors of 1 * 512 = 512 bytes
 Sector size (logical/physical): 512 bytes / 512 bytes
-I/O size (minimum/optimal): 512 bytes / <removed> bytes
+I/O size (minimum/optimal): <removed> bytes / <removed> bytes
 Disklabel type: dos
 Disk identifier: <removed>
 

--- a/tests/ts/blkid/md-raid1-whole
+++ b/tests/ts/blkid/md-raid1-whole
@@ -80,6 +80,8 @@ udevadm settle
 ts_log "Deinitialize devices"
 
 ts_fdisk_clean
+# seems that raid1 minimum I/O size has been changed in kernels >4.4.x and >4.8
+sed -i 's@^\(I/O size (minimum/optimal): \)[1-9][0-9]*@\1<removed>@' $TS_OUTPUT
 # remove generated UUIDs
 sed -i -e 's/ID_FS_UUID.*//g' $TS_OUTPUT
 


### PR DESCRIPTION
I have not validated if this is just a temporary kernel bug or if kernel has really changed that on purpose.