### PR TITLE
fstrim: prefer earlier mounted filesystems

### DIFF
--- a/sys-utils/fstrim.c
+++ b/sys-utils/fstrim.c
@@ -194,7 +194,7 @@ static int fstrim_all(struct fstrim_range *rangetpl, int verbose)
 	mnt_table_uniq_fs(tab, 0, uniq_fs_target_cmp);
 
 	/* de-duplicate by source and root */
-	mnt_table_uniq_fs(tab, 0, uniq_fs_source_cmp);
+	mnt_table_uniq_fs(tab, MNT_UNIQ_FORWARD, uniq_fs_source_cmp);
 
 	while (mnt_table_next_fs(tab, itr, &fs) == 0) {
 		const char *src = mnt_fs_get_srcpath(fs),


### PR DESCRIPTION
Also sent to mailing list.

`fstrim --all` is broken in a way that if there is a bind mount for some filesystem, that filesystem will not be trimmed. This is especially critical for e.g. NixOS distribution, which needs bind mount within root fs: https://github.com/NixOS/nixos/blob/master/modules/system/boot/stage-2-init.sh#L55

Currently for a given filesystem during "de-duplication by source and root" phase, an early mounted fs path is filtered (e.g. "/"), while later mounted fs path is kept (e.g. "/nix/store") though anyway discarded later (since it's an overlaying mount). This leads to skipped trimming.

So flip this behaviour. Should also help for other types of overlaying mounts.

Reference: https://github.com/karelzak/util-linux/blob/stable/v2.29/libmount/src/tab.c#L715