### PR TITLE
sfdisk: disambiguate units of --show-size

### DIFF
--- a/disk-utils/sfdisk.8
+++ b/disk-utils/sfdisk.8
@@ -132,7 +132,9 @@ then print the current partition UUID.
 Renumber the partitions, ordering them by their start offset.
 .TP
 .BR \-s , " \-\-show\-size " [ \fIdevice ...]
-List the sizes of all or the specified devices.
+List the sizes of all or the specified devices in units of 1024 byte size.
+This command is DEPRECATED in favour of
+.BR blockdev (1).
 .TP
 .BR \-T , " \-\-list\-types"
 Print all supported types for the current disk label or the label specified by
@@ -219,7 +221,8 @@ specified in the format \fI+list\fP (e.g. \fB-o +UUID\fP).
 Suppress extra info messages.
 .TP
 .BR \-u , " \-\-unit S"
-Deprecated option.  Only the sector unit is supported.
+Deprecated option.  Only the sector unit is supported. This option is not
+supported when using the --show-size command.
 .TP
 .BR \-X , " \-\-label " \fItype
 Specify the disk label type (e.g. \fBdos\fR, \fBgpt\fR, ...).  If this option

--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -96,6 +96,7 @@ struct sfdisk {
 	const char	*label_nested;	/* --label-nested <label> */
 	const char	*backup_file;	/* -O <path> */
 	const char	*move_typescript; /* --movedata <typescript> */
+	const char	*unit;		/* accept or report unit (deprecated) */
 	char		*prompt;
 
 	struct fdisk_context	*cxt;		/* libfdisk context */
@@ -1975,7 +1976,7 @@ int main(int argc, char *argv[])
 		{ "part-attrs", no_argument,    NULL, OPT_PARTATTRS },
 
 		{ "show-pt-geometry", no_argument, NULL, 'G' },		/* deprecated */
-		{ "unit",    required_argument, NULL, 'u' },
+		{ "unit",    required_argument, NULL, 'u' },		/* deprecated */
 		{ "Linux",   no_argument,       NULL, 'L' },		/* deprecated */
 
 		{ "change-id",no_argument,      NULL, OPT_CHANGE_ID },	/* deprecated */
@@ -2068,6 +2069,7 @@ int main(int argc, char *argv[])
 		case 'u':
 			if (*optarg != 'S')
 				errx(EXIT_FAILURE, _("unsupported unit '%c'"), *optarg);
+			sf->unit = optarg;
 			break;
 		case 'v':
 			printf(_("%s from %s\n"), program_invocation_short_name,
@@ -2148,6 +2150,9 @@ int main(int argc, char *argv[])
 
 	if (sf->movedata && !(sf->act == ACT_FDISK && sf->partno >= 0))
 		errx(EXIT_FAILURE, _("--movedata requires -N"));
+
+	if (sf->act == ACT_SHOW_SIZE && sf->unit != NULL)
+		errx(EXIT_FAILURE, _("use of both --unit and --show-size unsupported"));
 
 	switch (sf->act) {
 	case ACT_ACTIVATE:


### PR DESCRIPTION
This commit addresses 2 issues with the `sfdisk --show-sizes` command.
The first issue is the result units isn't documented anywhere. I made a change to the man page to address this. The unit is of size 1024 bytes. Should we just refer to these as kilobytes?

The second issue is that the output isn't shown in sectors when used with `-uS`. This is confusing since a user running `sfdisk --show-sizes -uS` would reasonably expect to get the result as sectors. There's no indication that the result isn't sectors either. Instead of changing the behavior of the `--show-sizes` command when combined with `-uS`, I have sfdisk error out with a clear message when both are used.