### PR TITLE
disk-utils/mkfs.minix: Set ninodes after checking max

### DIFF
--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -534,9 +534,9 @@ static void setup_tables(const struct fs_control *ctl) {
 	if (fs_version == 3)
 		Super3.s_ninodes = inodes;
 	else {
-		Super.s_ninodes = inodes;
 		if (inodes > MINIX_MAX_INODES)
 			inodes = MINIX_MAX_INODES;
+		Super.s_ninodes = inodes;
 	}
 	super_set_map_blocks(ctl, inodes);
 	if (MINIX_MAX_INODES < first_zone_data())

--- a/tests/expected/minix/mkfs-v2i65535
+++ b/tests/expected/minix/mkfs-v2i65535
@@ -1,0 +1,9 @@
+create minix fs -2 -i 65535
+65535 inodes
+10224 blocks
+Firstdatazone=4107 (4107)
+Zonesize=1024
+Maxsize=2147483647
+
+mkfs return value: 0
+umount the image

--- a/tests/ts/minix/mkfs
+++ b/tests/ts/minix/mkfs
@@ -49,6 +49,7 @@ mkfs_and_mount_minix 'v1c14' '-1 -n 14'
 mkfs_and_mount_minix 'v1c30' '-1 -n 30'
 mkfs_and_mount_minix 'v2c14' '-2 -n 14'
 mkfs_and_mount_minix 'v2c30' '-2 -n 30'
+mkfs_and_mount_minix 'v2i65535' '-2 -i 65535'
 mkfs_and_mount_minix 'v3c60' '-3 -n 60'
 
 ts_finalize


### PR DESCRIPTION
ninodes in the superblock needs to be set after inodes is checked
against MINIX_MAX_INODES otherwise a value larger than MINIX_MAX_INODES
can be attempted to be stored in the superblock.

Without this change the command "mkfs.minix -2 -i 65530 <dev>" would
write a minix superblock with ninodes set to 0.

Signed-off-by: Nate Clark <nate@neworld.us>