### PR TITLE
Fix some exit codes (strutils.h and friends)

### DIFF
--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -54,8 +54,6 @@
 #include "c.h"
 #include "fileutils.h"
 #include "monotonic.h"
-
-#define STRTOXX_EXIT_CODE	FSCK_EX_USAGE
 #include "strutils.h"
 
 #define XALLOC_EXIT_CODE	FSCK_EX_ERROR
@@ -1599,6 +1597,7 @@ int main(int argc, char *argv[])
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
+	strutils_set_exitcode(FSCK_EX_USAGE);
 	mnt_init_debug(0);		/* init libmount debug mask */
 	mntcache = mnt_new_cache();	/* no fatal error if failed */
 

--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -55,7 +55,7 @@
 #include "fileutils.h"
 #include "monotonic.h"
 
-#define STRTOXX_EXIT_CODE	FSCK_EX_ERROR
+#define STRTOXX_EXIT_CODE	FSCK_EX_USAGE
 #include "strutils.h"
 
 #define XALLOC_EXIT_CODE	FSCK_EX_ERROR

--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -671,7 +671,7 @@ int main(int argc, char **argv)
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
-			return EXIT_SUCCESS;
+			return FSCK_EX_OK;
 		case 'x':
 			opt_extract = 1;
 			if(optarg)

--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -660,6 +660,8 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
+	strutils_set_exitcode(FSCK_EX_USAGE);
+
 	/* command line options */
 	while ((c = getopt_long(argc, argv, "ayvVhb:", longopts, NULL)) != EOF)
 		switch (c) {

--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -1293,6 +1293,8 @@ main(int argc, char **argv) {
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
+	strutils_set_exitcode(FSCK_EX_USAGE);
+
 	if (INODE_SIZE * MINIX_INODES_PER_BLOCK != MINIX_BLOCK_SIZE)
 		die(_("bad inode size"));
 	if (INODE2_SIZE * MINIX2_INODES_PER_BLOCK != MINIX_BLOCK_SIZE)

--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -910,5 +910,5 @@ int main(int argc, char **argv)
 	    (warn_namelen|warn_skip|warn_size|warn_uid|warn_gid|warn_dev))
 		exit(MKFS_EX_ERROR);
 
-	return EXIT_SUCCESS;
+	return MKFS_EX_OK;
 }

--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -717,6 +717,8 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
+	strutils_set_exitcode(MKFS_EX_USAGE);
+
 	/* command line options */
 	while ((c = getopt(argc, argv, "hb:Ee:i:n:N:psVvz")) != EOF) {
 		switch (c) {

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -77,6 +77,8 @@
 #include "all-io.h"
 #include "closestream.h"
 #include "ismounted.h"
+
+#define XALLOC_EXIT_CODE MKFS_EX_ERROR
 #include "xalloc.h"
 
 #define MINIX_ROOT_INO 1

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -758,6 +758,8 @@ int main(int argc, char ** argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
+	strutils_set_exitcode(MKFS_EX_USAGE);
+
 	while ((i = getopt_long(argc, argv, "1v23n:i:cl:Vh", longopts, NULL)) != -1)
 		switch (i) {
 		case '1':

--- a/include/strutils.h
+++ b/include/strutils.h
@@ -9,11 +9,8 @@
 #include <stdio.h>
 #include <errno.h>
 
-/* default strtoxx_or_err() exit code */
-#ifndef STRTOXX_EXIT_CODE
-# define STRTOXX_EXIT_CODE EXIT_FAILURE
-#endif
-
+/* initialize a custom exit code for all *_or_err functions */
+extern void strutils_set_exitcode(int exit_code);
 
 extern int parse_size(const char *str, uintmax_t *res, int *power);
 extern int strtosize(const char *str, uintmax_t *res);

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -17,6 +17,12 @@
 #include "strutils.h"
 #include "bitops.h"
 
+static int STRTOXX_EXIT_CODE = EXIT_FAILURE;
+
+void strutils_set_exitcode(int ex) {
+	STRTOXX_EXIT_CODE = ex;
+}
+
 static int do_scale_by_power (uintmax_t *x, int base, int power)
 {
 	while (power--) {

--- a/misc-utils/blkid.c
+++ b/misc-utils/blkid.c
@@ -42,6 +42,8 @@
 
 #include "nls.h"
 #include "ttyutils.h"
+
+#define XALLOC_EXIT_CODE    BLKID_EXIT_OTHER    /* x.*alloc(), xstrndup() */
 #include "xalloc.h"
 
 struct blkid_control {

--- a/misc-utils/blkid.c
+++ b/misc-utils/blkid.c
@@ -34,7 +34,6 @@
 
 #include "ismounted.h"
 
-#define STRTOXX_EXIT_CODE	BLKID_EXIT_OTHER	/* strtoxx_or_err() */
 #include "strutils.h"
 #define OPTUTILS_EXIT_CODE	BLKID_EXIT_OTHER	/* exclusive_option() */
 #include "optutils.h"
@@ -690,6 +689,8 @@ int main(int argc, char **argv)
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
 	atexit(close_stdout);
+
+	strutils_set_exitcode(BLKID_EXIT_OTHER);
 
 	while ((c = getopt_long (argc, argv,
 			    "c:dghilL:n:ko:O:ps:S:t:u:U:w:Vv", longopts, NULL)) != -1) {

--- a/misc-utils/findfs.c
+++ b/misc-utils/findfs.c
@@ -63,11 +63,11 @@ int main(int argc, char **argv)
 		switch (c) {
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
-			return EXIT_SUCCESS;
+			return FINDFS_SUCCESS;
 		case 'h':
 			usage(FINDFS_SUCCESS);
 		default:
-			errtryhelp(EXIT_FAILURE);
+			errtryhelp(FINDFS_USAGE_ERROR);
 		}
 
 	dev = blkid_evaluate_tag(argv[1], NULL, NULL);

--- a/sys-utils/flock.c
+++ b/sys-utils/flock.c
@@ -170,6 +170,8 @@ int main(int argc, char *argv[])
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
+	strutils_set_exitcode(EX_USAGE);
+
 	if (argc < 2)
 		usage(EX_USAGE);
 

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -71,6 +71,7 @@
 #include <unistd.h>
 
 #define OPTUTILS_EXIT_CODE EX_USAGE
+#define XALLOC_EXIT_CODE EX_OSERR
 
 #include "c.h"
 #include "closestream.h"

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -1326,6 +1326,8 @@ int main(int argc, char **argv)
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
 
+	strutils_set_exitcode(EX_USAGE);
+
 	/* Remember what time we were invoked */
 	gettimeofday(&startup_time, NULL);
 

--- a/sys-utils/mount.c
+++ b/sys-utils/mount.c
@@ -36,9 +36,11 @@
 #include "c.h"
 #include "env.h"
 #include "strutils.h"
-#include "xalloc.h"
 #include "closestream.h"
 #include "canonicalize.h"
+
+#define XALLOC_EXIT_CODE MNT_EX_SYSERR
+#include "xalloc.h"
 
 #define OPTUTILS_EXIT_CODE MNT_EX_USAGE
 #include "optutils.h"

--- a/sys-utils/mount.c
+++ b/sys-utils/mount.c
@@ -534,6 +534,8 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
+	strutils_set_exitcode(MNT_EX_USAGE);
+
 	mnt_init_debug(0);
 	cxt = mnt_new_context();
 	if (!cxt)

--- a/sys-utils/tunelp.c
+++ b/sys-utils/tunelp.c
@@ -72,12 +72,11 @@
 #include "lp.h"
 #include "nls.h"
 #include "closestream.h"
+#include "strutils.h"
 
 #define EXIT_LP_MALLOC		2
-#define STRTOXX_EXIT_CODE	3
+#define EXIT_LP_BADVAL		3
 #define EXIT_LP_IO_ERR		4
-
-#include "strutils.h"
 
 #define XALLOC_EXIT_CODE EXIT_LP_MALLOC
 #include "xalloc.h"
@@ -146,6 +145,8 @@ int main(int argc, char **argv)
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
 	atexit(close_stdout);
+
+	strutils_set_exitcode(EXIT_LP_BADVAL);
 
 	if (argc < 2)
 		print_usage(stderr);

--- a/sys-utils/tunelp.c
+++ b/sys-utils/tunelp.c
@@ -71,13 +71,16 @@
 
 #include "lp.h"
 #include "nls.h"
-#include "xalloc.h"
 #include "closestream.h"
 
+#define EXIT_LP_MALLOC		2
 #define STRTOXX_EXIT_CODE	3
 #define EXIT_LP_IO_ERR		4
 
 #include "strutils.h"
+
+#define XALLOC_EXIT_CODE EXIT_LP_MALLOC
+#include "xalloc.h"
 
 struct command {
 	long op;

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -36,6 +36,8 @@
 #include "closestream.h"
 #include "pathnames.h"
 #include "canonicalize.h"
+
+#define XALLOC_EXIT_CODE MNT_EX_SYSERR
 #include "xalloc.h"
 
 static int table_parser_errcb(struct libmnt_table *tb __attribute__((__unused__)),

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -32,13 +32,15 @@
 #include "nls.h"
 #include "c.h"
 #include "env.h"
-#include "optutils.h"
 #include "closestream.h"
 #include "pathnames.h"
 #include "canonicalize.h"
 
 #define XALLOC_EXIT_CODE MNT_EX_SYSERR
 #include "xalloc.h"
+
+#define OPTUTILS_EXIT_CODE MNT_EX_USAGE
+#include "optutils.h"
 
 static int table_parser_errcb(struct libmnt_table *tb __attribute__((__unused__)),
 			const char *filename, int line)


### PR DESCRIPTION
As discussed on the mailing list, most importantly we remove the non-working define STRTOXX_EXIT_CODE.