### PR TITLE
term-utils/scriptreplay: add missing -lm to LDFLAGS

### DIFF
--- a/term-utils/Makemodule.am
+++ b/term-utils/Makemodule.am
@@ -21,7 +21,7 @@ if BUILD_SCRIPTREPLAY
 usrbin_exec_PROGRAMS += scriptreplay
 dist_man_MANS += term-utils/scriptreplay.1
 scriptreplay_SOURCES = term-utils/scriptreplay.c
-scriptreplay_LDADD = $(LDADD) libcommon.la
+scriptreplay_LDADD = $(LDADD) libcommon.la -lm
 endif # BUILD_SCRIPTREPLAY
 
 


### PR DESCRIPTION
This fixes a linker error when building for targets using uclibc or using -fno-builtin with glibc.