### PR TITLE
su: Remove SIGKILL of subprocess 2 seconds after SIGTERM is received #443

### DIFF
--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -389,13 +389,6 @@ create_watching_parent (void)
 
   if (caught_signal)
     {
-      if (child != (pid_t)-1)
-	{
-	  sleep (2);
-	  kill (child, SIGKILL);
-	  fprintf (stderr, _(" ...killed.\n"));
-	}
-
       /* Let's terminate itself with the received signal.
        *
        * It seems that shells use WIFSIGNALED() rather than our exit status


### PR DESCRIPTION
Such behavior should be out of scope of su and may do more harm than good.