### PR TITLE
term-utils/script: fix typo leading to syntax error

### DIFF
--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -112,7 +112,7 @@ struct script_control {
 	struct termios attrs;	/* slave terminal runtime attributes */
 	struct winsize win;	/* terminal window size */
 #if !HAVE_LIBUTIL || !HAVE_PTY_H
-	char line *;		/* terminal line */
+	char *line;		/* terminal line */
 #endif
 	unsigned int
 	 append:1,		/* append output */


### PR DESCRIPTION
I suspect this syntax error isn't triggered much, looking at the date of its introduction. Actually found this through a build system misconfiguration :)