### PR TITLE
fix even more random compiler warnings

### DIFF
--- a/include/pt-sun.h
+++ b/include/pt-sun.h
@@ -76,7 +76,7 @@ struct sun_disklabel {
 #define SUN_FLAG_UNMNT		0x01	/* Unmountable partition*/
 #define SUN_FLAG_RONLY		0x10	/* Read only		*/
 
-static inline uint16_t sun_pt_checksum(struct sun_disklabel *label)
+static inline uint16_t sun_pt_checksum(const struct sun_disklabel *label)
 {
 	uint16_t *ptr = ((uint16_t *) (label + 1)) - 1;
 	uint16_t sum;

--- a/libsmartcols/src/table_print.c
+++ b/libsmartcols/src/table_print.c
@@ -1656,9 +1656,9 @@ int scols_print_table(struct libscols_table *tb)
  *
  * Returns: 0, a negative value in case of an error.
  */
+#ifdef HAVE_OPEN_MEMSTREAM
 int scols_print_table_to_string(struct libscols_table *tb, char **data)
 {
-#ifdef HAVE_OPEN_MEMSTREAM
 	FILE *stream, *old_stream;
 	size_t sz;
 	int rc;
@@ -1680,8 +1680,13 @@ int scols_print_table_to_string(struct libscols_table *tb, char **data)
 	scols_table_set_stream(tb, old_stream);
 
 	return rc;
-#else
-	return -ENOSYS;
-#endif
 }
+#else
+int scols_print_table_to_string(
+		struct libscols_table *tb __attribute__((__unused__)),
+		char **data  __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+#endif
 

--- a/sys-utils/losetup.8
+++ b/sys-utils/losetup.8
@@ -179,7 +179,7 @@ loop control device
 The following commands can be used as an example of using the loop device.
 .nf
 .IP
-# dd if=/dev/zero of=~/file.img bs=1MiB count=10
+# dd if=/dev/zero of=~/file.img bs=1024k count=10
 # losetup --find --show ~/file.img
 /dev/loop0
 # mkfs -t ext2 /dev/loop0

--- a/tests/expected/misc/line
+++ b/tests/expected/misc/line
@@ -1,7 +1,25 @@
+# usually behave like "head -n 1"
 a
 ret: 0
+# never consume more than one line
 1
 2
 ret: 0
+# add a newline
+abc
+ret: 1
+# print one newline on empty input
 
 ret: 1
+# add a newline, return 1 when EOF
+xyz
+ret: 1
+# print one newline on empty input, return 1 when EOF
+
+ret: 1
+# large line of zero bytes
+00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
+*
+00100000  0a                                                |.|
+00100001
+ret: 0

--- a/tests/ts/fincore/count
+++ b/tests/ts/fincore/count
@@ -46,7 +46,7 @@ function check_dd_fs_feat
 	touch "$testf"
 
 	# NFS seems to fail for direct AND append
-	_dd if=/dev/zero of="$testf" bs=1K count=2 oflag=direct,append &>/dev/null \
+	_dd if=/dev/zero of="$testf" bs=1k count=2 oflag=direct,append &>/dev/null \
 		|| ts_skip "unsupported: dd oflag=direct,append"
 
 	# TODO: Should we check for sparse file support?

--- a/tests/ts/libmount/loop-overlay
+++ b/tests/ts/libmount/loop-overlay
@@ -36,7 +36,7 @@ IMG=$(ts_image_init 5)
 mkfs.ext2 -F "$IMG" &> /dev/null || ts_die "Cannot make extn on $IMG"
 OFFSET=$(stat -c %s "$IMG")
 
-dd if="$IMG" of="$IMG" oflag=append bs=5MiB count=1 conv=notrunc &>/dev/null
+dd if="$IMG" of="$IMG" oflag=append bs=1024k count=5 conv=notrunc &>/dev/null
 
 [ -d "$TS_MOUNTPOINT-1" ] || mkdir -p $TS_MOUNTPOINT-1
 [ -d "$TS_MOUNTPOINT-2" ] || mkdir -p $TS_MOUNTPOINT-2

--- a/tests/ts/misc/line
+++ b/tests/ts/misc/line
@@ -19,19 +19,40 @@ TS_DESC="line"
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LINE"
+ts_check_test_command "$TS_CMD_HEXDUMP"
 
-# usually behave like "head -n 1"
+ts_log '# usually behave like "head -n 1"'
 printf "a\nb\n" |
-	$TS_CMD_LINE > $TS_OUTPUT 2>&1
+	$TS_CMD_LINE >> $TS_OUTPUT 2>&1
 echo "ret: $?" >> $TS_OUTPUT
 
-# never consume more than one line
+ts_log '# never consume more than one line'
 printf "1\n2\n" |
 	($TS_CMD_LINE && $TS_CMD_LINE) >> $TS_OUTPUT 2>&1
 echo "ret: $?" >> $TS_OUTPUT
 
-# always print one newline, return 1 on EOF
+ts_log '# add a newline'
+printf "abc" |
+	$TS_CMD_LINE >> $TS_OUTPUT 2>&1
+echo "ret: $?" >> $TS_OUTPUT
+
+ts_log '# print one newline on empty input'
+printf "" |
+	$TS_CMD_LINE >> $TS_OUTPUT 2>&1
+echo "ret: $?" >> $TS_OUTPUT
+
+ts_log '# add a newline, return 1 when EOF'
+(printf "xyz" && cat </dev/null) |
+	$TS_CMD_LINE >> $TS_OUTPUT 2>&1
+echo "ret: $?" >> $TS_OUTPUT
+
+ts_log '# print one newline on empty input, return 1 when EOF'
 $TS_CMD_LINE </dev/null >> $TS_OUTPUT 2>&1
+echo "ret: $?" >> $TS_OUTPUT
+
+ts_log '# large line of zero bytes'
+dd if=/dev/zero  bs=1k count=1k 2>/dev/null |
+	$TS_CMD_LINE line | $TS_CMD_HEXDUMP -C >> $TS_OUTPUT 2>&1
 echo "ret: $?" >> $TS_OUTPUT
 
 ts_finalize


### PR DESCRIPTION
As already sent to mailing list, with some corrections.

Two patches regarding "taking address of packed member". The first
one (sun) makes things more nice, the second one (gpt) is more ugly.
Don't know how serious the problem is, see
https://stackoverflow.com/questions/8568432/is-gccs-attribute-packed-pragma-pack-unsafe

The wall/OSX patch is maybe too ugly and probably does not fix
a real issue. Maybe skip it.