### PR TITLE
lib/colors: Fix bug where help text was not being translated.

### DIFF
--- a/include/colors.h
+++ b/include/colors.h
@@ -24,9 +24,9 @@ enum colortmode {
 };
 
 #ifdef USE_COLORS_BY_DEFAULT
-# define USAGE_COLORS_DEFAULT	N_("colors are enabled by default")
+# define USAGE_COLORS_DEFAULT	_("colors are enabled by default")
 #else
-# define USAGE_COLORS_DEFAULT   N_("colors are disabled by default")
+# define USAGE_COLORS_DEFAULT   _("colors are disabled by default")
 #endif
 
 extern int colormode_from_string(const char *str);


### PR DESCRIPTION
This affected cfdisk, fdisk, sfdisk, cal, dmesg and hexdump.