### PR TITLE
libblkid/minix: Swap partitions can be mistaken as minix

### DIFF
--- a/libblkid/src/superblocks/minix.c
+++ b/libblkid/src/superblocks/minix.c
@@ -89,7 +89,8 @@ static int probe_minix(blkid_probe pr,
 
 	if (version <= 2) {
 		struct minix_super_block *sb = (struct minix_super_block *) data;
-		int zones, ninodes, imaps, zmaps, firstz;
+		unsigned long zones, ninodes, imaps, zmaps;
+		off_t firstz;
 
 		if (sb->s_imap_blocks == 0 || sb->s_zmap_blocks == 0 ||
 		    sb->s_log_zone_size != 0)

--- a/libblkid/src/superblocks/minix.c
+++ b/libblkid/src/superblocks/minix.c
@@ -87,14 +87,12 @@ static int probe_minix(blkid_probe pr,
 	if (version < 1)
 		return 1;
 
+	unsigned long zones, ninodes, imaps, zmaps;
+	off_t firstz;
+	size_t zone_size;
+
 	if (version <= 2) {
 		struct minix_super_block *sb = (struct minix_super_block *) data;
-		unsigned long zones, ninodes, imaps, zmaps;
-		off_t firstz;
-
-		if (sb->s_imap_blocks == 0 || sb->s_zmap_blocks == 0 ||
-		    sb->s_log_zone_size != 0)
-			return 1;
 
 		zones = version == 2 ? minix_swab32(swabme, sb->s_zones) :
 				       minix_swab16(swabme, sb->s_nzones);
@@ -102,18 +100,29 @@ static int probe_minix(blkid_probe pr,
 		imaps   = minix_swab16(swabme, sb->s_imap_blocks);
 		zmaps   = minix_swab16(swabme, sb->s_zmap_blocks);
 		firstz  = minix_swab16(swabme, sb->s_firstdatazone);
-
-		/* sanity checks to be sure that the FS is really minix */
-		if (imaps * MINIX_BLOCK_SIZE * 8 < ninodes + 1)
-			return 1;
-		if (zmaps * MINIX_BLOCK_SIZE * 8 < zones - firstz + 1)
-			return 1;
+		zone_size = sb->s_log_zone_size;
 	} else if (version == 3) {
 		struct minix3_super_block *sb = (struct minix3_super_block *) data;
 
-		if (sb->s_imap_blocks == 0 || sb->s_zmap_blocks == 0)
-			return 1;
+		zones = minix_swab32(swabme, sb->s_zones);
+		ninodes = minix_swab32(swabme, sb->s_ninodes);
+		imaps   = minix_swab16(swabme, sb->s_imap_blocks);
+		zmaps   = minix_swab16(swabme, sb->s_zmap_blocks);
+		firstz  = minix_swab16(swabme, sb->s_firstdatazone);
+		zone_size = sb->s_log_zone_size;
 	}
+
+	/* sanity checks to be sure that the FS is really minix.
+	 * see disk-utils/fsck.minix.c read_superblock
+	 */
+	if (zone_size != 0 || ninodes == 0 || ninodes == UINT32_MAX)
+		return 1;
+	if (imaps * MINIX_BLOCK_SIZE * 8 < ninodes + 1)
+		return 1;
+	if (firstz > (off_t) zones)
+		return 1;
+	if (zmaps * MINIX_BLOCK_SIZE * 8 < zones - firstz + 1)
+		return 1;
 
 	/* unfortunately, some parts of ext3 is sometimes possible to
 	 * interpreted as minix superblock. So check for extN magic

--- a/libblkid/src/superblocks/minix.c
+++ b/libblkid/src/superblocks/minix.c
@@ -94,6 +94,10 @@ static int probe_minix(blkid_probe pr,
 	if (version <= 2) {
 		struct minix_super_block *sb = (struct minix_super_block *) data;
 
+		uint16_t state = minix_swab16(swabme, sb->s_state);
+		if ((state & (MINIX_VALID_FS | MINIX_ERROR_FS)) != state)
+			return 1;
+
 		zones = version == 2 ? minix_swab32(swabme, sb->s_zones) :
 				       minix_swab16(swabme, sb->s_nzones);
 		ninodes = minix_swab16(swabme, sb->s_ninodes);


### PR DESCRIPTION
Swap partitions with a uuid which contains a minix magic number can be mistaken by blockid as minix partitions. This causes blockid to error out with a message like "/dev/sdb3: ambivalent result (probably more filesystems on the device, use wipefs(8) to see more details)"

These patches try to make it less likely for a swap partition or other partition to be mistaken as a minix partition.
A v1 or v2 offending uuid will look like 35f1f264-<minix magic>-471a-bc85-acc9f4bc04a3 where minix magic is one of 137f, 7f13, 138f, 8f13, 2468, 6824, 2478 or 7824.