### PR TITLE
agetty: fix a memory leak when parsing \S in issue files

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -2448,6 +2448,9 @@ static void output_special_char(unsigned char c, struct options *op,
 			uname(&uts);
 			fputs(uts.sysname, stdout);
 		}
+
+		free(var);
+
 		break;
 	}
 	case 'u':


### PR DESCRIPTION
I found a small memory leak in agetty, when parsing an issue file which contains the \S{...} escape sequence. The string returned from read_os_release() is strdup()'ed but never freed by the caller.

On a system that uses an issue file containing this escape sequence one could in theory press/send an infinite number of newlines at the login prompt to continuously leak memory, because agetty reprints the issue file and prompts again for each empty input line and leaks said memory for each iteration.