### PR TITLE
Fixed libuuid man page docs

### DIFF
--- a/libuuid/man/uuid.3
+++ b/libuuid/man/uuid.3
@@ -33,7 +33,7 @@
 .SH NAME
 uuid \- DCE compatible Universally Unique Identifier library
 .SH SYNOPSIS
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .SH DESCRIPTION
 The UUID library is used to generate unique identifiers for objects
 that may be accessible beyond the local system.  This library

--- a/libuuid/man/uuid_clear.3
+++ b/libuuid/man/uuid_clear.3
@@ -34,7 +34,7 @@
 uuid_clear \- reset value of UUID variable to the NULL value
 .SH SYNOPSIS
 .nf
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .sp
 .BI "void uuid_clear(uuid_t " uu );
 .fi

--- a/libuuid/man/uuid_compare.3
+++ b/libuuid/man/uuid_compare.3
@@ -34,7 +34,7 @@
 uuid_compare \- compare whether two UUIDs are the same
 .SH SYNOPSIS
 .nf
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .sp
 .BI "int uuid_compare(uuid_t " uu1 ", uuid_t " uu2)
 .fi

--- a/libuuid/man/uuid_copy.3
+++ b/libuuid/man/uuid_copy.3
@@ -34,7 +34,7 @@
 uuid_copy \- copy a UUID value
 .SH SYNOPSIS
 .nf
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .sp
 .BI "void uuid_copy(uuid_t " dst ", uuid_t " src);
 .fi

--- a/libuuid/man/uuid_generate.3
+++ b/libuuid/man/uuid_generate.3
@@ -35,7 +35,7 @@ uuid_generate, uuid_generate_random, uuid_generate_time,
 uuid_generate_time_safe \- create a new unique UUID value
 .SH SYNOPSIS
 .nf
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .sp
 .BI "void uuid_generate(uuid_t " out );
 .BI "void uuid_generate_random(uuid_t " out );

--- a/libuuid/man/uuid_is_null.3
+++ b/libuuid/man/uuid_is_null.3
@@ -34,7 +34,7 @@
 uuid_is_null \- compare the value of the UUID to the NULL value
 .SH SYNOPSIS
 .nf
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .sp
 .BI "int uuid_is_null(uuid_t " uu );
 .fi

--- a/libuuid/man/uuid_parse.3
+++ b/libuuid/man/uuid_parse.3
@@ -34,7 +34,7 @@
 uuid_parse \- convert an input UUID string into binary representation
 .SH SYNOPSIS
 .nf
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .sp
 .BI "int uuid_parse( char *" in ", uuid_t " uu );
 .fi

--- a/libuuid/man/uuid_time.3
+++ b/libuuid/man/uuid_time.3
@@ -34,7 +34,7 @@
 uuid_time \- extract the time at which the UUID was created
 .SH SYNOPSIS
 .nf
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .sp
 .BI "time_t uuid_time(uuid_t " uu ", struct timeval *" ret_tv )
 .fi

--- a/libuuid/man/uuid_unparse.3
+++ b/libuuid/man/uuid_unparse.3
@@ -34,7 +34,7 @@
 uuid_unparse \- convert an UUID from binary representation to a string
 .SH SYNOPSIS
 .nf
-.B #include <uuid.h>
+.B #include <uuid/uuid.h>
 .sp
 .BI "void uuid_unparse(uuid_t " uu ", char *" out );
 .BI "void uuid_unparse_upper(uuid_t " uu ", char *" out );


### PR DESCRIPTION
Hi,

```
root@raminfp /u/include# pwd
/usr/include
root@raminfp /u/include# find . -name uuid.h
./uuid/uuid.h
./linux/uuid.h
```

example code :

```c
#include <stdio.h>
#include <uuid/uuid.h>

int main(void) {
    uuid_t uuid;
    printf("sizeof uuid = %d\n", (int)sizeof uuid);
    for (size_t i = 0; i < sizeof uuid; i ++) {
        printf("%02x ", uuid[i]);
    }
    putchar('\n');
    return 0;
}

```