### PR TITLE
script: fix start message showing in output file when -q is on

### DIFF
--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -435,7 +435,8 @@ static void do_io(struct script_control *ctl)
 
 
 	strftime(buf, sizeof buf, "%c\n", localtime(&tvec));
-	fprintf(ctl->typescriptfp, _("Script started on %s"), buf);
+	if (!ctl->quiet && ctl->typescriptfp)
+		fprintf(ctl->typescriptfp, _("Script started on %s"), buf);
 	gettime_monotonic(&ctl->oldtime);
 
 	while (!ctl->die) {


### PR DESCRIPTION
The `-q` switch of `script` command doesn't supress the prompt message for beginning in the file. This is the fix to that.

By the way, there is a problem of the translation control (not the translation PO file) of this tool. Should I combine the two fixes together or make two seperate pull requests?