### PR TITLE
usage cleanup part 1 

### DIFF
--- a/disk-utils/fsck.8
+++ b/disk-utils/fsck.8
@@ -309,6 +309,12 @@ Don't show the title on startup.
 .B \-V
 Produce verbose output, including all filesystem-specific commands
 that are executed.
+.TP
+\fB\-?\fR, \fB\-\-help\fR
+Display help text and exit.
+.TP
+\fB\-\-version\fR
+Display version information and exit.
 .SH FILESYSTEM SPECIFIC OPTIONS
 .B Options which are not understood by fsck are passed to the filesystem-specific checker! 
 .PP

--- a/disk-utils/mkfs.cramfs.8
+++ b/disk-utils/mkfs.cramfs.8
@@ -64,11 +64,11 @@ sorting.
 \fB\-z\fR
 Make explicit holes.  Use of this option will require 2.3.39 kernel, or newer.
 .TP
-\fB\-V\fR
-Display version information and exit.
+\fB\-h\fR, \fB\-\-help\fR
+Display help text and exit.
 .TP
-\fB\-h\fR
-Display help and exit.
+\fB\-V\fR, \fB\-\-version\fR
+Display version information and exit.
 .SH "EXIT STATUS"
 .RS
 .PD 0

--- a/include/c.h
+++ b/include/c.h
@@ -216,12 +216,6 @@ errmsg(char doexit, int excode, char adderr, const char *fmt, ...)
 	exit(eval); \
 })
 
-#define errtryh(eval) __extension__ ({ \
-	fprintf(stderr, _("Try '%s -h' for more information.\n"), \
-			program_invocation_short_name); \
-	exit(eval); \
-})
-
 
 static inline __attribute__((const)) int is_power_of_2(unsigned long num)
 {

--- a/login-utils/chsh.c
+++ b/login-utils/chsh.c
@@ -235,8 +235,6 @@ static void parse_argv(int argc, char **argv, struct sinfo *pinfo)
 			print_shells();
 			exit(EXIT_SUCCESS);
 		case 's':
-			if (!optarg)
-				usage(stderr);
 			pinfo->shell = optarg;
 			break;
 		default:

--- a/login-utils/login.1
+++ b/login-utils/login.1
@@ -131,7 +131,10 @@ to tell
 .B login
 that printing the hostname should be suppressed in the login: prompt.
 .TP
-.B \-V
+\fB\-\-help\fR
+Display help text and exit.
+.TP
+\fB\-V\fR, \fB\-\-version\fR
 Display version information and exit.
 .SH CONFIG FILE ITEMS
 .B login

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1095,6 +1095,16 @@ static void init_remote_info(struct login_context *cxt, char *remotehost)
 	}
 }
 
+static void __attribute__((__noreturn__)) usage(void)
+{
+	fputs(USAGE_HEADER, stdout);
+	printf(_(" %s [-p] [-h <host>] [-H] [[-f] <username>]\n"), program_invocation_short_name);
+	fputs(USAGE_SEPARATOR, stdout);
+	fputs(_("Begin a session on the system.\n"), stdout);
+	printf(USAGE_MAN_TAIL("login(1)"));
+	exit(EXIT_SUCCESS);
+}
+
 int main(int argc, char **argv)
 {
 	int c;
@@ -1117,6 +1127,14 @@ int main(int argc, char **argv)
 		.conv = { openpam_ttyconv, NULL } /* OpenPAM conversation function */
 #endif
 
+	};
+
+	/* the only two longopts to satisfy UL standards */
+	enum { HELP_OPTION = CHAR_MAX + 1 };
+	static const struct option longopts[] = {
+		{"help", no_argument, NULL, HELP_OPTION},
+		{"version", no_argument, NULL, 'V'},
+		{NULL, 0, NULL, 0}
 	};
 
 	timeout = (unsigned int)getlogindefs_num("LOGIN_TIMEOUT", LOGIN_TIMEOUT);
@@ -1142,7 +1160,7 @@ int main(int argc, char **argv)
 	 * -h is used by other servers to pass the name of the remote
 	 *    host to login so that it may be placed in utmp and wtmp
 	 */
-	while ((c = getopt(argc, argv, "fHh:pV")) != -1)
+	while ((c = getopt_long(argc, argv, "fHh:pV", longopts, NULL)) != -1)
 		switch (c) {
 		case 'f':
 			cxt.noauth = 1;
@@ -1168,12 +1186,10 @@ int main(int argc, char **argv)
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
-		case '?':
+		case HELP_OPTION:
+			usage();
 		default:
-			fprintf(stderr, _("Usage: login [-p] [-h <host>] [-H] [[-f] <username>]\n"));
-			fputs(USAGE_SEPARATOR, stderr);
-			fputs(_("Begin a session on the system.\n"), stderr);
-			exit(EXIT_FAILURE);
+			errtryhelp(EXIT_FAILURE);
 		}
 	argc -= optind;
 	argv += optind;

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -1381,15 +1381,12 @@ int main(int argc, char *argv[])
 			outmode = OUT_NEWLINE;
 			break;
 		case 'o':
-			if (optarg) {
-				if (*optarg == '=')
-					optarg++;
-				ncolumns = string_to_idarray(optarg,
-						columns, ARRAY_SIZE(columns),
-						column_name_to_id);
-				if (ncolumns < 0)
-					return EXIT_FAILURE;
-			}
+			if (*optarg == '=')
+				optarg++;
+			ncolumns = string_to_idarray(optarg, columns,
+					ARRAY_SIZE(columns), column_name_to_id);
+			if (ncolumns < 0)
+				return EXIT_FAILURE;
 			opt_o = 1;
 			break;
 		case 'r':

--- a/misc-utils/blkid.c
+++ b/misc-utils/blkid.c
@@ -762,7 +762,7 @@ int main(int argc, char **argv)
 		case 's':
 			if (numtag + 1 >= sizeof(ctl.show) / sizeof(*ctl.show)) {
 				warnx(_("Too many tags specified"));
-				errtryh(err);
+				errtryhelp(err);
 			}
 			ctl.show[numtag++] = optarg;
 			break;
@@ -773,13 +773,13 @@ int main(int argc, char **argv)
 			if (search_type) {
 				warnx(_("Can only search for "
 					"one NAME=value pair"));
-				errtryh(err);
+				errtryhelp(err);
 			}
 			if (blkid_parse_tag_string(optarg,
 						   &search_type,
 						   &search_value)) {
 				warnx(_("-t needs NAME=value pair"));
-				errtryh(err);
+				errtryhelp(err);
 			}
 			break;
 		case 'V':
@@ -794,7 +794,7 @@ int main(int argc, char **argv)
 			usage(0);
 			break;
 		default:
-			errtryh(EXIT_FAILURE);
+			errtryhelp(EXIT_FAILURE);
 		}
 	}
 

--- a/misc-utils/test_uuidd.c
+++ b/misc-utils/test_uuidd.c
@@ -73,17 +73,17 @@ static int shmem_id;
 static object_t *objects;
 
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	fprintf(out, "\n %s [options]\n", program_invocation_short_name);
+	printf("\n %s [options]\n", program_invocation_short_name);
 
-	fprintf(out, "  -p <num>     number of nprocesses (default:%zu)\n", nprocesses);
-	fprintf(out, "  -t <num>     number of nthreads (default:%zu)\n", nthreads);
-	fprintf(out, "  -o <num>     number of nobjects (default:%zu)\n", nobjects);
-	fprintf(out, "  -l <level>   log level (default:%zu)\n", loglev);
-	fprintf(out, "  -h           display help\n");
+	printf("  -p <num>     number of nprocesses (default:%zu)\n", nprocesses);
+	printf("  -t <num>     number of nthreads (default:%zu)\n", nthreads);
+	printf("  -o <num>     number of nobjects (default:%zu)\n", nobjects);
+	printf("  -l <level>   log level (default:%zu)\n", loglev);
+	printf("  -h           display help\n");
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void allocate_segment(int *id, void **address, size_t number, size_t size)
@@ -260,6 +260,8 @@ static void object_dump(size_t idx, object_t *obj)
 	fprintf(stderr, "}\n");
 }
 
+#define MSG_TRY_HELP "Try '-h' for help."
+
 int main(int argc, char *argv[])
 {
 	size_t i, nfailed = 0, nignored = 0;
@@ -280,15 +282,16 @@ int main(int argc, char *argv[])
 			loglev = strtou32_or_err(optarg, "invalid log level argument");
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		default:
-			errtryh(EXIT_FAILURE);
+			fprintf(stderr, MSG_TRY_HELP);
+			exit(EXIT_FAILURE);
 		}
 	}
 
 	if (optind != argc)
-		usage(stderr);
+		errx(EXIT_FAILURE, "bad usage\n" MSG_TRY_HELP);
 
 	if (loglev == 1)
 		fprintf(stderr, "requested: %zu processes, %zu threads, %zu objects per thread (%zu objects = %zu bytes)\n",

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -41,12 +41,6 @@
 
 #include "nls.h"
 
-#ifdef __GNUC__
-#define CODE_ATTR(x) __attribute__(x)
-#else
-#define CODE_ATTR(x)
-#endif
-
 /* length of textual representation of UUID, including trailing \0 */
 #define UUID_STR_LEN	37
 

--- a/misc-utils/whereis.1
+++ b/misc-utils/whereis.1
@@ -125,6 +125,12 @@ or
 .BR \-S
 is specified, the option will output the hard-coded paths
 that the command was able to find on the system.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Display help text and exit.
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Display version information and exit.
 .SH EXAMPLE
 To find all files in
 .I /usr/\:bin

--- a/misc-utils/whereis.c
+++ b/misc-utils/whereis.c
@@ -183,8 +183,10 @@ static const char *whereis_type_to_name(int type)
 	}
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
+
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [-BMS <dir>... -f] <name>\n"), program_invocation_short_name);
 
@@ -201,9 +203,12 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(_(" -f         terminate <dirs> argument list\n"), out);
 	fputs(_(" -u         search for unusual entries\n"), out);
 	fputs(_(" -l         output effective lookup paths\n"), out);
-	fprintf(out, USAGE_MAN_TAIL("whereis(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	fputs(USAGE_SEPARATOR, out);
+	fputs(USAGE_HELP, out);
+	fputs(USAGE_VERSION, out);
+	fprintf(out, USAGE_MAN_TAIL("whereis(1)"));
+	exit(EXIT_SUCCESS);
 }
 
 static void dirlist_add_dir(struct wh_dirlist **ls0, int type, const char *dir)
@@ -502,8 +507,18 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
-	if (argc == 1)
-		usage(stderr);
+	if (argc <= 1) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	} else {
+		/* first arg may be one of our standard longopts */
+		if (!strcmp(argv[1], "--help"))
+			usage();
+		if (!strcmp(argv[1], "--version")) {
+			printf(UTIL_LINUX_VERSION);
+			exit(EXIT_SUCCESS);
+		}
+	}
 
 	whereis_init_debug();
 
@@ -547,8 +562,10 @@ int main(int argc, char **argv)
 				opt_f_missing = 0;
 				break;
 			case 'B':
-				if (*(arg + 1))
-					usage(stderr);
+				if (*(arg + 1)) {
+					warnx(_("bad usage"));
+					errtryhelp(EXIT_FAILURE);
+				}
 				i++;
 				free_dirlist(&ls, BIN_DIR);
 				construct_dirlist_from_argv(
@@ -556,8 +573,10 @@ int main(int argc, char **argv)
 				opt_f_missing = 1;
 				break;
 			case 'M':
-				if (*(arg + 1))
-					usage(stderr);
+				if (*(arg + 1)) {
+					warnx(_("bad usage"));
+					errtryhelp(EXIT_FAILURE);
+				}
 				i++;
 				free_dirlist(&ls, MAN_DIR);
 				construct_dirlist_from_argv(
@@ -565,8 +584,10 @@ int main(int argc, char **argv)
 				opt_f_missing = 1;
 				break;
 			case 'S':
-				if (*(arg + 1))
-					usage(stderr);
+				if (*(arg + 1)) {
+					warnx(_("bad usage"));
+					errtryhelp(EXIT_FAILURE);
+				}
 				i++;
 				free_dirlist(&ls, SRC_DIR);
 				construct_dirlist_from_argv(
@@ -604,9 +625,10 @@ int main(int argc, char **argv)
 				printf(UTIL_LINUX_VERSION);
 				return EXIT_SUCCESS;
 			case 'h':
-				usage(stdout);
+				usage();
 			default:
-				usage(stderr);
+				warnx(_("bad usage"));
+				errtryhelp(EXIT_FAILURE);
 			}
 
 			if (arg_i < i)		/* moved to the next argv[] item */

--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -1486,10 +1486,8 @@ int main(int argc, char *argv[])
 			errtryhelp(EXIT_FAILURE);
 		}
 	}
-	argc -= optind;
-	argv += optind;
 
-	if (argc > 1)
+	if (argc != optind)
 		usage(stderr);
 
 	if ((is_timefmt(&ctl, RELTIME) ||

--- a/sys-utils/setarch.c
+++ b/sys-utils/setarch.c
@@ -84,7 +84,7 @@
 
 static int archwrapper;
 
-static void __attribute__((__noreturn__)) show_help(void)
+static void __attribute__((__noreturn__)) usage(void)
 {
 	fputs(USAGE_HEADER, stdout);
 	if (!archwrapper)
@@ -119,17 +119,6 @@ static void __attribute__((__noreturn__)) show_help(void)
 	printf(USAGE_MAN_TAIL("setarch(8)"));
 
 	exit(EXIT_SUCCESS);
-}
-
-static void __attribute__((__noreturn__)) show_usage(const char *s)
-{
-	if (s)
-		errx(EXIT_FAILURE,
-		     _("%s\nTry `%s --help' for more information."), s,
-		     program_invocation_short_name);
-	else
-		errx(EXIT_FAILURE, _("Try `%s --help' for more information."),
-		     program_invocation_short_name);
 }
 
 static void __attribute__((__noreturn__))
@@ -301,9 +290,10 @@ int main(int argc, char *argv[])
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
-	if (argc < 1)
-		show_usage(_("Not enough arguments"));
-
+	if (argc < 1) {
+		warnx(_("Not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	archwrapper = strcmp(program_invocation_short_name, "setarch") != 0;
 	if (archwrapper)
 		arch = program_invocation_short_name;	/* symlinks to setarch */
@@ -328,7 +318,7 @@ int main(int argc, char *argv[])
 	while ((c = getopt_long(argc, argv, "+hVv3BFILRSTXZ", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'h':
-			show_help();
+			usage();
 			break;
 		case 'V':
 			show_version();

--- a/text-utils/hexdump.c
+++ b/text-utils/hexdump.c
@@ -107,7 +107,7 @@ parse_args(int argc, char **argv, struct hexdump *hex)
 		case 'f':
 			addfile(optarg, hex);
 			break;
-                case 'L':
+		case 'L':
 			colormode = UL_COLORMODE_AUTO;
 			if (optarg)
 				colormode = colormode_or_err(optarg,

--- a/text-utils/more.1
+++ b/text-utils/more.1
@@ -98,6 +98,12 @@ Start displaying each file at line
 The
 .I string
 to be searched in each file before starting to display it.
+.TP
+\fB\-\-help\fR
+Display help text and exit.
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Display version information and exit.
 .SH COMMANDS
 Interactive commands for
 .B more


### PR DESCRIPTION
The major goal is to avoid printing usage/help messages on stderr.

This is the preparing first part of a bigger patch-set. There are some minor bug fixes and finally we add --help options to all our commands (just 5 commands were missing it).  

The next completing patch-set (part 2) will be more invasive but even more trivial.