### PR TITLE
pylibmount: NULL terminate kwlist in Context_init

### DIFF
--- a/libmount/python/context.c
+++ b/libmount/python/context.c
@@ -90,7 +90,7 @@ static int Context_init(ContextObjext *self, PyObject *args, PyObject *kwds)
 		"source", "target", "fstype",
 		"options", "mflags", "fstype_pattern",
 		"options_pattern", "fs", "fstab",
-		"optsmode"
+		"optsmode", NULL
 	};
 
 	if (!PyArg_ParseTupleAndKeywords(


### PR DESCRIPTION
Fixes a segfault observed with python3.6.
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  vgetargskeywords (args=0x7f61ed7ca048, keywords=0x7f61ec3bb630, format=<optimized out>, format@entry=0x7f61ebe13057 "|sssskssO!O!i", kwlist=kwlist@entry=0x7fffdb972770, p_va=p_va@entry=0x7fffdb9725e0, flags=flags@entry=0) at Python/getargs.c:1631
1631	        if (!*kwlist[len]) {

Backtrace
=========
#0  vgetargskeywords (args=0x7f61ed7ca048, keywords=0x7f61ec3bb630, format=<optimized out>, format@entry=0x7f61ebe13057 "|sssskssO!O!i", kwlist=kwlist@entry=0x7fffdb972770, p_va=p_va@entry=0x7fffdb9725e0, flags=flags@entry=0) at Python/getargs.c:1631
#1  0x00007f61ed25010b in PyArg_ParseTupleAndKeywords (args=<optimized out>, keywords=<optimized out>, format=format@entry=0x7f61ebe13057 "|sssskssO!O!i", kwlist=kwlist@entry=0x7fffdb972770) at Python/getargs.c:1362
#2  0x00007f61ebe0ebe2 in Context_init (self=0x7f61ec3f6890, args=<optimized out>, kwds=<optimized out>) at /usr/src/debug/sys-apps/util-linux-2.30_rc2/util-linux-2.30-rc2/libmount/python/context.c:96
#3  0x00007f61ed1d55c2 in type_call (type=<optimized out>, type@entry=0x7f61ec019420 <ContextType>, args=args@entry=0x7f61ed7ca048, kwds=kwds@entry=0x7f61ec3bb630) at Objects/typeobject.c:915
#4  0x00007f61ed176ce9 in _PyObject_FastCallDict (func=func@entry=0x7f61ec019420 <ContextType>, args=args@entry=0x7f61ec34b3c0, nargs=nargs@entry=0, kwargs=kwargs@entry=0x7f61ec3bb630) at Objects/abstract.c:2316
#5  0x00007f61ed177290 in _PyObject_FastCallKeywords (func=func@entry=0x7f61ec019420 <ContextType>, stack=0x7f61ec34b3c0, nargs=nargs@entry=0, kwnames=kwnames@entry=0x7f61ec023ef0) at Objects/abstract.c:2480
#6  0x00007f61ed234ed3 in call_function (pp_stack=pp_stack@entry=0x7fffdb9729a8, oparg=<optimized out>, kwnames=kwnames@entry=0x7f61ec023ef0) at Python/ceval.c:4822
#7  0x00007f61ed239f30 in _PyEval_EvalFrameDefault (f=0x7f61ec34b240, throwflag=<optimized out>) at Python/ceval.c:3300
#8  0x00007f61ed234bdc in _PyEval_EvalCodeWithName (_co=_co@entry=0x7f61ec024c90, globals=globals@entry=0x7f61ec3fc318, locals=locals@entry=0x7f61ec3fc318, args=args@entry=0x0, argcount=argcount@entry=0, kwnames=kwnames@entry=0x0, kwargs=0x8, kwcount=0, kwstep=2, defs=0x0, defcount=0, kwdefs=0x0, closure=0x0, name=0x0, qualname=0x0) at Python/ceval.c:4128
#9  0x00007f61ed23515f in PyEval_EvalCodeEx (_co=_co@entry=0x7f61ec024c90, globals=globals@entry=0x7f61ec3fc318, locals=locals@entry=0x7f61ec3fc318, args=args@entry=0x0, argcount=argcount@entry=0, kws=kws@entry=0x0, kwcount=0, defs=0x0, defcount=0, kwdefs=0x0, closure=0x0) at Python/ceval.c:4149
#10 0x00007f61ed23518b in PyEval_EvalCode (co=co@entry=0x7f61ec024c90, globals=globals@entry=0x7f61ec3fc318, locals=locals@entry=0x7f61ec3fc318) at Python/ceval.c:695
#11 0x00007f61ed25f024 in run_mod (mod=mod@entry=0x11ef080, filename=filename@entry=0x7f61ec045570, globals=globals@entry=0x7f61ec3fc318, locals=locals@entry=0x7f61ec3fc318, flags=flags@entry=0x7fffdb972cd0, arena=arena@entry=0x7f61ec415258) at Python/pythonrun.c:980
#12 0x00007f61ed261545 in PyRun_FileExFlags (fp=fp@entry=0x11d1ab0, filename_str=filename_str@entry=0x7f61ec3e3ce0 "./segfault.py", start=start@entry=257, globals=globals@entry=0x7f61ec3fc318, locals=locals@entry=0x7f61ec3fc318, closeit=closeit@entry=1, flags=0x7fffdb972cd0) at Python/pythonrun.c:933
#13 0x00007f61ed2616b5 in PyRun_SimpleFileExFlags (fp=fp@entry=0x11d1ab0, filename=<optimized out>, closeit=closeit@entry=1, flags=flags@entry=0x7fffdb972cd0) at Python/pythonrun.c:396
#14 0x00007f61ed261af3 in PyRun_AnyFileExFlags (fp=fp@entry=0x11d1ab0, filename=<optimized out>, closeit=closeit@entry=1, flags=flags@entry=0x7fffdb972cd0) at Python/pythonrun.c:80
#15 0x00007f61ed278463 in run_file (p_cf=0x7fffdb972cd0, filename=0x1134290 L"./segfault.py", fp=0x11d1ab0) at Modules/main.c:338
#16 Py_Main (argc=argc@entry=2, argv=argv@entry=0x1133010) at Modules/main.c:809
#17 0x0000000000400ac9 in main (argc=2, argv=<optimized out>) at Programs/python.c:69
```
@kerolasa @ooprala