### PR TITLE
build-sys: don't clean *.img files

### DIFF
--- a/libmount/python/Makemodule.am
+++ b/libmount/python/Makemodule.am
@@ -32,6 +32,4 @@ dist_check_SCRIPTS += libmount/python/test_mount_context.py
 dist_check_SCRIPTS += libmount/python/test_mount_tab.py
 dist_check_SCRIPTS += libmount/python/test_mount_tab_update.py
 
-CLEANFILES += *.img
-
 endif # BUILD_PYLIBMOUNT


### PR DESCRIPTION
Don't know why this was added in d78df0ac but it can't be right that
libmount/python removes these files in the toplevel builddir. Moreover
I've never seen such *.img files appearing during build at all.

Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>