### PR TITLE
docs: replace FTP by HTTPS in kernel.org URLs

### DIFF
--- a/Documentation/howto-man-page.txt
+++ b/Documentation/howto-man-page.txt
@@ -183,6 +183,6 @@ Fred Foobar
 .BR bar (8)
 .SH AVAILABILITY
 The example command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/Documentation/releases/v2.13-ReleaseNotes
+++ b/Documentation/releases/v2.13-ReleaseNotes
@@ -61,7 +61,7 @@ Changelog:
 ---------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.13/
 
 
 agetty:

--- a/Documentation/releases/v2.14-ReleaseNotes
+++ b/Documentation/releases/v2.14-ReleaseNotes
@@ -69,20 +69,20 @@ Stable maintenance releases between v2.13 and v2.14
 
 util-linux-ng 2.13.1.1 [22-Apr-2008]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13.1.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13.1.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13.1.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13.1.1-ChangeLog
 
 util-linux-ng 2.13.1 [16-Jan-2008]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13.1-ChangeLog
 
 
 ChangeLog between v2.13 and v2.14
 ---------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.14/
 
 agetty:
    - cleanup MAXHOSTNAMELEN  [Karel Zak]

--- a/Documentation/releases/v2.15-ReleaseNotes
+++ b/Documentation/releases/v2.15-ReleaseNotes
@@ -111,20 +111,20 @@ Stable maintenance releases between v2.14 and v2.15
 
 util-linux-ng 2.14.1 [10-Aug-2008]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14.1-ChangeLog
 
 util-linux-ng 2.14.2 [09-Feb-2009]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14.2-ChangeLog
 
 
 ChangeLog between v2.14 and v2.15
 ---------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.15/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.15/
 
 addpart:
    - 512-byte sectors in code, bytes in man-page  [Karel Zak]

--- a/Documentation/releases/v2.16-ReleaseNotes
+++ b/Documentation/releases/v2.16-ReleaseNotes
@@ -24,15 +24,15 @@ Stable maintenance releases between v2.15 and v2.16
 
 util-linux-ng 2.15.1 [10-Jun-2009]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15.1-ChangeLog
 
 
 ChangeLog between v2.15 and v2.16
 ---------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.16/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.16/
 
 
 build-sys:

--- a/Documentation/releases/v2.17-ReleaseNotes
+++ b/Documentation/releases/v2.17-ReleaseNotes
@@ -51,20 +51,20 @@ Stable maintenance releases between v2.16 and v2.17
 
 util-linux-ng 2.16.1 [07-Sep-2009]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16.1-ChangeLog
 
 util-linux-ng 2.16.2 [30-Nov-2009]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16.2-ChangeLog
 
 
 ChangeLog between v2.16 and v2.17
 ---------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.17/
 
 addpart:
    - addpart.8 formatting  [Peter Breitenlohner]

--- a/Documentation/releases/v2.18-ReleaseNotes
+++ b/Documentation/releases/v2.18-ReleaseNotes
@@ -73,20 +73,20 @@ Stable maintenance releases between v2.17 and v2.18
 
 util-linux-ng 2.17.1 [22-Feb-2010]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17.1-ChangeLog
 
 util-linux-ng 2.17.2 [22-Mar-2010]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17.2-ChangeLog
 
 
 Changes between v2.17 and v2.18
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.18/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.18/
 
 addpart:
    - use atoll() for parsing command line arguments  [Thomas Fehr]

--- a/Documentation/releases/v2.19-ReleaseNotes
+++ b/Documentation/releases/v2.19-ReleaseNotes
@@ -62,7 +62,7 @@ Changes between v2.18 and v2.19
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.19/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.19/
 
 addpart:
    - code consolidation  [Karel Zak]

--- a/Documentation/releases/v2.20-ReleaseNotes
+++ b/Documentation/releases/v2.20-ReleaseNotes
@@ -81,15 +81,15 @@ Stable maintenance releases between v2.19 and v2.20
 
 util-linux 2.19.1 [02-May-2011]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19.1-ChangeLog
 
 
 Changes between v2.19 and v2.20
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.20/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.20/
 
 addpart:
    - multiplication on 512 deleted  [Anton V. Boyarshinov]

--- a/Documentation/releases/v2.21-ReleaseNotes
+++ b/Documentation/releases/v2.21-ReleaseNotes
@@ -81,15 +81,15 @@ Stable maintenance releases between v2.20 and v2.21
 
 util-linux 2.20.1 [20-Oct-2011]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20.1-ChangeLog
 
 
 Changes between v2.20 and v2.21
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.21/
 
 agetty:
    - add --nohints  [Karel Zak]

--- a/Documentation/releases/v2.22-ReleaseNotes
+++ b/Documentation/releases/v2.22-ReleaseNotes
@@ -97,20 +97,20 @@ Stable maintenance releases between v2.21 and v2.22
 
 util-linux 2.21.1 [30-Mar-2012]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21.1-ChangeLog
 
 util-linux 2.21.2 [25-May-2012]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21.2-ChangeLog
 
 
 Changes between v2.21 and v2.22
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.22/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.22/
 
 addpart:
    - align with util-linux coding standards  [Sami Kerola]

--- a/Documentation/releases/v2.23-ReleaseNotes
+++ b/Documentation/releases/v2.23-ReleaseNotes
@@ -113,20 +113,20 @@ Stable maintenance releases between v2.22 and v2.23
 
 util-linux 2.22.1 [10-Oct-2012]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22.1-ChangeLog
 
 util-linux 2.22.2 [13-Dec-2012]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22.2-ChangeLog
 
 
 Changes between v2.22 and v2.23
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.23/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.23/
 
 agetty:
    - add --chroot to usage() and man page  [Karel Zak]

--- a/Documentation/releases/v2.24-ReleaseNotes
+++ b/Documentation/releases/v2.24-ReleaseNotes
@@ -74,20 +74,20 @@ Stable maintenance releases between v2.23 and v2.24
 
 util-linux 2.22.1 [Jun 31 2013]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23.1-ChangeLog
 
 util-linux 2.23.2 [May 28 2013]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23.2-ChangeLog
 
 
 Changes between v2.23 and v2.24
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.24/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.24/
 
 agetty:
    - -L accepts optional argument  [Karel Zak]

--- a/Documentation/releases/v2.25-ReleaseNotes
+++ b/Documentation/releases/v2.25-ReleaseNotes
@@ -80,20 +80,20 @@ Stable maintenance releases between v2.24 and v2.25
 
 util-linux 2.24.1 [Jan 20 2014]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24.1-ChangeLog
 
 util-linux 2.24.2 [Apr 24 2014]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24.2-ChangeLog
 
 
 Changes between v2.24 and v2.25
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.25/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.25/
 
 
 addpart:

--- a/Documentation/releases/v2.26-ReleaseNotes
+++ b/Documentation/releases/v2.26-ReleaseNotes
@@ -91,20 +91,20 @@ Stable maintenance releases between v2.25 and v2.26
 
 util-linux 2.25.1 [Sep 3 2014]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25.1-ChangeLog
 
 util-linux 2.25.2 [Oct 24 2014]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25.2-ChangeLog
 
 
 Changes between v2.25 and v2.26
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.26/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.26/
 
 agetty:
    - Reprompt and reprint /etc/issue when asked  [Stef Walter]

--- a/Documentation/releases/v2.27-ReleaseNotes
+++ b/Documentation/releases/v2.27-ReleaseNotes
@@ -70,20 +70,20 @@ Stable maintenance releases between v2.26 and v2.27
 
 util-linux 2.26.1 [Mar 3 2015]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26.1-ChangeLog
 
 util-linux 2.26.2 [Apr 4 2015]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26.2-ChangeLog
 
 
 Changes between v2.26 and v2.27
 -------------------------------
 
  For more details see ChangeLog files at:
- ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.27/
+ https://www.kernel.org/pub/linux/utils/util-linux/v2.27/
 
 agetty:
    - Reprompt once the network addresses change if address displayed  [Stef Walter]

--- a/Documentation/releases/v2.28-ReleaseNotes
+++ b/Documentation/releases/v2.28-ReleaseNotes
@@ -67,8 +67,8 @@ Stable maintenance releases between v2.27 and v2.28
 
 util-linux 2.27.1 [Nov 11 2015]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27.1-ChangeLog
 
 
 Changes between v2.27 and v2.28

--- a/Documentation/releases/v2.29-ReleaseNotes
+++ b/Documentation/releases/v2.29-ReleaseNotes
@@ -19,13 +19,13 @@ Stable maintenance releases between v2.28 and v2.29
 
 util-linux 2.28.2 [Sep 7 2016]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28.2-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28.2-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28.2-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28.2-ChangeLog
 
 util-linux 2.28.1 [Aug 11 2016]
 
- * ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28.1-ReleaseNotes
-   ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28.1-ChangeLog
+ * https://www.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28.1-ReleaseNotes
+   https://www.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28.1-ChangeLog
 
 Changes between v2.28 and v2.29
 -------------------------------

--- a/NEWS
+++ b/NEWS
@@ -1,222 +1,222 @@
 util-linux 2.29: Nov 8 2016
 * see Documentation/releases/v2.29-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.29/v2.29-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.29/v2.29-ChangeLog
 
 util-linux 2.29-rc2: Oct 19 2016
 * see Documentation/releases/v2.29-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.29/v2.29-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.29/v2.29-rc2-ChangeLog
 
 util-linux 2.29-rc1: Sep 30 2016
 * see Documentation/releases/v2.29-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.29/v2.29-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.29/v2.29-rc1-ChangeLog
 
 util-linux 2.28: Apr 12 2016
 * see Documentation/releases/v2.28-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28-ChangeLog
 
 util-linux 2.28-rc2: Mar 29 2016
 * see Documentation/releases/v2.28-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28-rc2-ChangeLog
 
 util-linux 2.28-rc1: Mar 11 2016
 * see Documentation/releases/v2.28-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28-rc1-ChangeLog
 
 util-linux 2.27: Sep 07 2015
 * see Documentation/releases/v2.27-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27-ChangeLog
 
 util-linux 2.27-rc2: Aug 24 2015
 * see Documentation/releases/v2.27-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27-rc2-ChangeLog
 
 util-linux 2.27-rc1: Jul 31 2015
 * see Documentation/releases/v2.27-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27-rc1-ChangeLog
 
 util-linux 2.26: Feb 19 2015
 * see Documentation/releases/v2.26-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26-ChangeLog
 
 util-linux 2.26-rc2: Feb 4 2015
 * see Documentation/releases/v2.26-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26-rc2-ChangeLog
 
 util-linux 2.26-rc1: Jan 14 2015
 * see Documentation/releases/v2.26-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26-rc1-ChangeLog
 
 util-linux 2.25: Jul 22 2014
 * see Documentation/releases/v2.25-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25-ChangeLog
 
 util-linux 2.25-rc2: Jul 2 2014
 * see Documentation/releases/v2.25-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25-rc2-ChangeLog
 
 util-linux 2.25-rc1: Jun 18 2014
 * see Documentation/releases/v2.25-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.25/v2.25-rc1-ChangeLog
 
 util-linux 2.24: Oct 21 2013
 * see Documentation/releases/v2.24-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24-ChangeLog
 
 util-linux 2.24-rc2: Oct 11 2013
 * see Documentation/releases/v2.24-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24-rc2-ChangeLog
 
 util-linux 2.24-rc1: Sep 27 2013
 * see Documentation/releases/v2.24-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.24/v2.24-rc1-ChangeLog
 
 util-linux 2.23: Apr 25 2013
 * see Documentation/releases/v2.23-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-ChangeLog
 
 util-linux 2.23-rc2: Apr 10 2013
 * see Documentation/releases/v2.23-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-rc2-ChangeLog
 
 util-linux 2.23-rc1: Mar 22 2013
 * see Documentation/releases/v2.23-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-rc1-ChangeLog
 
 util-linux 2.22: Sep 04 2012
 * see Documentation/releases/v2.22-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22-ChangeLog
 
 util-linux 2.22-rc2: Aug 15 2012
 * see Documentation/releases/v2.22-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22-rc2-ChangeLog
 
 util-linux 2.22-rc1: Jul 27 2012
 * see Documentation/releases/v2.22-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22-rc1-ChangeLog
 
 util-linux 2.21: Feb 24 2012
 * see Documentation/releases/v2.21-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-ChangeLog
 
 util-linux 2.21-rc2: Feb 06 2012
 * see Documentation/releases/v2.21-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-rc2-ChangeLog
 
 util-linux 2.21-rc1: Jan 18 2012
 * see Documentation/releases/v2.21-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-rc1-ChangeLog
 
 util-linux 2.20: Aug 29 2011
 * see Documentation/releases/v2.20-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20-ChangeLog
 
 util-linux 2.20-rc2: Aug 17 2011
 * see Documentation/releases/v2.20-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20-rc2-ChangeLog
 
 util-linux 2.20-rc1: Jul 29 2011
 * see Documentation/releases/v2.20-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20-rc1-ChangeLog
 
 util-linux 2.19: Feb 10 2011
 * see Documentation/releases/v2.19-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19-ChangeLog
 
 util-linux 2.19-rc3: Jan 25 2011
 * see Documentation/releases/v2.19-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19-rc3-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19-rc3-ChangeLog
 
 util-linux 2.19-rc2: Jan 25 2011
 * see Documentation/releases/v2.19-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19-rc2-ChangeLog
 
 util-linux 2.19-rc1: Jan 05 2011
 * see Documentation/releases/v2.19-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.19/v2.19-rc1-ChangeLog
 
 util-linux-ng 2.18: Jun 30 2010
 * see Documentation/releases/v2.18-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.18/v2.18-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.18/v2.18-ChangeLog
 
 util-linux-ng 2.18-rc2: Jun 18 2010
 * see Documentation/releases/v2.18-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.18/v2.18-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.18/v2.18-rc2-ChangeLog
 
 util-linux-ng 2.18-rc1: Jun 7 2010
 * see Documentation/releases/v2.18-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.18/v2.18-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.18/v2.18-rc1-ChangeLog
 
 util-linux-ng 2.17: Jan 8 2010
 * see Documentation/releases/v2.17-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17-ChangeLog
 
 util-linux-ng 2.17-rc3: Dec 10 2009
 * see Documentation/releases/v2.17-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17-rc3-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17-rc3-ChangeLog
 
 util-linux-ng 2.17-rc2: Dec 9 2009
 * see Documentation/releases/v2.17-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17-rc2-ChangeLog
 
 util-linux-ng 2.17-rc1: Nov 20 2009
 * see Documentation/releases/v2.17-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.17/v2.17-rc1-ChangeLog
 
 util-linux-ng 2.16: Jul  2009
 * see Documentation/releases/v2.16-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16-ChangeLog
 
 util-linux-ng 2.16-rc2: Jul 2 2009
 * see Documentation/releases/v2.16-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16-rc2-ChangeLog
 
 util-linux-ng 2.16-rc1: Jun 28 2009
 * see Documentation/releases/v2.16-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.16/v2.16-rc1-ChangeLog
 
 util-linux-ng 2.15: May 5 2009
 * see Documentation/releases/v2.15-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15-ChangeLog
 
 util-linux-ng 2.15-rc2: Apr 17 2009
 * see Documentation/releases/v2.15-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15-rc2-ChangeLog
 
 util-linux-ng 2.15-rc1: Mar 18 2009
 * see Documentation/releases/v2.15-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.15/v2.15-rc1-ChangeLog
 
 util-linux-ng 2.14: Jun 9 2008
 * see Documentation/releases/v2.14-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14-ChangeLog
 
 util-linux-ng 2.14-rc3: May 19 2008
 * see Documentation/releases/v2.14-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14-rc3-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14-rc3-ChangeLog
 
 util-linux-ng 2.14-rc2: Apr 28 2008
 * see Documentation/releases/v2.14-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14-rc2-ChangeLog
 
 util-linux-ng 2.14-rc1: Apr 16 2008
 * see Documentation/releases/v2.14-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.14/v2.14-rc1-ChangeLog
 
 util-linux-ng 2.13: Aug 28 2007
 * see Documentation/releases/v2.13-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13-ChangeLog
 
 util-linux-ng 2.13-rc3: Aug 8 2007
 * see Documentation/releases/v2.13-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13-rc3-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13-rc3-ChangeLog
 
 util-linux-ng 2.13-rc2: Jul 17 2007
 * see Documentation/releases/v2.13-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13-rc2-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13-rc2-ChangeLog
 
 util-linux-ng 2.13-rc1: Jul 4 2007
 * see Documentation/releases/v2.13-ReleaseNotes or the complete changelog at
-  ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13-rc1-ChangeLog
+  https://www.kernel.org/pub/linux/utils/util-linux/v2.13/v2.13-rc1-ChangeLog
 
 util-linux 2.13-pre7
 

--- a/README
+++ b/README
@@ -13,7 +13,7 @@ MAILING LIST:
 
 DOWNLOAD:
 
-      ftp://ftp.kernel.org/pub/linux/utils/util-linux/
+      https://www.kernel.org/pub/linux/utils/util-linux/
 
 
 SOURCE CODE:

--- a/disk-utils/addpart.8
+++ b/disk-utils/addpart.8
@@ -37,4 +37,4 @@ The length of the partition (in 512-byte sectors).
 .BR partx (8)
 .SH AVAILABILITY
 The addpart command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/blockdev.8
+++ b/disk-utils/blockdev.8
@@ -82,4 +82,4 @@ Set read-write.
 blockdev was written by Andries E.\& Brouwer and rewritten by Karel Zak.
 .SH AVAILABILITY
 The blockdev command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/cfdisk.8
+++ b/disk-utils/cfdisk.8
@@ -201,4 +201,4 @@ from Kevin E. Martin (martin@cs.unc.edu).
 
 .SH AVAILABILITY
 The cfdisk command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/delpart.8
+++ b/disk-utils/delpart.8
@@ -24,4 +24,4 @@ This command doesn't manipulate partitions on a block device.
 .BR partx (8)
 .SH AVAILABILITY
 The delpart command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/fdformat.8
+++ b/disk-utils/fdformat.8
@@ -71,4 +71,4 @@ Display help text and exit.
 Werner Almesberger (almesber@nessie.cs.id.ethz.ch)
 .SH AVAILABILITY
 The fdformat command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/fdisk.8
+++ b/disk-utils/fdisk.8
@@ -365,4 +365,4 @@ use visible padding characters. Requires enabled LIBSMARTCOLS_DEBUG.
 
 .SH AVAILABILITY
 The fdisk command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/fsck.8
+++ b/disk-utils/fsck.8
@@ -407,6 +407,6 @@ Karel Zak <kzak@redhat.com>
 .fi.
 .SH AVAILABILITY
 The fsck command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/disk-utils/fsck.cramfs.8
+++ b/disk-utils/fsck.cramfs.8
@@ -56,6 +56,6 @@ usage information was printed
 .BR mkfs.cramfs (8)
 .SH AVAILABILITY
 The example command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/disk-utils/fsck.minix.8
+++ b/disk-utils/fsck.minix.8
@@ -163,6 +163,6 @@ Russell King
 .BR reboot (8)
 .SH AVAILABILITY
 The fsck.minix command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/disk-utils/isosize.8
+++ b/disk-utils/isosize.8
@@ -34,6 +34,6 @@ are allowed to add "run out" sectors at the end of an iso9660
 image.
 .SH AVAILABILITY
 The isosize command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/disk-utils/mkfs.8
+++ b/disk-utils/mkfs.8
@@ -91,4 +91,4 @@ for the ext2 filesystem.
 .ad
 .SH AVAILABILITY
 The mkfs command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/mkfs.bfs.8
+++ b/disk-utils/mkfs.bfs.8
@@ -55,4 +55,4 @@ is 0 when all went well, and 1 when something went wrong.
 .BR mkfs (8)
 .SH AVAILABILITY
 The mkfs.bfs command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/mkfs.cramfs.8
+++ b/disk-utils/mkfs.cramfs.8
@@ -85,6 +85,6 @@ operation error, such as unable to allocate memory
 .BR mount (8)
 .SH AVAILABILITY
 The example command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/disk-utils/mkfs.minix.8
+++ b/disk-utils/mkfs.minix.8
@@ -86,4 +86,4 @@ Usage or syntax error
 .BR reboot (8)
 .SH AVAILABILITY
 The mkfs.minix command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/mkswap.8
+++ b/disk-utils/mkswap.8
@@ -151,4 +151,4 @@ enables libblkid debug output.
 .BR swapon (8)
 .SH AVAILABILITY
 The mkswap command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/partx.8
+++ b/disk-utils/partx.8
@@ -193,6 +193,6 @@ Andries E.\& Brouwer
 enables libblkid debug output.
 .SH AVAILABILITY
 The partx command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/disk-utils/raw.8
+++ b/disk-utils/raw.8
@@ -92,4 +92,4 @@ but is regarded either a bug or a feature depending on who you ask!
 Stephen Tweedie (sct@redhat.com)
 .SH AVAILABILITY
 The raw command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/resizepart.8
+++ b/disk-utils/resizepart.8
@@ -35,4 +35,4 @@ The new length of the partition (in 512-byte sectors).
 .BR partx (8)
 .SH AVAILABILITY
 The resizepart command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/sfdisk.8
+++ b/disk-utils/sfdisk.8
@@ -520,4 +520,4 @@ from Andries E. Brouwer.
 
 .SH AVAILABILITY
 The sfdisk command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/disk-utils/swaplabel.8
+++ b/disk-utils/swaplabel.8
@@ -63,7 +63,7 @@ was written by Jason Borden <jborden@bluehost.com> and Karel Zak <kzak@redhat.co
 enables libblkid debug output.
 .SH AVAILABILITY
 The swaplabel command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .SH SEE ALSO
 .BR uuidgen (1),
 .BR mkswap (8),

--- a/lib/terminal-colors.d.5
+++ b/lib/terminal-colors.d.5
@@ -187,6 +187,6 @@ COLORS section in the man page for the utility.
 
 .SH AVAILABILITY
 terminal-colors.d is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/libblkid/docs/libblkid-docs.xml
+++ b/libblkid/docs/libblkid-docs.xml
@@ -36,7 +36,7 @@ by Karel Zak. Currently, the library is maintained by Karel Zak.
     </para>
     <para>
 The library is part of the util-linux package since version 2.15 and is
-available from ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+available from https://www.kernel.org/pub/linux/utils/util-linux/.
     </para>
   </partintro>
   <xi:include href="xml/libblkid-config.xml"/>

--- a/libblkid/libblkid.3
+++ b/libblkid/libblkid.3
@@ -76,4 +76,4 @@ version 2 (or at your discretion any later version).
 .BR findfs (8)
 .SH AVAILABILITY
 libblkid is part of the util-linux package since version 2.15 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/libfdisk/docs/libfdisk-docs.xml
+++ b/libfdisk/docs/libfdisk-docs.xml
@@ -22,7 +22,7 @@ The libfdisk library is used for manipulating with partition tables.
     </para>
     <para>
 The library is part of the util-linux package since version 2.26 and is
-available from ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+available from https://www.kernel.org/pub/linux/utils/util-linux/.
     </para>
   </partintro>
  </part>

--- a/libmount/docs/libmount-docs.xml
+++ b/libmount/docs/libmount-docs.xml
@@ -23,7 +23,7 @@ The libmount library is used to parse /etc/fstab, /etc/mtab and
     </para>
     <para>
 The library is part of the util-linux package since version 2.18 and is
-available from ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+available from https://www.kernel.org/pub/linux/utils/util-linux/.
     </para>
   </partintro>
  </part>

--- a/libsmartcols/docs/libsmartcols-docs.xml
+++ b/libsmartcols/docs/libsmartcols-docs.xml
@@ -22,7 +22,7 @@ The libsmartcols library is used for smart adaptive formatting of tabular data.
     </para>
     <para>
 The library is part of the util-linux package since version 2.25 and is
-available from ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+available from https://www.kernel.org/pub/linux/utils/util-linux/.
     </para>
   </partintro>
  </part>

--- a/libuuid/man/uuid.3
+++ b/libuuid/man/uuid.3
@@ -53,7 +53,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .SH "SEE ALSO"
 .BR uuid_clear (3),
 .BR uuid_compare (3),

--- a/libuuid/man/uuid_clear.3
+++ b/libuuid/man/uuid_clear.3
@@ -49,7 +49,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .na
 .SH "SEE ALSO"
 .BR uuid (3),

--- a/libuuid/man/uuid_compare.3
+++ b/libuuid/man/uuid_compare.3
@@ -55,7 +55,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .na
 .SH "SEE ALSO"
 .BR uuid (3),

--- a/libuuid/man/uuid_copy.3
+++ b/libuuid/man/uuid_copy.3
@@ -51,7 +51,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .na
 .SH "SEE ALSO"
 .BR uuid (3),

--- a/libuuid/man/uuid_generate.3
+++ b/libuuid/man/uuid_generate.3
@@ -112,7 +112,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .SH "SEE ALSO"
 .BR uuidgen (1),
 .BR uuid (3),

--- a/libuuid/man/uuid_is_null.3
+++ b/libuuid/man/uuid_is_null.3
@@ -50,7 +50,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .na
 .SH "SEE ALSO"
 .BR uuid (3),

--- a/libuuid/man/uuid_parse.3
+++ b/libuuid/man/uuid_parse.3
@@ -59,7 +59,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .na
 .SH "SEE ALSO"
 .BR uuid (3),

--- a/libuuid/man/uuid_time.3
+++ b/libuuid/man/uuid_time.3
@@ -64,7 +64,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .na
 .SH "SEE ALSO"
 .BR uuid (3),

--- a/libuuid/man/uuid_unparse.3
+++ b/libuuid/man/uuid_unparse.3
@@ -67,7 +67,7 @@ Theodore Y.\& Ts'o
 .SH AVAILABILITY
 .B libuuid
 is part of the util-linux package since version 2.15.1 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.
 .na
 .SH "SEE ALSO"
 .BR uuid (3),

--- a/login-utils/chfn.1
+++ b/login-utils/chfn.1
@@ -103,4 +103,4 @@ Returns 0 if operation was successful, 1 if operation failed or command syntax w
 Salvatore Valente <svalente@mit.edu>
 .SH AVAILABILITY
 The chfn command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/login-utils/chsh.1
+++ b/login-utils/chsh.1
@@ -61,4 +61,4 @@ Returns 0 if operation was successful, 1 if operation failed or command syntax w
 Salvatore Valente <svalente@mit.edu>
 .SH AVAILABILITY
 The chsh command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/login-utils/last.1
+++ b/login-utils/last.1
@@ -188,7 +188,7 @@ Miquel van Smoorenburg
 .ME
 .SH AVAILABILITY
 The last command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .
 .SH "SEE ALSO"

--- a/login-utils/login.1
+++ b/login-utils/login.1
@@ -330,6 +330,6 @@ Karel Zak
 .SH AVAILABILITY
 The login command is part of the util-linux package and is
 available from
-.UR ftp:\://ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/login-utils/lslogins.1
+++ b/login-utils/lslogins.1
@@ -127,6 +127,6 @@ Karel Zak
 
 .SH AVAILABILITY
 The lslogins command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/login-utils/newgrp.1
+++ b/login-utils/newgrp.1
@@ -31,4 +31,4 @@ Peter Orbaek (poe@daimi.aau.dk).
 
 .SH AVAILABILITY
 The newgrp command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/login-utils/nologin.8
+++ b/login-utils/nologin.8
@@ -47,6 +47,6 @@ The
 command appeared in 4.4BSD.
 .SH AVAILABILITY
 The nologin command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/login-utils/runuser.1
+++ b/login-utils/runuser.1
@@ -236,6 +236,6 @@ David MacKenzie, and the Fedora \fBrunuser\fR command by Dan Walsh.
 .SH AVAILABILITY
 The runuser command is part of the util-linux package and is
 available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/login-utils/su.1
+++ b/login-utils/su.1
@@ -263,6 +263,6 @@ David MacKenzie.
 .SH AVAILABILITY
 The su command is part of the util-linux package and is
 available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/login-utils/sulogin.8
+++ b/login-utils/sulogin.8
@@ -90,6 +90,6 @@ was written by Miquel van Smoorenburg for sysvinit and later ported
 to util-linux by Dave Reisner and Karel Zak.
 .SH AVAILABILITY
 The sulogin command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/login-utils/utmpdump.1
+++ b/login-utils/utmpdump.1
@@ -88,6 +88,6 @@ Michael Krapp
 .SH AVAILABILITY
 The utmpdump command is part of the util-linux package and is available
 from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/login-utils/vipw.8
+++ b/login-utils/vipw.8
@@ -84,6 +84,6 @@ The
 command appeared in Util-Linux 2.6.
 .SH AVAILABILITY
 The vigr and vipw commands are part of the util-linux package and are available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/misc-utils/blkid.8
+++ b/misc-utils/blkid.8
@@ -317,4 +317,4 @@ and Karel Zak.
 .BR wipefs (8)
 .SH AVAILABILITY
 The blkid command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/cal.1
+++ b/misc-utils/cal.1
@@ -163,4 +163,4 @@ or the lunisolar Hindu, are not supported.
 A cal command appeared in Version 6 AT&T UNIX.
 .SH AVAILABILITY
 The cal command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/findfs.8
+++ b/misc-utils/findfs.8
@@ -79,6 +79,6 @@ enables libblkid debug output.
 .BR partx (8)
 .SH AVAILABILITY
 The findfs command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/misc-utils/findmnt.8
+++ b/misc-utils/findmnt.8
@@ -294,4 +294,4 @@ Karel Zak <kzak@redhat.com>
 .BR mount (8)
 .SH AVAILABILITY
 The findmnt command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/getopt.1
+++ b/misc-utils/getopt.1
@@ -455,6 +455,6 @@ Frodo Looijaard
 .BR getopt (3)
 .SH AVAILABILITY
 The getopt command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/misc-utils/kill.1
+++ b/misc-utils/kill.1
@@ -174,6 +174,6 @@ The original version was taken from BSD 4.4.
 
 .SH AVAILABILITY
 The kill command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/misc-utils/logger.1
+++ b/misc-utils/logger.1
@@ -350,6 +350,6 @@ The
 command is expected to be IEEE Std 1003.2 ("POSIX.2") compatible.
 .SH AVAILABILITY
 The logger command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/misc-utils/look.1
+++ b/misc-utils/look.1
@@ -115,4 +115,4 @@ The
 utility appeared in Version 7 AT&T Unix.
 .SH AVAILABILITY
 The look command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/lsblk.8
+++ b/misc-utils/lsblk.8
@@ -169,4 +169,4 @@ use visible padding characters. Requires enabled LIBSMARTCOLS_DEBUG.
 .BR findmnt (8)
 .SH AVAILABILITY
 The lsblk command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/lslocks.8
+++ b/misc-utils/lslocks.8
@@ -94,4 +94,4 @@ Davidlohr Bueso <dave@gnu.org>
 
 .SH AVAILABILITY
 The lslocks command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/mcookie.1
+++ b/misc-utils/mcookie.1
@@ -62,6 +62,6 @@ It is assumed that none of the randomness sources will block.
 .BR rand (3)
 .SH AVAILABILITY
 The mcookie command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/misc-utils/namei.1
+++ b/misc-utils/namei.1
@@ -77,4 +77,4 @@ To be discovered.
 .BR symlink (7)
 .SH AVAILABILITY
 The namei command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/rename.1
+++ b/misc-utils/rename.1
@@ -89,4 +89,4 @@ unanticipated error occurred
 .BR mv (1)
 .SH AVAILABILITY
 The rename command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/uuidd.8.in
+++ b/misc-utils/uuidd.8.in
@@ -89,6 +89,6 @@ daemon was written by Theodore Ts'o <tytso@mit.edu>.
 .BR uuidgen (1)
 .SH AVAILABILITY
 The uuidd daemon is part of the util-linux package and is available from the
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/misc-utils/uuidgen.1
+++ b/misc-utils/uuidgen.1
@@ -56,4 +56,4 @@ was written by Andreas Dilger for libuuid.
 .BR libuuid (3)
 .SH AVAILABILITY
 The uuidgen command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/misc-utils/whereis.1
+++ b/misc-utils/whereis.1
@@ -161,6 +161,6 @@ are displayed with
 enables debug output.
 .SH AVAILABILITY
 The whereis command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/misc-utils/wipefs.8
+++ b/misc-utils/wipefs.8
@@ -105,4 +105,4 @@ enables libblkid debug output.
 .BR findfs (8)
 .SH AVAILABILITY
 The wipefs command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/schedutils/chrt.1
+++ b/schedutils/chrt.1
@@ -170,4 +170,4 @@ Karel Zak
 .UE
 .SH AVAILABILITY
 The chrt command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/schedutils/ionice.1
+++ b/schedutils/ionice.1
@@ -139,4 +139,4 @@ Karel Zak <kzak@redhat.com>
 .BR ioprio_set (2)
 .SH AVAILABILITY
 The ionice command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/schedutils/taskset.1
+++ b/schedutils/taskset.1
@@ -133,4 +133,4 @@ This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 .SH AVAILABILITY
 The taskset command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/blkdiscard.8
+++ b/sys-utils/blkdiscard.8
@@ -80,6 +80,6 @@ Lukas Czerner
 .BR fstrim (8)
 .SH AVAILABILITY
 The blkdiscard command is part of the util-linux package and is available
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/chcpu.8
+++ b/sys-utils/chcpu.8
@@ -101,6 +101,6 @@ Copyright IBM Corp. 2011
 .BR lscpu (1)
 .SH AVAILABILITY
 The chcpu command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/chmem.8
+++ b/sys-utils/chmem.8
@@ -90,6 +90,6 @@ This command requests the memory block number 10 to be set offline.
 .BR lsmem (1)
 .SH AVAILABILITY
 The \fBchmem\fP command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/ctrlaltdel.8
+++ b/sys-utils/ctrlaltdel.8
@@ -53,6 +53,6 @@ Peter Orbaek
 .UE
 .SH AVAILABILITY
 The ctrlaltdel command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/dmesg.1
+++ b/sys-utils/dmesg.1
@@ -242,6 +242,6 @@ Theodore Ts'o
 .ME
 .SH AVAILABILITY
 The dmesg command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/eject.1
+++ b/sys-utils/eject.1
@@ -182,6 +182,6 @@ Michal Luscon
 .BR umount (8)
 .SH AVAILABILITY
 The eject command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/fallocate.1
+++ b/sys-utils/fallocate.1
@@ -124,6 +124,6 @@ Karel Zak
 .BR posix_fallocate (3)
 .SH AVAILABILITY
 The fallocate command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/flock.1
+++ b/sys-utils/flock.1
@@ -192,6 +192,6 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 .BR flock (2)
 .SH AVAILABILITY
 The flock command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/fsfreeze.8
+++ b/sys-utils/fsfreeze.8
@@ -72,4 +72,4 @@ This man page is based on
 .BR mount (8)
 .SH AVAILABILITY
 The fsfreeze command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/fstab.5
+++ b/sys-utils/fstab.5
@@ -244,4 +244,4 @@ file format appeared in 4.0BSD.
 .\" Instead there was a type rw/ro/rq/sw/xx, where xx is the present 'ignore'.
 .SH AVAILABILITY
 This man page is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/fstrim.8
+++ b/sys-utils/fstrim.8
@@ -118,4 +118,4 @@ Karel Zak <kzak@redhat.com>
 .BR mount (8)
 .SH AVAILABILITY
 The fstrim command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/hwclock.8.in
+++ b/sys-utils/hwclock.8.in
@@ -1046,4 +1046,4 @@ See the source code for complete history and credits.
 .
 .SH AVAILABILITY
 The hwclock command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/ipcmk.1
+++ b/sys-utils/ipcmk.1
@@ -49,6 +49,6 @@ Hayden A. James
 .ME
 .SH "AVAILABILITY"
 The ipcmk command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/ipcrm.1
+++ b/sys-utils/ipcrm.1
@@ -112,6 +112,6 @@ compatibility the previous syntax is still supported.
 .BR ftok (3)
 .SH AVAILABILITY
 The ipcrm command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/ipcs.1
+++ b/sys-utils/ipcs.1
@@ -111,6 +111,6 @@ Krishna Balasubramanian
 .UE
 .SH AVAILABILITY
 The ipcs command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/ldattach.8
+++ b/sys-utils/ldattach.8
@@ -152,4 +152,4 @@ Tilman Schmidt (tilman@imap.cc)
 .SH AVAILABILITY
 The ldattach command is part of the util-linux package
 and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/losetup.8
+++ b/sys-utils/losetup.8
@@ -201,4 +201,4 @@ Karel Zak <kzak@redhat.com>, based on the original version from
 Theodore Ts'o <tytso@athena.mit.edu>
 .SH AVAILABILITY
 The losetup command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/lscpu.1
+++ b/sys-utils/lscpu.1
@@ -174,4 +174,4 @@ Heiko Carstens <heiko.carstens@de.ibm.com>
 .BR chcpu (8)
 .SH AVAILABILITY
 The lscpu command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/lsipc.1
+++ b/sys-utils/lsipc.1
@@ -131,6 +131,6 @@ Karel Zak
 
 .SH AVAILABILITY
 The lsipc command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/lsmem.1
+++ b/sys-utils/lsmem.1
@@ -73,6 +73,6 @@ for util-linux was written by Clemens von Mann, Heiko Carstens and Karel Zak.
 .BR chmem (8)
 .SH AVAILABILITY
 The \fBlsmem\fP command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/lsns.8
+++ b/sys-utils/lsns.8
@@ -79,4 +79,4 @@ Karel Zak <kzak@redhat.com>
 
 .SH AVAILABILITY
 The lsns command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -3144,4 +3144,4 @@ Karel Zak <kzak@redhat.com>
 .fi
 .SH AVAILABILITY
 The mount command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/mountpoint.1
+++ b/sys-utils/mountpoint.1
@@ -55,4 +55,4 @@ for sysvinit suite was written by Miquel van Smoorenburg.
 .BR mount (8)
 .SH AVAILABILITY
 The mountpoint command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/nsenter.1
+++ b/sys-utils/nsenter.1
@@ -265,6 +265,6 @@ Karel Zak
 .UE
 .SH AVAILABILITY
 The nsenter command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/pivot_root.8
+++ b/sys-utils/pivot_root.8
@@ -72,4 +72,4 @@ exec chroot . sh -c 'umount /old_root; exec /sbin/init' \\
 .BR umount (8)
 .SH AVAILABILITY
 The pivot_root command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/prlimit.1
+++ b/sys-utils/prlimit.1
@@ -117,4 +117,4 @@ Davidlohr Bueso <dave@gnu.org> - In memory of Dennis M. Ritchie.
 .fi
 .SH AVAILABILITY
 The prlimit command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/readprofile.8
+++ b/sys-utils/readprofile.8
@@ -148,6 +148,6 @@ out for misleading information.
 .SH AVAILABILITY
 The readprofile command is part of the util-linux package and is
 available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/renice.1
+++ b/sys-utils/renice.1
@@ -114,6 +114,6 @@ The
 command appeared in 4.0BSD.
 .SH AVAILABILITY
 The renice command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/rtcwake.8.in
+++ b/sys-utils/rtcwake.8.in
@@ -176,6 +176,6 @@ There is NO WARRANTY, to the extent permitted by law.
 .BR date (1)
 .SH AVAILABILITY
 The rtcwake command is part of the util-linux package and is available from the
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/setarch.8
+++ b/sys-utils/setarch.8
@@ -88,6 +88,6 @@ Jindrich Novy
 .ME
 .SH AVAILABILITY
 The setarch command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/setpriv.1
+++ b/sys-utils/setpriv.1
@@ -161,6 +161,6 @@ Andy Lutomirski
 The
 .B setpriv
 command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/setsid.1
+++ b/sys-utils/setsid.1
@@ -32,4 +32,4 @@ Display help text and exit.
 Rick Sladkey <jrs@world.std.com>
 .SH AVAILABILITY
 The setsid command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/swapon.8
+++ b/sys-utils/swapon.8
@@ -250,4 +250,4 @@ The
 command appeared in 4.0BSD.
 .SH AVAILABILITY
 The swapon command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/switch_root.8
+++ b/sys-utils/switch_root.8
@@ -58,4 +58,4 @@ Karel Zak <kzak@redhat.com>
 .fi
 .SH AVAILABILITY
 The switch_root command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/tunelp.8
+++ b/sys-utils/tunelp.8
@@ -141,6 +141,6 @@ have unexpected effects.
 .I /proc/parport/*/*
 .SH AVAILABILITY
 The tunelp  command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/umount.8
+++ b/sys-utils/umount.8
@@ -228,6 +228,6 @@ A
 command appeared in Version 6 AT&T UNIX.
 .SH AVAILABILITY
 The umount command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/unshare.1
+++ b/sys-utils/unshare.1
@@ -238,4 +238,4 @@ Karel Zak
 .UE
 .SH AVAILABILITY
 The unshare command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/sys-utils/wdctl.8
+++ b/sys-utils/wdctl.8
@@ -65,6 +65,6 @@ Lennart Poettering
 The
 .B wdctl
 command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/sys-utils/zramctl.8
+++ b/sys-utils/zramctl.8
@@ -120,4 +120,4 @@ Karel Zak <kzak@redhat.com>
 .fi
 .SH AVAILABILITY
 The zramctl command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/term-utils/agetty.8
+++ b/term-utils/agetty.8
@@ -457,4 +457,4 @@ and ported to Linux by Peter Orbaek <poe@daimi.aau.dk>.
 
 .SH AVAILABILITY
 The agetty command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util\-linux/.
+https://www.kernel.org/pub/linux/utils/util\-linux/.

--- a/term-utils/mesg.1
+++ b/term-utils/mesg.1
@@ -106,4 +106,4 @@ command appeared in Version 6 AT&T UNIX.
 
 .SH AVAILABILITY
 The mesg command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/term-utils/reset.1
+++ b/term-utils/reset.1
@@ -42,4 +42,4 @@ argument in an attempt to get cooked mode back.
 Rik Faith (faith@cs.unc.edu)
 .SH AVAILABILITY
 The reset command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/term-utils/script.1
+++ b/term-utils/script.1
@@ -187,6 +187,6 @@ can hang, because the interactive shell within the script session misses EOF and
 has no clue when to close the session.  See the \fBNOTES\fR section for more information.
 .SH AVAILABILITY
 The script command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/term-utils/scriptreplay.1
+++ b/term-utils/scriptreplay.1
@@ -106,6 +106,6 @@ Karel Zak
 .ME .
 .SH AVAILABILITY
 The scriptreplay command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/term-utils/setterm.1
+++ b/term-utils/setterm.1
@@ -275,6 +275,6 @@ reasons to discontinue single-hyphen compatibility.
 Differences between the Minix and Linux versions are not documented.
 .SH AVAILABILITY
 The setterm command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/term-utils/wall.1
+++ b/term-utils/wall.1
@@ -98,6 +98,6 @@ A
 command appeared in Version 7 AT&T UNIX.
 .SH AVAILABILITY
 The wall command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/term-utils/write.1
+++ b/term-utils/write.1
@@ -98,4 +98,4 @@ A
 command appeared in Version 6 AT&T UNIX.
 .SH AVAILABILITY
 The write command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/text-utils/col.1
+++ b/text-utils/col.1
@@ -153,6 +153,6 @@ A
 command appeared in Version 6 AT&T UNIX.
 .SH AVAILABILITY
 The col command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/text-utils/colcrt.1
+++ b/text-utils/colcrt.1
@@ -100,6 +100,6 @@ The
 command appeared in 3.0BSD.
 .SH AVAILABILITY
 The colcrt command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/text-utils/colrm.1
+++ b/text-utils/colrm.1
@@ -70,6 +70,6 @@ The
 command appeared in 3.0BSD.
 .SH AVAILABILITY
 The colrm command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/text-utils/column.1
+++ b/text-utils/column.1
@@ -98,4 +98,4 @@ a  b  c
 The column command appeared in 4.3BSD-Reno.
 .SH AVAILABILITY
 The column command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/text-utils/hexdump.1
+++ b/text-utils/hexdump.1
@@ -374,6 +374,6 @@ The
 utility is expected to be IEEE Std 1003.2 ("POSIX.2") compatible.
 .SH AVAILABILITY
 The hexdump command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/text-utils/line.1
+++ b/text-utils/line.1
@@ -14,4 +14,4 @@ on EOF or read error.
 .BR read (1)
 .SH AVAILABILITY
 The line command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/text-utils/more.1
+++ b/text-utils/more.1
@@ -235,6 +235,6 @@ community.  Documentation was produced using several other versions of the
 man page, and extensive inspection of the source code.
 .SH AVAILABILITY
 The more command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/text-utils/pg.1
+++ b/text-utils/pg.1
@@ -235,4 +235,4 @@ characters cannot be displayed by
 .BR pg .
 .SH AVAILABILITY
 The pg command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/text-utils/rev.1
+++ b/text-utils/rev.1
@@ -54,6 +54,6 @@ Display help text and exit.
 .BR tac (1)
 .SH AVAILABILITY
 The rev command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/text-utils/tailf.1
+++ b/text-utils/tailf.1
@@ -70,4 +70,4 @@ The latest inotify-based implementation was written by Karel Zak (kzak@redhat.co
 .BR tail (1)
 .SH AVAILABILITY
 The tailf command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/text-utils/ul.1
+++ b/text-utils/ul.1
@@ -108,6 +108,6 @@ The
 command appeared in 3.0BSD.
 .SH AVAILABILITY
 The ul command is part of the util-linux package and is available from
-.UR ftp://\:ftp.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
+.UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/util-linux.doap
+++ b/util-linux.doap
@@ -16,7 +16,7 @@
     </description>
     <bug-database rdf:resource="https://github.com/karelzak/util-linux/issues" />
     <mailing-list rdf:resource="http://vger.kernel.org/vger-lists.html#util-linux" />
-    <download-page rdf:resource="http://ftp.kernel.org/pub/linux/utils/util-linux/" />
+    <download-page rdf:resource="https://www.kernel.org/pub/linux/utils/util-linux/" />
     <programming-language>C</programming-language>
     <repository>
       <GitRepository>


### PR DESCRIPTION
The FTP server on kernel.org seems down for me. I don't know if it's something broken, or if it's down for good.
I think using HTTPS instead of the old and unsecure FTP protocol is a better choice anyway.

This PR replaces all links to `ftp://ftp.kernel.org/` by `https://www.kernel.org/`.

If ever FTP is the preferred choice anyway to access the packages and ChangeLogs, please just ignore this PR.

Thanks.