### PR TITLE
usage cleanup part 2

### DIFF
--- a/Documentation/boilerplate.c
+++ b/Documentation/boilerplate.c
@@ -34,8 +34,9 @@
  * Other usage() constants that are not demonstrated below:
  * USAGE_FUNCTIONS USAGE_COMMANDS USAGE_COLUMNS
  */
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] file...\n"), program_invocation_short_name);
 
@@ -58,7 +59,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("fixme-command-name(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -101,7 +102,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/Makefile.am
+++ b/Makefile.am
@@ -183,11 +183,15 @@ checkdecl:
 checkcompletion:
 	@ $(top_srcdir)/tools/checkcompletion.sh $(top_srcdir)
 
+checkusage:
+	@ $(top_srcdir)/tools/checkusage.sh \
+		$(bin_PROGRAMS) $(sbin_PROGRAMS) \
+		$(usrbin_exec_PROGRAMS) $(usrsbin_exec_PROGRAMS)
+
 DISTCHECK_CONFIGURE_FLAGS = \
 	--disable-use-tty-group \
 	--disable-silent-rules \
 	--enable-all-programs \
-	--disable-makeinstall-chown \
 	--enable-static-programs \
 	--enable-gtk-doc \
 	--with-python \

--- a/disk-utils/addpart.c
+++ b/disk-utils/addpart.c
@@ -8,8 +8,9 @@
 #include "partx.h"
 #include "strutils.h"
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s <disk device> <partition number> <start> <length>\n"),
 		program_invocation_short_name);
@@ -21,7 +22,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("addpart(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -44,13 +45,15 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 
-	if (argc != 5)
-		usage(stderr);
+	if (argc != 5) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	if ((fd = open(argv[1], O_RDONLY)) < 0)
 		err(EXIT_FAILURE, _("cannot open %s"), argv[1]);

--- a/disk-utils/blockdev.c
+++ b/disk-utils/blockdev.c
@@ -178,9 +178,11 @@ static const struct bdc bdcms[] =
 	}
 };
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE * out = stdout;
 	size_t i;
+
 	fprintf(out, _("\nUsage:\n"
 		       " %1$s -V\n"
 		       " %1$s --report [devices]\n"
@@ -197,8 +199,9 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 			fprintf(out, " %-25s %s\n", bdcms[i].name,
 				_(bdcms[i].help));
 	}
-	fputc('\n', out);
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+
+	fprintf(out, USAGE_MAN_TAIL("blockdev(1)"));
+	exit(EXIT_SUCCESS);
 }
 
 static int find_cmd(char *s)
@@ -225,8 +228,10 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
-	if (argc < 2)
-		usage(stderr);
+	if (argc < 2) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	/* -V not together with commands */
 	if (!strcmp(argv[1], "-V") || !strcmp(argv[1], "--version")) {
@@ -234,7 +239,7 @@ int main(int argc, char **argv)
 		return EXIT_SUCCESS;
 	}
 	if (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))
-		usage(stdout);
+		usage();
 
 	/* --report not together with other commands */
 	if (!strcmp(argv[1], "--report")) {
@@ -267,8 +272,10 @@ int main(int argc, char **argv)
 			break;
 	}
 
-	if (d >= argc)
-		usage(stderr);
+	if (d >= argc) {
+		warnx(_("no device specified"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	for (k = d; k < argc; k++) {
 		fd = open(argv[k], O_RDONLY, 0);
@@ -315,7 +322,7 @@ static void do_commands(int fd, char **argv, int d)
 		j = find_cmd(argv[i]);
 		if (j == -1) {
 			warnx(_("Unknown command: %s"), argv[i]);
-			usage(stderr);
+			errtryhelp(EXIT_FAILURE);
 		}
 
 		switch (bdcms[j].argtype) {
@@ -332,7 +339,7 @@ static void do_commands(int fd, char **argv, int d)
 				if (i == d - 1) {
 					warnx(_("%s requires an argument"),
 					      bdcms[j].name);
-					usage(stderr);
+					errtryhelp(EXIT_FAILURE);
 				}
 				iarg = atoi(argv[++i]);
 			} else

--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -2542,8 +2542,9 @@ static int ui_run(struct cfdisk *cf)
 	return 0;
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %1$s [options] <disk>\n"), program_invocation_short_name);
@@ -2562,7 +2563,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 
 	fprintf(out, USAGE_MAN_TAIL("cfdisk(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -2588,7 +2589,7 @@ int main(int argc, char *argv[])
 	while((c = getopt_long(argc, argv, "L::hVz", longopts, NULL)) != -1) {
 		switch(c) {
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'L':
 			colormode = UL_COLORMODE_AUTO;

--- a/disk-utils/delpart.c
+++ b/disk-utils/delpart.c
@@ -8,8 +8,9 @@
 #include "partx.h"
 #include "strutils.h"
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s <disk device> <partition number>\n"),
 		program_invocation_short_name);
@@ -21,7 +22,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("delpart(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -44,13 +45,15 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 
-	if (argc != 3)
-		usage(stderr);
+	if (argc != 3) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 
 	if ((fd = open(argv[1], O_RDONLY)) < 0)

--- a/disk-utils/fdformat.c
+++ b/disk-utils/fdformat.c
@@ -138,8 +138,9 @@ static void verify_disk(int ctrl, unsigned int track_from, unsigned int track_to
 	printf(_("done\n"));
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <device>\n"),
 		program_invocation_short_name);
@@ -159,7 +160,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("fdformat(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -207,7 +208,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -215,8 +216,10 @@ int main(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	if (argc < 1)
-		usage(stderr);
+	if (argc < 1) {
+		warnx(_("no device specified"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	if (stat(argv[0], &st) < 0)
 		err(EXIT_FAILURE, _("stat of %s failed"), argv[0]);
 	if (!S_ISBLK(st.st_mode))

--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -102,11 +102,9 @@ static char *outbuffer;
 
 static size_t blksize = 0;
 
-
-/* Input status of 0 to print help and exit without an error. */
-static void __attribute__((__noreturn__)) usage(int status)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	FILE *out = status ? stderr : stdout;
+	FILE *out = stdout;
 
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
@@ -126,7 +124,7 @@ static void __attribute__((__noreturn__)) usage(int status)
 	fputs(USAGE_VERSION, out);
 	fputs(USAGE_SEPARATOR, out);
 
-	exit(status);
+	exit(FSCK_EX_OK);
 }
 
 static int get_superblock_endianness(uint32_t magic)
@@ -669,7 +667,7 @@ int main(int argc, char **argv)
 		case 'y':
 			break;
 		case 'h':
-			usage(FSCK_EX_OK);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
@@ -689,8 +687,10 @@ int main(int argc, char **argv)
 			errtryhelp(FSCK_EX_USAGE);
 		}
 
-	if ((argc - optind) != 1)
-		usage(FSCK_EX_USAGE);
+	if ((argc - optind) != 1){
+		warnx(_("bad usage"));
+		errtryhelp(FSCK_EX_USAGE);
+	}
 	filename = argv[optind];
 
 	test_super(&start, &length);

--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -177,7 +177,8 @@ leave(int status) {
 }
 
 static void __attribute__((__noreturn__))
-usage(FILE *out) {
+usage(void) {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <device>\n"), program_invocation_short_name);
 	fputs(USAGE_SEPARATOR, out);
@@ -194,7 +195,7 @@ usage(FILE *out) {
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("fsck.minix(8)"));
-	leave(out == stderr ? FSCK_EX_USAGE : FSCK_EX_OK);
+	exit(FSCK_EX_OK);
 }
 
 static void die(const char *fmt, ...)
@@ -1329,7 +1330,7 @@ main(int argc, char **argv) {
 			printf(UTIL_LINUX_VERSION);
 			return FSCK_EX_OK;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(FSCK_EX_USAGE);
 		}
@@ -1337,9 +1338,10 @@ main(int argc, char **argv) {
 	argv += optind;
 	if (0 < argc) {
 		device_name = argv[0];
-	} else
-		usage(stderr);
-
+	} else {
+		warnx(_("no device specified"));
+		errtryhelp(FSCK_EX_USAGE);
+	}
 	check_mount();		/* trying to check a mounted filesystem? */
 	if (repair && !automatic && (!isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO)))
 		die(_("need terminal for interactive repairs"));

--- a/disk-utils/isosize.c
+++ b/disk-utils/isosize.c
@@ -126,8 +126,9 @@ static void isosize(int argc, char *filenamep, int xflag, long divisor)
 	close(fd);
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 		_(" %s [options] <iso9660_image_file>\n"),
@@ -144,7 +145,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("isosize(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -179,15 +180,17 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 
 	ct = argc - optind;
 
-	if (ct <= 0)
-		usage(stderr);
+	if (ct <= 0) {
+		warnx(_("no device specified"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	for (j = optind; j < argc; j++)
 		isosize(ct, argv[j], xflag, divisor);

--- a/disk-utils/mkfs.bfs.c
+++ b/disk-utils/mkfs.bfs.c
@@ -67,8 +67,9 @@ struct bfsde {
 	char d_name[BFS_NAMELEN];
 };
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fprintf(out,
 		_("Usage: %s [options] device [block-count]\n"),
 		program_invocation_short_name);
@@ -88,7 +89,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 		       " -h, --help          display this help and exit\n\n"));
 
 	fprintf(out, USAGE_MAN_TAIL("mkfs.bfs(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void __attribute__ ((__noreturn__)) print_version(void)
@@ -129,9 +130,10 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
-	if (argc < 2)
-		usage(stderr);
-
+	if (argc < 2) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	if (argc == 2 && !strcmp(argv[1], "-V"))
 		print_version();
 
@@ -170,14 +172,16 @@ int main(int argc, char **argv)
 		case VERSION_OPTION:
 			print_version();
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 	}
 
-	if (optind == argc)
-		usage(stderr);
+	if (optind == argc) {
+		warnx(_("no device specified"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	device = argv[optind++];
 
@@ -191,8 +195,10 @@ int main(int argc, char **argv)
 	if (optind == argc - 1)
 		user_specified_total_blocks =
 			strtou64_or_err(argv[optind], _("invalid block-count"));
-	else if (optind != argc)
-		usage(stderr);
+	else if (optind != argc) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	if (blkdev_get_sectors(fd, &total_blocks) == -1) {
 		if (!user_specified_total_blocks)

--- a/disk-utils/mkfs.c
+++ b/disk-utils/mkfs.c
@@ -38,8 +38,9 @@
 #define DEFAULT_FSTYPE	"ext2"
 #endif
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [-t <type>] [fs-options] <device> [<size>]\n"),
 		     program_invocation_short_name);
@@ -60,7 +61,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 
 	fprintf(out, USAGE_MAN_TAIL("mkfs(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void __attribute__ ((__noreturn__)) print_version(void)
@@ -106,7 +107,7 @@ int main(int argc, char **argv)
 			fstype = optarg;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case VERSION_OPTION:
 			print_version();
 		default:
@@ -114,8 +115,10 @@ int main(int argc, char **argv)
 			more = 1;
 			break;	/* start of specific arguments */
 		}
-	if (optind == argc)
-		usage(stderr);
+	if (optind == argc) {
+		warnx(_("no device specified"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	/* If -t wasn't specified, use the default */
 	if (fstype == NULL)

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -131,8 +131,9 @@ static char *zone_map;
 #define mark_zone(x) (setbit(zone_map,(x)-get_first_zone()+1))
 #define unmark_zone(x) (clrbit(zone_map,(x)-get_first_zone()+1))
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] /dev/name [blocks]\n"), program_invocation_short_name);
 	fputs(USAGE_OPTIONS, out);
@@ -147,7 +148,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("mkfs.minix(8)"));
-	exit(out == stderr ? MKFS_EX_USAGE : MKFS_EX_OK);
+	exit(MKFS_EX_OK);
 }
 
 #ifdef TEST_SCRIPT
@@ -795,7 +796,7 @@ int main(int argc, char ** argv)
 			printf(UTIL_LINUX_VERSION);
 			return MKFS_EX_OK;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(MKFS_EX_USAGE);
 		}
@@ -810,7 +811,8 @@ int main(int argc, char ** argv)
 		ctl.fs_blocks = strtoul_or_err(argv[0], _("failed to parse number of blocks"));
 
 	if (!ctl.device_name) {
-		usage(stderr);
+		warnx(_("no device specified"));
+		errtryhelp(MKFS_EX_USAGE);
 	}
 	check_user_instructions(&ctl);
 	if (is_mounted(ctl.device_name))

--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -141,8 +141,9 @@ static void set_uuid_and_label(const struct mkswap_control *ctl)
 	}
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fprintf(out,
 		_("\nUsage:\n"
 		  " %s [options] device [size]\n"),
@@ -162,7 +163,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE *out)
 		" -V, --version             output version information and exit\n"
 		" -h, --help                display this help and exit\n\n"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void page_bad(struct mkswap_control *ctl, unsigned int page)
@@ -400,7 +401,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -412,7 +413,7 @@ int main(int argc, char **argv)
 		block_count = argv[optind++];
 	if (optind != argc) {
 		warnx(_("only one device argument is currently supported"));
-		usage(stderr);
+		errtryhelp(EXIT_FAILURE);
 	}
 
 #ifdef HAVE_LIBUUID
@@ -428,7 +429,7 @@ int main(int argc, char **argv)
 
 	if (!ctl.devname) {
 		warnx(_("error: Nowhere to set up swap on?"));
-		usage(stderr);
+		errtryhelp(EXIT_FAILURE);
 	}
 	if (block_count) {
 		/* this silly user specified the number of blocks explicitly */

--- a/disk-utils/partx.c
+++ b/disk-utils/partx.c
@@ -743,8 +743,9 @@ static blkid_partlist get_partlist(blkid_probe pr,
 	return ls;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -781,7 +782,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("partx(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -891,7 +892,7 @@ int main(int argc, char **argv)
 			return EXIT_SUCCESS;
 		}
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
@@ -963,9 +964,10 @@ int main(int argc, char **argv)
 			device = NULL;
 			part_devno = 0;
 		}
-	} else
-		usage(stderr);
-
+	} else {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	if (device && (upper || lower))
 		errx(EXIT_FAILURE, _("--nr and <partition> are mutually exclusive"));
 

--- a/disk-utils/resizepart.c
+++ b/disk-utils/resizepart.c
@@ -13,8 +13,9 @@
 #include "strutils.h"
 #include "closestream.h"
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s <disk device> <partition number> <length>\n"),
 		program_invocation_short_name);
@@ -26,7 +27,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("resizepart(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int get_partition_start(int fd, int partno, uint64_t *start)
@@ -86,13 +87,15 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 
-	if (argc != 4)
-		usage(stderr);
+	if (argc != 4) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	wholedisk = argv[1];
 	partno = strtou32_or_err(argv[2], _("invalid partition number argument"));

--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -1839,8 +1839,9 @@ static int command_fdisk(struct sfdisk *sf, int argc, char **argv)
 	return rc;
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 
 	fprintf(out,
@@ -1906,7 +1907,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE *out)
 	list_available_columns(out);
 
 	fprintf(out, USAGE_MAN_TAIL("sfdisk(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 
@@ -2042,7 +2043,7 @@ int main(int argc, char *argv[])
 			sf->act = ACT_SHOW_GEOM;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'l':
 			sf->act = ACT_LIST;

--- a/disk-utils/swaplabel.c
+++ b/disk-utils/swaplabel.c
@@ -111,8 +111,9 @@ err:
 	return -1;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <device>\n"),
 		program_invocation_short_name);
@@ -127,7 +128,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("swaplabel(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -152,7 +153,7 @@ int main(int argc, char *argv[])
 	while ((c = getopt_long(argc, argv, "hVL:U:", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
@@ -172,9 +173,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (optind == argc)
-		usage(stderr);
-
+	if (optind == argc) {
+		warnx(_("no device specified"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	devname = argv[optind];
 	pr = get_swap_prober(devname);
 	if (pr) {

--- a/libsmartcols/samples/fromfile.c
+++ b/libsmartcols/samples/fromfile.c
@@ -194,8 +194,9 @@ static void compose_tree(struct libscols_table *tb, int parent_col, int id_col)
 }
 
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fprintf(out,
 		"\n %s [options] <column-data-file> ...\n\n", program_invocation_short_name);
 
@@ -212,7 +213,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(" -h, --help                     this help\n", out);
 	fputs("\n", out);
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -298,9 +299,9 @@ int main(int argc, char *argv[])
 			scols_table_set_termwidth(tb, strtou32_or_err(optarg, "failed to parse terminal width"));
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
-			usage(stderr);
+			errtryhelp(EXIT_FAILURE);
 		}
 	}
 

--- a/login-utils/chfn.c
+++ b/login-utils/chfn.c
@@ -89,8 +89,9 @@ struct chfn_control {
 /* we do not accept gecos field sizes longer than MAX_FIELD_SIZE */
 #define MAX_FIELD_SIZE		256
 
-static void __attribute__((__noreturn__)) usage(FILE *fp)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *fp = stdout;
 	fputs(USAGE_HEADER, fp);
 	fprintf(fp, _(" %s [options] [<username>]\n"), program_invocation_short_name);
 
@@ -106,7 +107,7 @@ static void __attribute__((__noreturn__)) usage(FILE *fp)
 	fputs(_(" -u, --help     display this help and exit\n"), fp);
 	fputs(_(" -v, --version  output version information and exit\n"), fp);
 	fprintf(fp, USAGE_MAN_TAIL("chfn(1)"));
-	exit(fp == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 /*
@@ -178,7 +179,7 @@ static void parse_argv(struct chfn_control *ctl, int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'u':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -189,8 +190,10 @@ static void parse_argv(struct chfn_control *ctl, int argc, char **argv)
 		exit(EXIT_FAILURE);
 	/* done parsing arguments.  check for a username. */
 	if (optind < argc) {
-		if (optind + 1 < argc)
-			usage(stderr);
+		if (optind + 1 < argc) {
+			warnx(_("cannot handle multiple usernames"));
+			errtryhelp(EXIT_FAILURE);
+		}
 		ctl->username = argv[optind];
 	}
 	return;

--- a/login-utils/chsh.c
+++ b/login-utils/chsh.c
@@ -70,8 +70,9 @@ struct sinfo {
 /* global due readline completion */
 static char **global_shells;
 
-static void __attribute__((__noreturn__)) usage (FILE *fp)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *fp = stdout;
 	fputs(USAGE_HEADER, fp);
 	fprintf(fp, _(" %s [options] [<username>]\n"), program_invocation_short_name);
 
@@ -85,7 +86,7 @@ static void __attribute__((__noreturn__)) usage (FILE *fp)
 	fputs(_(" -u, --help     display this help and exit\n"), fp);
 	fputs(_(" -v, --version  output version information and exit\n"), fp);
 	fprintf(fp, USAGE_MAN_TAIL("chsh(1)"));
-	exit(fp == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 /*
@@ -229,7 +230,7 @@ static void parse_argv(int argc, char **argv, struct sinfo *pinfo)
 			exit(EXIT_SUCCESS);
 		case 'u': /* deprecated */
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'l':
 			init_shells();
 			print_shells();
@@ -243,8 +244,9 @@ static void parse_argv(int argc, char **argv, struct sinfo *pinfo)
 	}
 	/* done parsing arguments.  check for a username. */
 	if (optind < argc) {
-		if (optind + 1 < argc)
-			usage(stderr);
+		if (optind + 1 < argc) {
+			errx(EXIT_FAILURE, _("cannot handle multiple usernames"));
+		}
 		pinfo->username = argv[optind];
 	}
 }

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -560,8 +560,9 @@ static int list(const struct last_control *ctl, struct utmpx *p, time_t logout_t
 }
 
 
-static void __attribute__((__noreturn__)) usage(const struct last_control *ctl, FILE *out)
+static void __attribute__((__noreturn__)) usage(const struct last_control *ctl)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(
 		" %s [options] [<username>...] [<tty>...]\n"), program_invocation_short_name);
@@ -953,7 +954,7 @@ int main(int argc, char **argv)
 
 		switch(c) {
 		case 'h':
-			usage(&ctl, stdout);
+			usage(&ctl);
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -1219,8 +1219,9 @@ static int parse_time_mode(const char *s)
 	errx(EXIT_FAILURE, _("unknown time format: %s"), s);
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -1261,7 +1262,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("lslogins(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -1365,7 +1366,7 @@ int main(int argc, char *argv[])
 			groups = optarg;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'L':
 			add_column(columns, ncolumns++, COL_LAST_TTY);

--- a/login-utils/newgrp.c
+++ b/login-utils/newgrp.c
@@ -166,19 +166,20 @@ static int allow_setgid(const struct passwd *pe, const struct group *ge)
 	return FALSE;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	fprintf(out, USAGE_HEADER);
+	FILE *out = stdout;
+	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s <group>\n"), program_invocation_short_name);
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Log in to a new group.\n"), out);
 
-	fprintf(out, USAGE_OPTIONS);
-	fprintf(out, USAGE_HELP);
-	fprintf(out, USAGE_VERSION);
+	fputs(USAGE_OPTIONS, out);
+	fputs(USAGE_HELP,out);
+	fputs(USAGE_VERSION,out);
 	fprintf(out, USAGE_MAN_TAIL("newgrp(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -204,7 +205,7 @@ int main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/login-utils/nologin.c
+++ b/login-utils/nologin.c
@@ -19,8 +19,9 @@
  * Always return EXIT_FAILURE (1), don't try to be smart!
  */
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 		_(" %s [options]\n"), program_invocation_short_name);
@@ -53,7 +54,7 @@ int main(int argc, char *argv[])
 	while ((c = getopt_long(argc, argv, "hV", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -672,7 +672,7 @@ restricted_shell (const char * const shell)
 }
 
 static void __attribute__((__noreturn__))
-usage (const int status)
+usage(void)
 {
   if (su_mode == RUNUSER_MODE) {
     fputs(USAGE_HEADER, stdout);
@@ -712,7 +712,7 @@ usage (const int status)
   fputs(USAGE_HELP, stdout);
   fputs(USAGE_VERSION, stdout);
   printf(USAGE_MAN_TAIL(su_mode == SU_MODE ? "su(1)" : "runuser(1)"));
-  exit (status);
+  exit(EXIT_SUCCESS);
 }
 
 static
@@ -851,13 +851,15 @@ su_main (int argc, char **argv, int mode)
 	  break;
 
 	case 'u':
-	  if (su_mode != RUNUSER_MODE)
-	    usage (EXIT_FAILURE);
+	  if (su_mode != RUNUSER_MODE) {
+	    warnx(_("invalid option -- 'u'"));
+	    errtryhelp(EXIT_FAILURE);
+	  }
 	  runuser_user = optarg;
 	  break;
 
 	case 'h':
-	  usage(0);
+	  usage();
 
 	case 'V':
 	  printf(UTIL_LINUX_VERSION);

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -795,8 +795,9 @@ static void sushell(struct passwd *pwd)
 	warn(_("failed to execute %s"), "/bin/sh");
 }
 
-static void usage(FILE *out)
+static void usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(
 		" %s [options] [tty device]\n"), program_invocation_short_name);
@@ -872,11 +873,10 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 			return EXIT_SUCCESS;
 		default:
-			usage(stderr);
-			/* Do not exit! */
+			/* Do not exit! getopt prints a warning. */
 			break;
 		}
 	}

--- a/login-utils/utmpdump.c
+++ b/login-utils/utmpdump.c
@@ -296,8 +296,9 @@ static void undump(FILE *in, FILE *out)
 	free(linestart);
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 
 	fprintf(out,
@@ -314,7 +315,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 
 	fprintf(out, USAGE_MAN_TAIL("utmpdump(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -356,7 +357,7 @@ int main(int argc, char **argv)
 			break;
 
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);

--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -296,8 +296,9 @@ static void edit_file(int is_shadow)
 	ulckpwdf();
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, " %s\n", program_invocation_short_name);
 
@@ -308,7 +309,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("vipw(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -339,7 +340,7 @@ int main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/misc-utils/blkid.c
+++ b/misc-utils/blkid.c
@@ -68,9 +68,9 @@ static void print_version(FILE *out)
 		LIBBLKID_VERSION, LIBBLKID_DATE);
 }
 
-static void usage(int error)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	FILE *out = error ? stderr : stdout;
+	FILE *out = stdout;
 
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(	" %s --label <label> | --uuid <uuid>\n\n"), program_invocation_short_name);
@@ -106,7 +106,7 @@ static void usage(int error)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("blkid(8)"));
-	exit(error);
+	exit(EXIT_SUCCESS);
 }
 
 /*
@@ -794,7 +794,7 @@ int main(int argc, char **argv)
 			/* ignore - backward compatibility */
 			break;
 		case 'h':
-			usage(0);
+			usage();
 			break;
 		default:
 			errtryhelp(EXIT_FAILURE);

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -244,7 +244,7 @@ static int week_number(int day, int month, int32_t year, const struct cal_contro
 static int week_to_day(const struct cal_control *ctl);
 static int center_str(const char *src, char *dest, size_t dest_size, size_t width);
 static void center(const char *str, size_t len, int separate);
-static void __attribute__((__noreturn__)) usage(FILE *out);
+static void __attribute__((__noreturn__)) usage(void);
 
 int main(int argc, char **argv)
 {
@@ -394,7 +394,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -470,7 +470,8 @@ int main(int argc, char **argv)
 			ctl.req.month = local_time->tm_mon + 1;
 		break;
 	default:
-		usage(stderr);
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
 	}
 
 	if (0 < ctl.req.week) {
@@ -987,8 +988,9 @@ static void center(const char *str, size_t len, int separate)
 	}
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [[[day] month] year]\n"), program_invocation_short_name);
 	fprintf(out, _(" %s [options] <timestamp|monthname>\n"), program_invocation_short_name);
@@ -1017,5 +1019,5 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("cal(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -258,8 +258,9 @@ static int fincore_name(struct fincore_control *ctl,
 	return rc;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -283,7 +284,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("fincore(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char ** argv)
@@ -334,7 +335,7 @@ int main(int argc, char ** argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/misc-utils/findfs.c
+++ b/misc-utils/findfs.c
@@ -22,9 +22,9 @@
 #define FINDFS_NOT_FOUND	1	/* label or uuid cannot be found */
 #define FINDFS_USAGE_ERROR	2	/* user did something unexpected */
 
-static void __attribute__((__noreturn__)) usage(int rc)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	FILE *out = rc ? stderr : stdout;
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] {LABEL,UUID,PARTUUID,PARTLABEL}=<value>\n"),
 		program_invocation_short_name);
@@ -36,7 +36,7 @@ static void __attribute__((__noreturn__)) usage(int rc)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("findfs(8)"));
-	exit(rc);
+	exit(FINDFS_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -54,10 +54,12 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
-	if (argc != 2)
+	if (argc != 2) {
 		/* we return '2' for backward compatibility
 		 * with version from e2fsprogs */
-		usage(FINDFS_USAGE_ERROR);
+		warnx(_("bad usage"));
+		errtryhelp(FINDFS_USAGE_ERROR);
+	}
 
 	while ((c = getopt_long(argc, argv, "Vh", longopts, NULL)) != -1)
 		switch (c) {
@@ -65,7 +67,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return FINDFS_SUCCESS;
 		case 'h':
-			usage(FINDFS_SUCCESS);
+			usage();
 		default:
 			errtryhelp(FINDFS_USAGE_ERROR);
 		}

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1182,8 +1182,9 @@ static int uniq_fs_target_cmp(
 	return !mnt_fs_match_target(a, mnt_fs_get_target(b), cache);
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -1254,7 +1255,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("findmnt(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -1377,7 +1378,7 @@ int main(int argc, char *argv[])
 			flags |= FL_EVALUATE;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'i':
 			flags |= FL_INVERT;

--- a/misc-utils/getopt.c
+++ b/misc-utils/getopt.c
@@ -243,9 +243,7 @@ static void __attribute__ ((__noreturn__)) parse_error(const char *message)
 {
 	if (message)
 		warnx("%s", message);
-	fprintf(stderr, _("Try `%s --help' for more information.\n"),
-		program_invocation_short_name);
-	exit(PARAMETER_EXIT_CODE);
+	errtryhelp(PARAMETER_EXIT_CODE);
 }
 
 
@@ -325,33 +323,33 @@ static shell_t shell_type(const char *new_shell)
 	parse_error(_("unknown shell after -s or --shell argument"));
 }
 
-static void __attribute__ ((__noreturn__)) print_help(void)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	fputs(USAGE_HEADER, stderr);
-	fprintf(stderr, _(
+	fputs(USAGE_HEADER, stdout);
+	printf(_(
 		" %1$s <optstring> <parameters>\n"
 		" %1$s [options] [--] <optstring> <parameters>\n"
 		" %1$s [options] -o|--options <optstring> [options] [--] <parameters>\n"),
 		program_invocation_short_name);
 
-	fputs(USAGE_SEPARATOR, stderr);
-	fputs(_("Parse command options.\n"), stderr);
+	fputs(USAGE_SEPARATOR, stdout);
+	fputs(_("Parse command options.\n"), stdout);
 
-	fputs(USAGE_OPTIONS, stderr);
-	fputs(_(" -a, --alternative             allow long options starting with single -\n"), stderr);
-	fputs(_(" -l, --longoptions <longopts>  the long options to be recognized\n"), stderr);
-	fputs(_(" -n, --name <progname>         the name under which errors are reported\n"), stderr);
-	fputs(_(" -o, --options <optstring>     the short options to be recognized\n"), stderr);
-	fputs(_(" -q, --quiet                   disable error reporting by getopt(3)\n"), stderr);
-	fputs(_(" -Q, --quiet-output            no normal output\n"), stderr);
-	fputs(_(" -s, --shell <shell>           set quoting conventions to those of <shell>\n"), stderr);
-	fputs(_(" -T, --test                    test for getopt(1) version\n"), stderr);
-	fputs(_(" -u, --unquoted                do not quote the output\n"), stderr);
-	fputs(USAGE_SEPARATOR, stderr);
-	fputs(USAGE_HELP, stderr);
-	fputs(USAGE_VERSION, stderr);
-	fprintf(stderr, USAGE_MAN_TAIL("getopt(1)"));
-	exit(PARAMETER_EXIT_CODE);
+	fputs(USAGE_OPTIONS, stdout);
+	fputs(_(" -a, --alternative             allow long options starting with single -\n"), stdout);
+	fputs(_(" -l, --longoptions <longopts>  the long options to be recognized\n"), stdout);
+	fputs(_(" -n, --name <progname>         the name under which errors are reported\n"), stdout);
+	fputs(_(" -o, --options <optstring>     the short options to be recognized\n"), stdout);
+	fputs(_(" -q, --quiet                   disable error reporting by getopt(3)\n"), stdout);
+	fputs(_(" -Q, --quiet-output            no normal output\n"), stdout);
+	fputs(_(" -s, --shell <shell>           set quoting conventions to those of <shell>\n"), stdout);
+	fputs(_(" -T, --test                    test for getopt(1) version\n"), stdout);
+	fputs(_(" -u, --unquoted                do not quote the output\n"), stdout);
+	fputs(USAGE_SEPARATOR, stdout);
+	fputs(USAGE_HELP, stdout);
+	fputs(USAGE_VERSION, stdout);
+	printf(USAGE_MAN_TAIL("getopt(1)"));
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -417,7 +415,7 @@ int main(int argc, char *argv[])
 			getopt_long_fp = getopt_long_only;
 			break;
 		case 'h':
-			print_help();
+			usage();
 		case 'o':
 			free(ctl.optstr);
 			ctl.optstr = xstrdup(optarg);

--- a/misc-utils/kill.c
+++ b/misc-utils/kill.c
@@ -296,8 +296,9 @@ static int arg_to_signum(char *arg, int maskbit)
 	return signame_to_signum(arg);
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <pid>|<name>...\n"), program_invocation_short_name);
 
@@ -321,7 +322,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("kill(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static char **parse_arguments(int argc, char **argv, struct kill_control *ctl)
@@ -345,7 +346,7 @@ static char **parse_arguments(int argc, char **argv, struct kill_control *ctl)
 			exit(EXIT_SUCCESS);
 		}
 		if (!strcmp(arg, "-h") || !strcmp(arg, "--help"))
-			usage(stdout);
+			usage();
 		if (!strcmp(arg, "--verbose")) {
 			ctl->verbose = 1;
 			continue;

--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -988,8 +988,9 @@ static void logger_close(const struct logger_ctl *ctl)
 	free(ctl->hdr);
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [<message>]\n"), program_invocation_short_name);
 
@@ -1030,7 +1031,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("logger(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 /*
@@ -1160,7 +1161,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'h':
-			usage(stdout);
+			usage();
 		case OPT_OCTET_COUNT:
 			ctl.octet_count = 1;
 			break;

--- a/misc-utils/look.c
+++ b/misc-utils/look.c
@@ -78,7 +78,7 @@ static int compare (char *, char *);
 static char *linear_search (char *, char *);
 static int look (char *, char *);
 static void print_from (char *, char *);
-static void __attribute__ ((__noreturn__)) usage(FILE * out);
+static void __attribute__((__noreturn__)) usage(void);
 
 int
 main(int argc, char *argv[])
@@ -126,7 +126,7 @@ main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -143,7 +143,8 @@ main(int argc, char *argv[])
 		string = *argv;
 		break;
 	default:
-		usage(stderr);
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
 	}
 
 	if (termchar != '\0' && (p = strchr(string, termchar)) != NULL)
@@ -348,8 +349,9 @@ compare(char *s2, char *s2end) {
 	return ((i > 0) ? LESS : (i < 0) ? GREATER : EQUAL);
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <string> [<file>...]\n"), program_invocation_short_name);
 
@@ -367,5 +369,5 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("look(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -1622,8 +1622,9 @@ static int cmp_u64_cells(struct libscols_cell *a,
 	return *adata == *bdata ? 0 : *adata >= *bdata ? 1 : -1;
 }
 
-static void __attribute__((__noreturn__)) help(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -1667,7 +1668,7 @@ static void __attribute__((__noreturn__)) help(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("lsblk(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void check_sysdevblock(void)
@@ -1766,7 +1767,7 @@ int main(int argc, char *argv[])
 			parse_excludes(optarg);
 			break;
 		case 'h':
-			help(stdout);
+			usage();
 			break;
 		case 'J':
 			lsblk->flags |= LSBLK_JSON;

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -484,8 +484,9 @@ static int show_locks(struct list_head *locks)
 }
 
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -516,7 +517,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 
 	fprintf(out, USAGE_MAN_TAIL("lslocks(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -569,7 +570,7 @@ int main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'n':
 			no_headings = 1;
 			break;

--- a/misc-utils/mcookie.c
+++ b/misc-utils/mcookie.c
@@ -76,8 +76,9 @@ static uint64_t hash_file(struct mcookie_control *ctl, int fd)
 	return count;
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options]\n"), program_invocation_short_name);
 
@@ -94,7 +95,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("mcookie(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void randomness_from_files(struct mcookie_control *ctl)
@@ -167,7 +168,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/misc-utils/namei.c
+++ b/misc-utils/namei.c
@@ -320,10 +320,10 @@ print_namei(struct namei *nm, char *path)
 	return 0;
 }
 
-static void usage(int rc)
+static void __attribute__((__noreturn__)) usage(void)
 {
 	const char *p = program_invocation_short_name;
-	FILE *out = rc == EXIT_FAILURE ? stderr : stdout;
+	FILE *out = stdout;
 
 	if (!*p)
 		p = "namei";
@@ -346,7 +346,7 @@ static void usage(int rc)
 		" -v, --vertical      vertical align of modes and owners\n"), out);
 
 	fprintf(out, USAGE_MAN_TAIL("namei(1)"));
-	exit(rc);
+	exit(EXIT_SUCCESS);
 }
 
 static const struct option longopts[] =
@@ -376,7 +376,7 @@ main(int argc, char **argv)
 	while ((c = getopt_long(argc, argv, "hVlmnovx", longopts, NULL)) != -1) {
 		switch(c) {
 		case 'h':
-			usage(EXIT_SUCCESS);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
@@ -406,7 +406,7 @@ main(int argc, char **argv)
 
 	if (optind == argc) {
 		warnx(_("pathname argument is missing"));
-		usage(EXIT_FAILURE);
+		errtryhelp(EXIT_FAILURE);
 	}
 
 	ucache = new_idcache();

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -127,8 +127,9 @@ static int do_file(char *from, char *to, char *s, int verbose, int noact, int no
 	return ret;
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options] <expression> <replacement> <file>...\n"),
@@ -146,7 +147,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("rename(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -188,7 +189,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -198,7 +199,7 @@ int main(int argc, char **argv)
 
 	if (argc < 3) {
 		warnx(_("not enough arguments"));
-		usage(stderr);
+		errtryhelp(EXIT_FAILURE);
 	}
 
 	from = argv[0];

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -58,8 +58,9 @@ struct uuidd_cxt_t {
 			no_sock: 1;
 };
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options]\n"), program_invocation_short_name);
 	fputs(USAGE_SEPARATOR, out);
@@ -81,7 +82,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("uuidd(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void create_daemon(void)
@@ -633,7 +634,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/misc-utils/uuidgen.c
+++ b/misc-utils/uuidgen.c
@@ -18,8 +18,9 @@
 #include "c.h"
 #include "closestream.h"
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options]\n"), program_invocation_short_name);
@@ -34,7 +35,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("uuidgen(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int
@@ -70,7 +71,7 @@ main (int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/misc-utils/wipefs.c
+++ b/misc-utils/wipefs.c
@@ -451,8 +451,9 @@ do_wipe(struct wipe_desc *wp, const char *devname, int flags)
 
 
 static void __attribute__((__noreturn__))
-usage(FILE *out)
+usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options] <device>\n"), program_invocation_short_name);
@@ -474,7 +475,7 @@ usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("wipefs(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 
@@ -525,7 +526,7 @@ main(int argc, char **argv)
 			flags |= WP_FL_FORCE;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'n':
 			flags |= WP_FL_NOACT;
@@ -552,8 +553,11 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (optind == argc)
-		usage(stderr);
+	if (optind == argc) {
+		warnx(_("no device specified"));
+		errtryhelp(EXIT_FAILURE);
+
+	}
 
 	if ((flags & WP_FL_BACKUP) && !((flags & WP_FL_ALL) || has_offset))
 		warnx(_("The --backup option is meaningless in this context"));

--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -128,9 +128,9 @@ struct chrt_ctl {
 		     verbose : 1;		/* verbose output */
 };
 
-static void __attribute__((__noreturn__)) show_usage(int rc)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	FILE *out = rc == EXIT_SUCCESS ? stdout : stderr;
+	FILE *out = stdout;
 
 	fputs(_("Show or change the real-time scheduling attributes of a process.\n"), out);
 	fputs(USAGE_SEPARATOR, out);
@@ -169,7 +169,7 @@ static void __attribute__((__noreturn__)) show_usage(int rc)
 	fputs(USAGE_VERSION, out);
 
 	fprintf(out, USAGE_MAN_TAIL("chrt(1)"));
-	exit(rc);
+	exit(EXIT_SUCCESS);
 }
 
 static const char *get_policy_name(int policy)
@@ -494,15 +494,17 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			show_usage(EXIT_SUCCESS);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 	}
 
 	if (((ctl->pid > -1) && argc - optind < 1) ||
-	    ((ctl->pid == -1) && argc - optind < 2))
-		show_usage(EXIT_FAILURE);
+	    ((ctl->pid == -1) && argc - optind < 2)) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+}
 
 	if ((ctl->pid > -1) && (ctl->verbose || argc - optind == 1)) {
 		show_sched_info(ctl);

--- a/schedutils/ionice.c
+++ b/schedutils/ionice.c
@@ -98,8 +98,9 @@ static void ioprio_setid(int which, int ioclass, int data, int who)
 		err(EXIT_FAILURE, _("ioprio_set failed"));
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,  _(" %1$s [options] -p <pid>...\n"
 			" %1$s [options] -P <pgid>...\n"
@@ -125,7 +126,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 
 	fprintf(out, USAGE_MAN_TAIL("ionice(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -201,7 +202,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -258,9 +259,10 @@ int main(int argc, char **argv)
 		ioprio_setid(0, ioclass, data, IOPRIO_WHO_PROCESS);
 		execvp(argv[optind], &argv[optind]);
 		err(EXIT_FAILURE, _("failed to execute %s"), argv[optind]);
-	} else
-		usage(stderr);
-
+	} else {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	return EXIT_SUCCESS;
 }

--- a/schedutils/taskset.c
+++ b/schedutils/taskset.c
@@ -45,8 +45,9 @@ struct taskset {
 			get_only:1;	/* print the mask, but not modify */
 };
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fprintf(out,
 		_("Usage: %s [options] [mask | cpu-list] [pid|cmd [args...]]\n\n"),
 		program_invocation_short_name);
@@ -78,7 +79,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("taskset(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void print_affinity(struct taskset *ts, int isnew)
@@ -176,7 +177,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		default:
 			errtryhelp(EXIT_FAILURE);
@@ -184,8 +185,10 @@ int main(int argc, char **argv)
 	}
 
 	if ((!pid && argc - optind < 2)
-	    || (pid && (argc - optind < 1 || argc - optind > 2)))
-		usage(stderr);
+	    || (pid && (argc - optind < 1 || argc - optind > 2))) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	ncpus = get_max_number_of_cpus();
 	if (ncpus <= 0)

--- a/sys-utils/blkdiscard.c
+++ b/sys-utils/blkdiscard.c
@@ -77,8 +77,9 @@ static void print_stats(int act, char *path, uint64_t stats[])
 	}
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options] <device>\n"), program_invocation_short_name);
@@ -99,7 +100,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 
 	fprintf(out, USAGE_MAN_TAIL("blkdiscard(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 
@@ -136,7 +137,7 @@ int main(int argc, char **argv)
 	while ((c = getopt_long(argc, argv, "hVsvo:l:p:z", longopts, NULL)) != -1) {
 		switch(c) {
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
@@ -174,7 +175,7 @@ int main(int argc, char **argv)
 
 	if (optind != argc) {
 		warnx(_("unexpected number of arguments"));
-		usage(stderr);
+		errtryhelp(EXIT_FAILURE);
 	}
 
 	fd = open(path, O_WRONLY);

--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -290,8 +290,9 @@ static int blkzone_reset(struct blkzone_control *ctl)
 	return 0;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -314,7 +315,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 
 	fprintf(out, USAGE_MAN_TAIL("blkzone(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -362,7 +363,7 @@ int main(int argc, char **argv)
 
 		switch (c) {
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'c':
 			ctl.count = strtou32_or_err(optarg,

--- a/sys-utils/chcpu.c
+++ b/sys-utils/chcpu.c
@@ -232,8 +232,9 @@ static void cpu_parse(char *cpu_string, cpu_set_t *cpu_set, size_t setsize)
 	errx(EXIT_FAILURE, _("failed to parse CPU list: %s"), cpu_string);
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fprintf(out, _(
 		"\nUsage:\n"
 		" %s [options]\n"), program_invocation_short_name);
@@ -251,7 +252,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 		"  -r, --rescan                  trigger rescan of cpus\n"
 		"  -V, --version                 output version information and exit\n"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -316,7 +317,7 @@ int main(int argc, char *argv[])
 			cpu_parse(argv[optind - 1], cpu_set, setsize);
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'p':
 			if (strcmp("horizontal", argv[optind - 1]) == 0)
 				cmd = CMD_CPU_DISPATCH_HORIZONTAL;
@@ -337,8 +338,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if ((argc == 1) || (argc != optind))
-		usage(stderr);
+	if ((argc == 1) || (argc != optind)) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	switch (cmd) {
 	case CMD_CPU_ENABLE:

--- a/sys-utils/chmem.c
+++ b/sys-utils/chmem.c
@@ -234,8 +234,9 @@ static void parse_parameter(struct chmem_desc *desc, char *param)
 		errx(EXIT_FAILURE, _("Invalid range: %s"), param);
 }
 
-static void __attribute__((__noreturn__)) chmem_usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [SIZE|RANGE|BLOCKRANGE]\n"), program_invocation_short_name);
 
@@ -253,7 +254,7 @@ static void __attribute__((__noreturn__)) chmem_usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("chmem(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -300,7 +301,7 @@ int main(int argc, char **argv)
 			desc->use_blocks = 1;
 			break;
 		case 'h':
-			chmem_usage(stdout);
+			usage();
 			break;
 		case 'v':
 			desc->verbose = 1;
@@ -313,8 +314,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if ((argc == 1) || (argc != optind + 1) || (cmd == CMD_NONE))
-		chmem_usage(stderr);
+	if ((argc == 1) || (argc != optind + 1) || (cmd == CMD_NONE)) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	parse_parameter(desc, argv[optind]);
 

--- a/sys-utils/ctrlaltdel.c
+++ b/sys-utils/ctrlaltdel.c
@@ -21,19 +21,20 @@
 #define LINUX_REBOOT_CMD_CAD_ON 0x89ABCDEF
 #define LINUX_REBOOT_CMD_CAD_OFF 0x00000000
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	fprintf(out, USAGE_HEADER);
+	FILE *out = stdout;
+	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s hard|soft\n"), program_invocation_short_name);
 
-	fprintf(out, USAGE_SEPARATOR);
+	fputs(USAGE_SEPARATOR, out);
 	fprintf(out, _("Set the function of the Ctrl-Alt-Del combination.\n"));
 
-	fprintf(out, USAGE_OPTIONS);
-	fprintf(out, USAGE_HELP);
-	fprintf(out, USAGE_VERSION);
+	fputs(USAGE_OPTIONS, out);
+	fputs(USAGE_HELP, out);
+	fputs(USAGE_VERSION,out);
 	fprintf(out, USAGE_MAN_TAIL("ctrlaltdel(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int get_cad(void)
@@ -98,7 +99,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -266,8 +266,9 @@ static int set_level_color(int log_level, const char *mesg, size_t mesgsz)
 	return id >= 0 ? 0 : -1;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -320,7 +321,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 			_(level_names[i].help));
 	fputs(USAGE_SEPARATOR, out);
 	fprintf(out, USAGE_MAN_TAIL("dmesg(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 /*
@@ -1422,7 +1423,7 @@ int main(int argc, char *argv[])
 			ctl.pager = 1;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'k':
 			ctl.fltr_fac = 1;
@@ -1487,8 +1488,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (argc != optind)
-		usage(stderr);
+	if (argc != optind) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	if ((is_timefmt(&ctl, RELTIME) ||
 	     is_timefmt(&ctl, CTIME)   ||

--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -127,8 +127,9 @@ static inline void info(const char *fmt, ...)
 	va_end(va);
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 		_(" %s [options] [<device>|<mountpoint>]\n"), program_invocation_short_name);
@@ -164,7 +165,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(_("\nBy default tries -r, -s, -f, and -q in order until success.\n"), out);
 	fprintf(out, USAGE_MAN_TAIL("eject(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 
@@ -223,7 +224,7 @@ static void parse_args(struct eject_control *ctl, int argc, char **argv)
 			ctl->F_option = 1;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'i':
 			ctl->i_option = 1;

--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -76,8 +76,9 @@
 static int verbose;
 static char *filename;
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options] <filename>\n"), program_invocation_short_name);
@@ -105,7 +106,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("fallocate(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static loff_t cvtnum(char *s)
@@ -329,7 +330,7 @@ int main(int argc, char **argv)
 
 		switch(c) {
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'c':
 			mode |= FALLOC_FL_COLLAPSE_RANGE;

--- a/sys-utils/flock.c
+++ b/sys-utils/flock.c
@@ -46,34 +46,34 @@
 #include "monotonic.h"
 #include "timer.h"
 
-static void __attribute__((__noreturn__)) usage(int ex)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	fprintf(stderr, USAGE_HEADER);
-	fprintf(stderr,
+	fputs(USAGE_HEADER, stdout);
+	printf(
 		_(" %1$s [options] <file>|<directory> <command> [<argument>...]\n"
 		  " %1$s [options] <file>|<directory> -c <command>\n"
 		  " %1$s [options] <file descriptor number>\n"),
 		program_invocation_short_name);
 
-	fputs(USAGE_SEPARATOR, stderr);
-	fputs(_("Manage file locks from shell scripts.\n"), stderr);
+	fputs(USAGE_SEPARATOR, stdout);
+	fputs(_("Manage file locks from shell scripts.\n"), stdout);
 
-	fputs(USAGE_OPTIONS, stderr);
-	fputs(_(  " -s, --shared             get a shared lock\n"), stderr);
-	fputs(_(  " -x, --exclusive          get an exclusive lock (default)\n"), stderr);
-	fputs(_(  " -u, --unlock             remove a lock\n"), stderr);
-	fputs(_(  " -n, --nonblock           fail rather than wait\n"), stderr);
-	fputs(_(  " -w, --timeout <secs>     wait for a limited amount of time\n"), stderr);
-	fputs(_(  " -E, --conflict-exit-code <number>  exit code after conflict or timeout\n"), stderr);
-	fputs(_(  " -o, --close              close file descriptor before running command\n"), stderr);
-	fputs(_(  " -c, --command <command>  run a single command string through the shell\n"), stderr);
-	fputs(_(  " -F, --no-fork            execute command without forking\n"), stderr);
-	fputs(_(  "     --verbose            increase verbosity\n"), stderr);
-	fprintf(stderr, USAGE_SEPARATOR);
-	fprintf(stderr, USAGE_HELP);
-	fprintf(stderr, USAGE_VERSION);
-	fprintf(stderr, USAGE_MAN_TAIL("flock(1)"));
-	exit(ex);
+	fputs(USAGE_OPTIONS, stdout);
+	fputs(_(  " -s, --shared             get a shared lock\n"), stdout);
+	fputs(_(  " -x, --exclusive          get an exclusive lock (default)\n"), stdout);
+	fputs(_(  " -u, --unlock             remove a lock\n"), stdout);
+	fputs(_(  " -n, --nonblock           fail rather than wait\n"), stdout);
+	fputs(_(  " -w, --timeout <secs>     wait for a limited amount of time\n"), stdout);
+	fputs(_(  " -E, --conflict-exit-code <number>  exit code after conflict or timeout\n"), stdout);
+	fputs(_(  " -o, --close              close file descriptor before running command\n"), stdout);
+	fputs(_(  " -c, --command <command>  run a single command string through the shell\n"), stdout);
+	fputs(_(  " -F, --no-fork            execute command without forking\n"), stdout);
+	fputs(_(  "     --verbose            increase verbosity\n"), stdout);
+	fputs(USAGE_SEPARATOR, stdout);
+	fputs(USAGE_HELP, stdout);
+	fputs(USAGE_VERSION, stdout);
+	printf(USAGE_MAN_TAIL("flock(1)"));
+	exit(EXIT_SUCCESS);
 }
 
 static sig_atomic_t timeout_expired = 0;
@@ -172,8 +172,10 @@ int main(int argc, char *argv[])
 
 	strutils_set_exitcode(EX_USAGE);
 
-	if (argc < 2)
-		usage(EX_USAGE);
+	if (argc < 2) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EX_USAGE);
+	}
 
 	memset(&timeout, 0, sizeof timeout);
 
@@ -217,7 +219,7 @@ int main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			exit(EX_OK);
 		case 'h':
-			usage(0);
+			usage();
 		default:
 			errtryhelp(EX_USAGE);
 		}

--- a/sys-utils/fsfreeze.c
+++ b/sys-utils/fsfreeze.c
@@ -33,9 +33,10 @@ enum fs_operation {
 	UNFREEZE
 };
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	fprintf(out, USAGE_HEADER);
+	FILE *out = stdout;
+	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options] <mountpoint>\n"), program_invocation_short_name);
 
@@ -45,12 +46,12 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -f, --freeze      freeze the filesystem\n"), out);
 	fputs(_(" -u, --unfreeze    unfreeze the filesystem\n"), out);
-	fprintf(out, USAGE_SEPARATOR);
-	fprintf(out, USAGE_HELP);
-	fprintf(out, USAGE_VERSION);
+	fputs(USAGE_SEPARATOR, out);
+	fputs(USAGE_HELP, out);
+	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("fsfreeze(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -85,7 +86,7 @@ int main(int argc, char **argv)
 
 		switch(c) {
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'f':
 			action = FREEZE;
@@ -109,7 +110,7 @@ int main(int argc, char **argv)
 
 	if (optind != argc) {
 		warnx(_("unexpected number of arguments"));
-		usage(stderr);
+		errtryhelp(EXIT_FAILURE);
 	}
 
 	fd = open(path, O_RDONLY);

--- a/sys-utils/fstrim.c
+++ b/sys-utils/fstrim.c
@@ -244,8 +244,9 @@ static int fstrim_all(struct fstrim_range *rangetpl, int verbose)
 	return EXIT_SUCCESS;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options] <mount point>\n"), program_invocation_short_name);
@@ -264,7 +265,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("fstrim(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -298,7 +299,7 @@ int main(int argc, char **argv)
 			all = 1;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
@@ -332,7 +333,7 @@ int main(int argc, char **argv)
 
 	if (optind != argc) {
 		warnx(_("unexpected number of arguments"));
-		usage(stderr);
+		errtryhelp(EXIT_FAILURE);
 	}
 
 	if (all)

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -1200,8 +1200,9 @@ static void out_version(void)
 }
 
 static void __attribute__((__noreturn__))
-usage(const struct hwclock_control *ctl, FILE *out)
+usage(const struct hwclock_control *ctl)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fputs(_(" hwclock [function] [option...]\n"), out);
 
@@ -1451,7 +1452,7 @@ int main(int argc, char **argv)
 			out_version();
 			return 0;
 		case 'h':			/* --help */
-			usage(&ctl, stdout);
+			usage(&ctl);
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/sys-utils/ipcmk.c
+++ b/sys-utils/ipcmk.c
@@ -60,8 +60,9 @@ static int create_sem(int nsems, int permission)
 	return semget(key, nsems, permission | IPC_CREAT);
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options]\n"), program_invocation_short_name);
 
@@ -79,7 +80,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("ipcmk(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -121,7 +122,7 @@ int main(int argc, char **argv)
 			permission = strtoul(optarg, NULL, 8);
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
@@ -131,9 +132,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if(!ask_shm && !ask_msg && !ask_sem)
-		usage(stderr);
-
+	if(!ask_shm && !ask_msg && !ask_sem) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	if (ask_shm) {
 		int shmid;
 		if (-1 == (shmid = create_shm(size, permission)))

--- a/sys-utils/ipcrm.c
+++ b/sys-utils/ipcrm.c
@@ -44,8 +44,9 @@ typedef enum type_id {
 static int verbose = 0;
 
 /* print the usage */
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %1$s [options]\n"
 		       " %1$s shm|msg|sem <id>...\n"), program_invocation_short_name);
@@ -68,7 +69,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("ipcrm(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int remove_id(int type, int iskey, int id)
@@ -158,7 +159,7 @@ static int deprecated_main(int argc, char **argv)
 
 	if (argc < 3) {
 		warnx(_("not enough arguments"));
-		usage(stderr);
+		errtryhelp(EXIT_FAILURE);
 	}
 
 	if (remove_arg_list(type, argc - 2, &argv[2]))
@@ -401,7 +402,7 @@ int main(int argc, char **argv)
 			verbose = 1;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;

--- a/sys-utils/ipcs.c
+++ b/sys-utils/ipcs.c
@@ -46,8 +46,9 @@ static void print_msg (int id, int unit);
 /* we read time as int64_t from /proc, so cast... */
 #define xctime(_x)	ctime((time_t *) (_x))
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %1$s [resource-option...] [output-option]\n"
 		       " %1$s -m|-q|-s -i <id>\n"), program_invocation_short_name);
@@ -78,7 +79,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(_(" -b, --bytes       show sizes in bytes\n"), out);
 	fprintf(out, USAGE_MAN_TAIL("ipcs(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main (int argc, char **argv)
@@ -150,7 +151,7 @@ int main (int argc, char **argv)
 			unit = IPC_UNIT_BYTES;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;

--- a/sys-utils/ldattach.c
+++ b/sys-utils/ldattach.c
@@ -188,9 +188,9 @@ static int parse_iflag(char *str, int *set_iflag, int *clr_iflag)
 }
 
 
-static void __attribute__ ((__noreturn__)) usage(int exitcode)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	FILE *out = exitcode == EXIT_SUCCESS ? stdout : stderr;
+	FILE *out = stdout;
 
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <ldisc> <device>\n"), program_invocation_short_name);
@@ -224,7 +224,7 @@ static void __attribute__ ((__noreturn__)) usage(int exitcode)
 	print_table(out, ld_iflags);
 
 	fprintf(out, USAGE_MAN_TAIL("ldattach(8)"));
-	exit(exitcode);
+	exit(EXIT_SUCCESS);
 }
 
 static int my_cfsetspeed(struct termios *ts, int speed)
@@ -315,7 +315,8 @@ int main(int argc, char **argv)
 
 	/* parse options */
 	if (argc == 0)
-		usage(EXIT_SUCCESS);
+		errx(EXIT_FAILURE, _("bad usage"));
+
 	while ((optc =
 		getopt_long(argc, argv, "dhV78neo12s:i:c:p:", opttbl,
 			    NULL)) >= 0) {
@@ -354,15 +355,16 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(EXIT_SUCCESS);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 	}
 
-	if (argc - optind != 2)
-		usage(EXIT_FAILURE);
-
+	if (argc - optind != 2) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	/* parse line discipline specification */
 	ldisc = lookup_table(ld_discs, argv[optind]);
 	if (ldisc < 0)

--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -375,8 +375,9 @@ done:
 	return rc;
 }
 
-static void usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -427,7 +428,7 @@ static void usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("losetup(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void warn_size(const char *filename, uint64_t size)
@@ -653,7 +654,7 @@ int main(int argc, char **argv)
 			act = A_FIND_FREE;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'J':
 			json = 1;
@@ -860,7 +861,8 @@ int main(int argc, char **argv)
 			        loopcxt_get_device(&lc));
 		break;
 	default:
-		usage(stderr);
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
 		break;
 	}
 

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -2044,8 +2044,9 @@ print_summary(struct lscpu_desc *desc, struct lscpu_modifier *mod)
 	scols_unref_table(tb);
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -2074,7 +2075,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("lscpu(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -2130,7 +2131,7 @@ int main(int argc, char *argv[])
 			cpu_modifier_specified = 1;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'J':
 			mod->json = 1;
 			break;
@@ -2173,8 +2174,10 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (argc != optind)
-		usage(stderr);
+	if (argc != optind) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	/* set default cpu display mode if none was specified */
 	if (!mod->online && !mod->offline) {

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -269,8 +269,9 @@ static int parse_time_mode(const char *s)
 	errx(EXIT_FAILURE, _("unknown time format: %s"), s);
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -327,7 +328,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
 
 	fprintf(out, USAGE_MAN_TAIL("lsipc(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static struct libscols_table *new_table(struct lsipc_control *ctl)
@@ -1223,12 +1224,12 @@ int main(int argc, char *argv[])
 			show_creat = 1;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		default:
-			usage(stderr);
+			errtryhelp(EXIT_FAILURE);
 		}
 	}
 

--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -363,8 +363,9 @@ static void read_basic_info(struct lsmem *lsmem)
 		lsmem->have_nodes = 1;
 }
 
-static void __attribute__((__noreturn__)) lsmem_usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	unsigned int i;
 
 	fputs(USAGE_HEADER, out);
@@ -449,7 +450,7 @@ int main(int argc, char **argv)
 			lsmem->bytes = 1;
 			break;
 		case 'h':
-			lsmem_usage(stdout);
+			usage();
 			break;
 		case 'J':
 			lsmem->json = 1;
@@ -493,8 +494,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (argc != optind)
-		lsmem_usage(stderr);
+	if (argc != optind) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	if (lsmem->want_table + lsmem->want_summary == 0)
 		errx(EXIT_FAILURE, _("options --{raw,json,pairs} and --summary=only are mutually exclusive"));

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -603,8 +603,9 @@ static int show_namespace_processes(struct lsns *ls, struct lsns_namespace *ns)
 	return 0;
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -635,7 +636,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 
 	fprintf(out, USAGE_MAN_TAIL("lsns(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 
@@ -698,7 +699,7 @@ int main(int argc, char *argv[])
 			ls.fltr_pid = strtos32_or_err(optarg, _("invalid PID argument"));
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'n':
 			ls.no_headings = 1;
 			break;

--- a/sys-utils/mount.c
+++ b/sys-utils/mount.c
@@ -384,8 +384,9 @@ static int has_remount_flag(struct libmnt_context *cxt)
 	return mflags & MS_REMOUNT;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(
 		" %1$s [-lhV]\n"
@@ -460,7 +461,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("mount(8)"));
 
-	exit(out == stderr ? MNT_EX_USAGE : MNT_EX_SUCCESS);
+	exit(MNT_EX_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -571,7 +572,7 @@ int main(int argc, char **argv)
 			mnt_context_enable_fork(cxt, TRUE);
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'i':
 			mnt_context_disable_helpers(cxt, TRUE);
@@ -694,8 +695,10 @@ int main(int argc, char **argv)
 	    !mnt_context_get_target(cxt) &&
 	    !argc &&
 	    !all) {
-		if (oper || mnt_context_get_options(cxt))
-			usage(stderr);
+		if (oper || mnt_context_get_options(cxt)) {
+			warnx(_("bad usage"));
+			errtryhelp(MNT_EX_USAGE);
+		}
 		print_all(cxt, types, show_labels);
 		goto done;
 	}
@@ -705,8 +708,10 @@ int main(int argc, char **argv)
 	if (mnt_context_is_restricted(cxt) && types)
 		exit_non_root("types");
 
-	if (oper && (types || all || mnt_context_get_source(cxt)))
-		usage(stderr);
+	if (oper && (types || all || mnt_context_get_source(cxt))) {
+		warnx(_("bad usage"));
+		errtryhelp(MNT_EX_USAGE);
+	}
 
 	if (types && (all || strchr(types, ',') ||
 			     strncmp(types, "no", 2) == 0))
@@ -772,8 +777,10 @@ int main(int argc, char **argv)
 		mnt_context_set_source(cxt, argv[0]);
 		mnt_context_set_target(cxt, argv[1]);
 
-	} else
-		usage(stderr);
+	} else {
+		warnx(_("bad usage"));
+		errtryhelp(MNT_EX_USAGE);
+	}
 
 	if (mnt_context_is_restricted(cxt))
 		sanitize_paths(cxt);

--- a/sys-utils/mountpoint.c
+++ b/sys-utils/mountpoint.c
@@ -111,8 +111,9 @@ static int print_devno(const struct mountpoint_control *ctl)
 	return 0;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %1$s [-qd] /path/to/directory\n"
@@ -130,7 +131,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("mountpoint(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -167,7 +168,7 @@ int main(int argc, char **argv)
 			ctl.dev_devno = 1;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
@@ -177,8 +178,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (optind + 1 != argc)
-		usage(stderr);
+	if (optind + 1 != argc) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	ctl.path = argv[optind];
 

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -65,9 +65,9 @@ static struct namespace_file {
 	{ .nstype = 0, .name = NULL, .fd = -1 }
 };
 
-static void __attribute__((__noreturn__)) usage(int status)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	FILE *out = status == EXIT_SUCCESS ? stdout : stderr;
+	FILE *out = stdout;
 
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [<program> [<argument>...]]\n"),
@@ -101,7 +101,7 @@ static void __attribute__((__noreturn__)) usage(int status)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("nsenter(1)"));
 
-	exit(status);
+	exit(EXIT_SUCCESS);
 }
 
 static pid_t namespace_target_pid = 0;
@@ -253,7 +253,7 @@ int main(int argc, char *argv[])
 			    longopts, NULL)) != -1) {
 		switch (c) {
 		case 'h':
-			usage(EXIT_SUCCESS);
+			usage();
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;

--- a/sys-utils/pivot_root.c
+++ b/sys-utils/pivot_root.c
@@ -27,20 +27,21 @@
 
 #define pivot_root(new_root,put_old) syscall(SYS_pivot_root,new_root,put_old)
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	fprintf(out, USAGE_HEADER);
+	FILE *out = stdout;
+	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] new_root put_old\n"),
 		program_invocation_short_name);
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Change the root filesystem.\n"), out);
 
-	fprintf(out, USAGE_OPTIONS);
-	fprintf(out, USAGE_HELP);
-	fprintf(out, USAGE_VERSION);
+	fputs(USAGE_OPTIONS, out);
+	fputs(USAGE_HELP, out);
+	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("pivot_root(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -63,14 +64,15 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 
-	if (argc != 3)
-		usage(stderr);
-
+	if (argc != 3) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	if (pivot_root(argv[1], argv[2]) < 0)
 		err(EXIT_FAILURE, _("failed to change root from `%s' to `%s'"),
 		    argv[1], argv[2]);

--- a/sys-utils/prlimit.c
+++ b/sys-utils/prlimit.c
@@ -151,8 +151,9 @@ static int prlimit(pid_t p, int resource,
 }
 #endif
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -199,7 +200,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 
 	fprintf(out, USAGE_MAN_TAIL("prlimit(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static inline int get_column_id(int num)
@@ -584,7 +585,7 @@ int main(int argc, char **argv)
 			pid = strtos32_or_err(optarg, _("invalid PID argument"));
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'o':
 			ncolumns = string_to_idarray(optarg,
 						     columns, ARRAY_SIZE(columns),

--- a/sys-utils/readprofile.c
+++ b/sys-utils/readprofile.c
@@ -97,9 +97,9 @@ static char *boot_uname_r_str(void)
 	return s;
 }
 
-static void __attribute__ ((__noreturn__))
-    usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options]\n"), program_invocation_short_name);
 
@@ -125,7 +125,7 @@ static void __attribute__ ((__noreturn__))
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("readprofile(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/sys-utils/renice.c
+++ b/sys-utils/renice.c
@@ -54,8 +54,9 @@ static const char *idtype[] = {
 	[PRIO_USER]	= N_("user ID"),
 };
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %1$s [-n] <priority> [-p|--pid] <pid>...\n"
@@ -75,7 +76,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("renice(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int getprio(const int which, const int who, int *prio)
@@ -127,7 +128,7 @@ int main(int argc, char **argv)
 	if (argc == 1) {
 		if (strcmp(*argv, "-h") == 0 ||
 		    strcmp(*argv, "--help") == 0)
-			usage(stdout);
+			usage();
 
 		if (strcmp(*argv, "-v") == 0 ||
 		    strcmp(*argv, "-V") == 0 ||
@@ -142,13 +143,16 @@ int main(int argc, char **argv)
 		argv++;
 	}
 
-	if (argc < 2)
-		usage(stderr);
+	if (argc < 2) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	prio = strtol(*argv, &endptr, 10);
-	if (*endptr)
-		usage(stderr);
-
+	if (*endptr) {
+		warnx(_("invalid priorty '%s'"), *argv);
+		errtryhelp(EXIT_FAILURE);
+	}
 	argc--;
 	argv++;
 

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -88,8 +88,9 @@ struct rtcwake_control {
 		     dryrun:1;		/* do not set alarm, suspend system, etc */
 };
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options]\n"), program_invocation_short_name);
@@ -113,13 +114,11 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(_(" -u, --utc                RTC uses UTC\n"), out);
 	fputs(_(" -v, --verbose            verbose messages\n"), out);
 
-	printf(USAGE_SEPARATOR);
-	printf(USAGE_HELP);
-	printf(USAGE_VERSION);
-
+	fputs(USAGE_SEPARATOR, out);
+	fputs(USAGE_HELP, out);
+	fputs(USAGE_VERSION, out);
 	printf(USAGE_MAN_TAIL("rtcwake(8)"));
-
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int is_wakeup_enabled(const char *devname)
@@ -496,9 +495,9 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
-			usage(stderr);
+			errtryhelp(EXIT_FAILURE);
 		}
 	}
 

--- a/sys-utils/setpriv.c
+++ b/sys-utils/setpriv.c
@@ -92,8 +92,9 @@ struct privctx {
 	const char *apparmor_profile;
 };
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <program> [<argument>...]\n"),
 		program_invocation_short_name);
@@ -127,7 +128,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(_(" This tool can be dangerous.  Read the manpage, and be careful.\n"), out);
 	fprintf(out, USAGE_MAN_TAIL("setpriv(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int real_cap_last_cap(void)
@@ -797,7 +798,7 @@ int main(int argc, char **argv)
 			opts.apparmor_profile = optarg;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;

--- a/sys-utils/setsid.c
+++ b/sys-utils/setsid.c
@@ -25,8 +25,9 @@
 #include "nls.h"
 #include "closestream.h"
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(
 		" %s [options] <program> [arguments ...]\n"),
@@ -43,7 +44,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 
 	fprintf(out, USAGE_MAN_TAIL("setsid(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -78,13 +79,15 @@ int main(int argc, char **argv)
 			status = 1;
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 
-	if (argc - optind < 1)
-		usage(stderr);
+	if (argc - optind < 1) {
+		warnx(_("no command specified"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	if (getpgrp() == getpid()) {
 		pid = fork();

--- a/sys-utils/swapoff.c
+++ b/sys-utils/swapoff.c
@@ -116,8 +116,9 @@ static int swapoff_by(const char *name, const char *value, int quiet)
 	return special ? do_swapoff(special, quiet, CANONIC) : cannot_find(value);
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [<spec>]\n"), program_invocation_short_name);
 
@@ -141,7 +142,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 		" <file>                 name of file to be used\n"), out);
 
 	fprintf(out, USAGE_MAN_TAIL("swapoff(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int swapoff_all(void)
@@ -207,7 +208,7 @@ int main(int argc, char *argv[])
 			++all;
 			break;
 		case 'h':		/* help */
-			usage(stdout);
+			usage();
 			break;
 		case 'v':		/* be chatty */
 			++verbose;
@@ -227,8 +228,10 @@ int main(int argc, char *argv[])
 	}
 	argv += optind;
 
-	if (!all && !numof_labels() && !numof_uuids() && *argv == NULL)
-		usage(stderr);
+	if (!all && !numof_labels() && !numof_uuids() && *argv == NULL) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	mnt_init_debug(0);
 	mntcache = mnt_new_cache();

--- a/sys-utils/swapon.c
+++ b/sys-utils/swapon.c
@@ -782,9 +782,11 @@ static int swapon_all(struct swapon_ctl *ctl)
 }
 
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
+
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [<spec>]\n"), program_invocation_short_name);
 
@@ -829,7 +831,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 		fprintf(out, " %-5s  %s\n", infos[i].name, _(infos[i].help));
 
 	fprintf(out, USAGE_MAN_TAIL("swapon(8)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -895,7 +897,7 @@ int main(int argc, char *argv[])
 			ctl.all = 1;
 			break;
 		case 'h':		/* help */
-			usage(stdout);
+			usage();
 			break;
 		case 'o':
 			options = optarg;
@@ -980,8 +982,10 @@ int main(int argc, char *argv[])
 		return status;
 	}
 
-	if (ctl.props.no_fail && !ctl.all)
-		usage(stderr);
+	if (ctl.props.no_fail && !ctl.all) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	if (ctl.all)
 		status |= swapon_all(&ctl);

--- a/sys-utils/switch_root.c
+++ b/sys-utils/switch_root.c
@@ -198,8 +198,9 @@ static int switchroot(const char *newroot)
 	return 0;
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *output)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *output = stdout;
 	fputs(USAGE_HEADER, output);
 	fprintf(output, _(" %s [options] <newrootdir> <init> <args to init>\n"),
 		program_invocation_short_name);
@@ -212,7 +213,7 @@ static void __attribute__((__noreturn__)) usage(FILE *output)
 	fputs(USAGE_VERSION, output);
 	fprintf(output, USAGE_MAN_TAIL("switch_root(8)"));
 
-	exit(output == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -233,19 +234,23 @@ int main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
-	if (argc < 3)
-		usage(stderr);
+	if (argc < 3) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	newroot = argv[1];
 	init = argv[2];
 	initargs = &argv[2];
 
-	if (!*newroot || !*init)
-		usage(stderr);
+	if (!*newroot || !*init) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	if (switchroot(newroot))
 		errx(EXIT_FAILURE, _("failed. Sorry."));

--- a/sys-utils/tunelp.c
+++ b/sys-utils/tunelp.c
@@ -87,8 +87,9 @@ struct command {
 	struct command *next;
 };
 
-static void __attribute__((__noreturn__)) print_usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <device>\n"), program_invocation_short_name);
 
@@ -115,7 +116,7 @@ static void __attribute__((__noreturn__)) print_usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("tunelp(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -148,8 +149,10 @@ int main(int argc, char **argv)
 
 	strutils_set_exitcode(EXIT_LP_BADVAL);
 
-	if (argc < 2)
-		print_usage(stderr);
+	if (argc < 2) {
+		warnx(_("not enough arguments"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	cmdst = cmds = xmalloc(sizeof(struct command));
 	cmds->next = NULL;
@@ -158,7 +161,7 @@ int main(int argc, char **argv)
 	while ((c = getopt_long(argc, argv, "t:c:w:a:i:ho:C:sq:rT:vV", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'h':
-			print_usage(stdout);
+			usage();
 			break;
 		case 'i':
 			cmds->op = LPSETIRQ;
@@ -246,8 +249,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (optind != argc - 1)
-		print_usage(stderr);
+	if (optind != argc - 1) {
+		warnx(_("no device specified"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	filename = xstrdup(argv[optind]);
 	fd = open(filename, O_WRONLY | O_NONBLOCK, 0);
@@ -263,7 +268,7 @@ int main(int argc, char **argv)
 
 	if (!S_ISCHR(statbuf.st_mode)) {
 		warnx(_("%s not an lp device"), filename);
-		print_usage(stderr);
+		errtryhelp(EXIT_FAILURE);
 	}
 	/* Allow for binaries compiled under a new kernel to work on
 	 * the old ones The irq argument to ioctl isn't touched by

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -71,8 +71,9 @@ static void __attribute__((__noreturn__)) print_version(void)
 	fputs(")\n", stdout);
 	exit(MNT_EX_SUCCESS);
 }
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(
 		" %1$s [-hV]\n"
@@ -105,7 +106,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("umount(8)"));
 
-	exit(out == stderr ? MNT_EX_USAGE : MNT_EX_SUCCESS);
+	exit(MNT_EX_SUCCESS);
 }
 
 static void __attribute__((__noreturn__)) exit_non_root(const char *option)
@@ -479,7 +480,7 @@ int main(int argc, char **argv)
 			mnt_context_enable_force(cxt, TRUE);
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		case 'i':
 			mnt_context_disable_helpers(cxt, TRUE);
@@ -525,7 +526,8 @@ int main(int argc, char **argv)
 		rc = umount_all(cxt);
 
 	} else if (argc < 1) {
-		usage(stderr);
+		warnx(_("bad usage"));
+		errtryhelp(MNT_EX_USAGE);
 
 	} else if (alltargets) {
 		while (argc--)

--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -238,9 +238,9 @@ static void bind_ns_files_from_child(pid_t *child, int fds[2])
 	}
 }
 
-static void __attribute__((__noreturn__)) usage(int status)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	FILE *out = status == EXIT_SUCCESS ? stdout : stderr;
+	FILE *out = stdout;
 
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [<program> [<argument>...]]\n"),
@@ -269,7 +269,7 @@ static void __attribute__((__noreturn__)) usage(int status)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("unshare(1)"));
 
-	exit(status);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -321,7 +321,7 @@ int main(int argc, char *argv[])
 			forkit = 1;
 			break;
 		case 'h':
-			usage(EXIT_SUCCESS);
+			usage();
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;

--- a/sys-utils/wdctl.c
+++ b/sys-utils/wdctl.c
@@ -165,8 +165,9 @@ static struct colinfo *get_column_info(unsigned num)
 	return &infos[ get_column_id(num) ];
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -201,7 +202,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("wdctl(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void add_flag_line(struct libscols_table *table, struct wdinfo *wd, const struct wdflag *fl)
@@ -531,7 +532,7 @@ int main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'F':
 			noflags = 1;
 			break;

--- a/sys-utils/zramctl.c
+++ b/sys-utils/zramctl.c
@@ -517,8 +517,9 @@ static void status(struct zram *z)
 	scols_unref_table(tb);
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	size_t i;
 
 	fputs(USAGE_HEADER, out);
@@ -550,7 +551,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 		fprintf(out, " %11s  %s\n", infos[i].name, _(infos[i].help));
 
 	fprintf(out, USAGE_MAN_TAIL("zramctl(8)"));
-	exit(out == stderr ? 1 : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 /* actions */
@@ -642,7 +643,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -308,7 +308,7 @@ static void termio_final(struct options *op,
 			 struct termios *tp, struct chardata *cp);
 static int caps_lock(char *s);
 static speed_t bcode(char *s);
-static void usage(FILE * out) __attribute__((__noreturn__));
+static void usage(void) __attribute__((__noreturn__));
 static void log_err(const char *, ...) __attribute__((__noreturn__))
 			       __attribute__((__format__(printf, 1, 2)));
 static void log_warn (const char *, ...)
@@ -785,9 +785,9 @@ static void parse_args(int argc, char **argv, struct options *op)
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case HELP_OPTION:
-			usage(stdout);
+			usage();
 		default:
-			usage(stderr);
+			errtryhelp(EXIT_FAILURE);
 		}
 	}
 
@@ -795,7 +795,7 @@ static void parse_args(int argc, char **argv, struct options *op)
 
 	if (argc < optind + 1) {
 		log_warn(_("not enough arguments"));
-		usage(stderr);
+		warn(_("not enough arguments"));
 	}
 
 	/* Accept "tty", "baudrate tty", and "tty baudrate". */
@@ -803,8 +803,8 @@ static void parse_args(int argc, char **argv, struct options *op)
 		/* Assume BSD style speed. */
 		parse_speeds(op, argv[optind++]);
 		if (argc < optind + 1) {
+			log_warn(_("not enough arguments"));
 			warn(_("not enough arguments"));
-			usage(stderr);
 		}
 		op->tty = argv[optind++];
 	} else {
@@ -2066,8 +2066,10 @@ static speed_t bcode(char *s)
 	return 0;
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
+
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %1$s [options] <line> [<baud_rate>,...] [<termtype>]\n"
 		       " %1$s [options] <baud_rate>,... <line> [<termtype>]\n"), program_invocation_short_name);
@@ -2112,7 +2114,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE *out)
 	fputs(_("     --version              output version information and exit\n"), out);
 	fprintf(out, USAGE_MAN_TAIL("agetty(8)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 /*

--- a/term-utils/mesg.c
+++ b/term-utils/mesg.c
@@ -66,8 +66,9 @@
 #define IS_NOT_ALLOWED    1  /* Receiving messages is not allowed.  */
 #define MESG_EXIT_FAILURE 2  /* An error occurred.  */
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	/* TRANSLATORS: this program uses for y and n rpmatch(3),
 	 * which means they can be translated.  */
@@ -83,7 +84,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("mesg(1)"));
 
-	exit(out == stderr ? MESG_EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[])
@@ -113,7 +114,7 @@ int main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -159,7 +160,7 @@ int main(int argc, char *argv[])
 		break;
 	case RPMATCH_INVALID:
 		warnx(_("invalid argument: %s"), argv[0]);
-		usage(stderr);
+		errtryhelp(EXIT_FAILURE);
         default:
                 abort();
 	}

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -154,8 +154,9 @@ static inline time_t script_time(time_t *t)
 # define script_time(x) time(x)
 #endif
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [file]\n"), program_invocation_short_name);
 
@@ -174,7 +175,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 		" -h, --help              display this help and exit\n\n"), out);
 
 	fprintf(out, USAGE_MAN_TAIL("script(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void die_if_link(const struct script_control *ctl)
@@ -736,7 +737,7 @@ int main(int argc, char **argv)
 			exit(EXIT_SUCCESS);
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 			break;
 		default:
 			errtryhelp(EXIT_FAILURE);

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -36,8 +36,9 @@
 #define SCRIPT_MIN_DELAY 0.0001		/* from original sripreplay.pl */
 
 static void __attribute__((__noreturn__))
-usage(FILE *out)
+usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [-t] timingfile [typescript] [divisor]\n"),
@@ -55,7 +56,7 @@ usage(FILE *out)
 		" -h, --help              display this help and exit\n\n"), out);
 
 	fprintf(out, USAGE_MAN_TAIL("scriptreplay(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static double
@@ -172,7 +173,7 @@ main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 			}

--- a/term-utils/setterm.c
+++ b/term-utils/setterm.c
@@ -371,8 +371,9 @@ static int parse_bfreq(char **av, char *oa, int *oi)
 	return strtos32_or_err(arg, _("argument error"));
 }
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options]\n"), program_invocation_short_name);
@@ -420,7 +421,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(_(" --version                         show version information and exit\n"), out);
 	fputs(_(" --help                            display this help and exit\n"), out);
 	fprintf(out, USAGE_MAN_TAIL("setterm(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int __attribute__((__pure__)) set_opt_flag(int opt)
@@ -672,7 +673,7 @@ static void parse_option(struct setterm_control *ctl, int ac, char **av)
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case OPT_HELP:
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
@@ -1170,9 +1171,10 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	atexit(close_stdout);
 
-	if (argc < 2)
-		usage(stderr);
-
+	if (argc < 2) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 	parse_option(&ctl, argc, argv);
 	init_terminal(&ctl);
 	perform_sequence(&ctl);

--- a/term-utils/wall.c
+++ b/term-utils/wall.c
@@ -78,8 +78,9 @@
 static char *makemsg(char *fname, char **mvec, int mvecsz,
 		    size_t *mbufsize, int print_banner);
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options] [<file> | <message>]\n"), program_invocation_short_name);
@@ -96,7 +97,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("wall(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 struct group_workspace {
@@ -224,7 +225,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/term-utils/write.c
+++ b/term-utils/write.c
@@ -79,8 +79,9 @@ struct write_control {
 	const char *dst_tty_name;
 };
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 	      _(" %s [options] <user> [<ttyname>]\n"),
@@ -92,9 +93,8 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_OPTIONS, out);
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
-
 	fprintf(out, USAGE_MAN_TAIL("write(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 /*
@@ -317,9 +317,9 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
-			usage(stderr);
+			errtryhelp(EXIT_FAILURE);
 		}
 
 	if (get_terminal_name(&ctl.src_tty_path, &ctl.src_tty_name, NULL) == 0) {

--- a/tests/expected/getopt/options-compatible
+++ b/tests/expected/getopt/options-compatible
@@ -1,5 +1,5 @@
 getopt: missing optstring argument
-Try `getopt --help' for more information.
+Try 'getopt --help' for more information.
 exit value: 2
  --
 exit value: 0

--- a/tests/expected/getopt/options-invalid_getopt_option
+++ b/tests/expected/getopt/options-invalid_getopt_option
@@ -1,3 +1,3 @@
 getopt: invalid option -- 'b'
-Try `getopt --help' for more information.
+Try 'getopt --help' for more information.
 exit value: 2

--- a/tests/expected/getopt/options-invocation_without_parameters
+++ b/tests/expected/getopt/options-invocation_without_parameters
@@ -1,3 +1,3 @@
 getopt: missing optstring argument
-Try `getopt --help' for more information.
+Try 'getopt --help' for more information.
 exit value: 2

--- a/tests/expected/getopt/options-no-arguments
+++ b/tests/expected/getopt/options-no-arguments
@@ -1,3 +1,3 @@
 getopt: missing optstring argument
-Try `getopt --help' for more information.
+Try 'getopt --help' for more information.
 exit value: 2

--- a/text-utils/col.c
+++ b/text-utils/col.c
@@ -124,8 +124,9 @@ static int pass_unknown_seqs;		/* whether to pass unknown control sequences */
 	if (putwchar(ch) == WEOF) \
 		wrerr();
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fprintf(out, _(
 		"\nUsage:\n"
 		" %s [options]\n"), program_invocation_short_name);
@@ -149,7 +150,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 		program_invocation_short_name);
 
 	fprintf(out, USAGE_MAN_TAIL("col(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void __attribute__((__noreturn__)) wrerr(void)
@@ -221,13 +222,15 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'H':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}
 
-	if (optind != argc)
-		usage(stderr);
+	if (optind != argc) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	adjust = cur_col = extra_lines = warned = 0;
 	cur_line = max_line = nflushd_lines = this_line = 0;

--- a/text-utils/colcrt.c
+++ b/text-utils/colcrt.c
@@ -75,8 +75,9 @@ struct colcrt_control {
 			half_lines:1;
 };
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [<file>...]\n"), program_invocation_short_name);
 
@@ -93,7 +94,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("colcrt(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void trim_trailing_spaces(wchar_t *s)
@@ -264,7 +265,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/text-utils/colrm.c
+++ b/text-utils/colrm.c
@@ -54,8 +54,9 @@ COLRM removes unwanted columns from a file
 	Jeff Schriebman  UC Berkeley 11-74
 */
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fprintf(out, _("\nUsage:\n"
 		       " %s [startcol [endcol]]\n"),
 		       program_invocation_short_name);
@@ -69,7 +70,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fprintf(out, _("%s reads from standard input and writes to standard output\n\n"),
 		       program_invocation_short_name);
 	fprintf(out, USAGE_MAN_TAIL("colrm(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static int process_input(unsigned long first, unsigned long last)
@@ -176,7 +177,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -546,9 +546,9 @@ static void simple_print(struct column_control *ctl)
 	}
 }
 
-static void __attribute__((__noreturn__)) usage(int rc)
+static void __attribute__((__noreturn__)) usage(void)
 {
-	FILE *out = rc == EXIT_FAILURE ? stderr : stdout;
+	FILE *out = stdout;
 
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [<file>...]\n"), program_invocation_short_name);
@@ -585,7 +585,7 @@ static void __attribute__((__noreturn__)) usage(int rc)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("column(1)"));
 
-	exit(rc);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -657,7 +657,7 @@ int main(int argc, char **argv)
 			ctl.tab_colhide = optarg;
 			break;
 		case 'h':
-			usage(EXIT_SUCCESS);
+			usage();
 			break;
 		case 'i':
 			ctl.tree_id = optarg;

--- a/text-utils/hexdump.c
+++ b/text-utils/hexdump.c
@@ -131,7 +131,7 @@ parse_args(int argc, char **argv, struct hexdump *hex)
 			add_fmt("\"%07.7_ax \" 8/2 \"   %04x \" \"\\n\"", hex);
 			break;
 		case 'h':
-			usage(stdout);
+			usage();
 		case 'V':
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
@@ -149,8 +149,9 @@ parse_args(int argc, char **argv, struct hexdump *hex)
 	return optind;
 }
 
-void __attribute__((__noreturn__)) usage(FILE *out)
+void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] <file>...\n"), program_invocation_short_name);
 
@@ -177,7 +178,7 @@ void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("hexdump(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)

--- a/text-utils/hexdump.h
+++ b/text-utils/hexdump.h
@@ -101,7 +101,7 @@ void add_fmt(const char *, struct hexdump *);
 void rewrite_rules(struct hexdump_fs *, struct hexdump *);
 void addfile(char *, struct hexdump *);
 void display(struct hexdump *);
-void __attribute__((__noreturn__)) usage(FILE *out);
+void __attribute__((__noreturn__)) usage(void);
 void conv_c(struct hexdump_pr *, u_char *);
 void conv_u(struct hexdump_pr *, u_char *);
 int  next(char **, struct hexdump *);

--- a/text-utils/line.c
+++ b/text-utils/line.c
@@ -24,8 +24,9 @@
 #include "nls.h"
 #include "widechar.h"
 
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options]\n"), program_invocation_short_name);
 
@@ -36,7 +37,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_HELP, out);
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("line(1)"));
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -62,7 +63,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -223,8 +223,9 @@ static void __attribute__((__noreturn__)) quit(int status)
 }
 
 /* Usage message and similar routines. */
-static void __attribute__((__noreturn__)) usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out,
 		_(" %s [options] [+line] [+/pattern/] [files]\n"),
@@ -250,19 +251,19 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
 	fputs(USAGE_VERSION, out);
 
 	fprintf(out, USAGE_MAN_TAIL("pg(1)"));
-	quit(out == stderr ? 2 : 0);
+	exit(0);
 }
 
 static void __attribute__((__noreturn__)) needarg(const char *s)
 {
 	warnx(_("option requires an argument -- %s"), s);
-	usage(stderr);
+	errtryhelp(2);
 }
 
 static void __attribute__((__noreturn__)) invopt(const char *s)
 {
 	warnx(_("illegal option -- %s"), s);
-	usage(stderr);
+	errtryhelp(2);
 }
 
 #ifdef HAVE_WIDECHAR
@@ -1567,7 +1568,7 @@ int main(int argc, char **argv)
 		argc--;
 
 		if (!strcmp(argv[arg], "--help")) {
-		    usage(stdout);
+		    usage();
 		}
 
 		if (!strcmp(argv[arg], "--version")) {
@@ -1623,7 +1624,7 @@ int main(int argc, char **argv)
 				sflag = 1;
 				break;
 			case 'h':
-				usage(stdout);
+				usage();
 			case 'V':
 				printf(UTIL_LINUX_VERSION);
 				return EXIT_SUCCESS;

--- a/text-utils/rev.c
+++ b/text-utils/rev.c
@@ -71,8 +71,9 @@ static void sig_handler(int signo __attribute__ ((__unused__)))
 	_exit(EXIT_SUCCESS);
 }
 
-static void __attribute__ ((__noreturn__)) usage(FILE * out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fprintf(out, _("Usage: %s [options] [file ...]\n"),
 		program_invocation_short_name);
 
@@ -84,7 +85,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 	fputs(USAGE_VERSION, out);
 	fprintf(out, USAGE_MAN_TAIL("rev(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 static void reverse_str(wchar_t *str, size_t n)
@@ -125,7 +126,7 @@ int main(int argc, char *argv[])
 			printf(UTIL_LINUX_VERSION);
 			exit(EXIT_SUCCESS);
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/text-utils/ul.c
+++ b/text-utils/ul.c
@@ -135,9 +135,9 @@ static int	halfpos;
 static int	upln;
 static int	iflag;
 
-static void __attribute__((__noreturn__))
-usage(FILE *out)
+static void __attribute__((__noreturn__)) usage(void)
 {
+	FILE *out = stdout;
 	fputs(USAGE_HEADER, out);
 	fprintf(out, _(" %s [options] [<file> ...]\n"), program_invocation_short_name);
 
@@ -153,7 +153,7 @@ usage(FILE *out)
 
 	fprintf(out, USAGE_MAN_TAIL("ul(1)"));
 
-	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char **argv)
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
 			printf(UTIL_LINUX_VERSION);
 			return EXIT_SUCCESS;
 		case 'h':
-			usage(stdout);
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}

--- a/tools/checkusage.sh
+++ b/tools/checkusage.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+## This script is potentially dangerous! Don't run it on
+## arbitrary commands.
+
+export LC_ALL=C
+
+if [ "$#" -lt 1 ]; then
+	echo "usage: $0 program..." >&2
+	echo "       or try 'make checkusage' to check all built programs" >&2
+	exit 1
+fi
+
+builddir="."
+cmds=$(echo $@ | tr ' ' '\n' | sort)
+
+## Set alternative options for --help, --version
+## or --unknownopt. "x" means "not implemented".
+##
+## Examples:
+##   alt_whereis__help="-h"  # in past whereis(1) had no longopt for --help
+##   alt_more__help="x"      # more(1) had neither --help nor -h
+
+alt_fsck__unknownopt="-Tunknown"  # no title (-T) and pass -unknown to fsck.foo
+
+function exec_option {
+	local cmdb=$1
+	local cmd=$2
+	opt=$3
+
+	local alt="alt_${cmdb}${opt}"
+	alt=${alt//-/_}
+	alt=${alt//./_}
+	alt=$(eval printf -- \"\$${alt}\")
+	if test -n "$alt"; then
+		if test "$alt" = "x"; then
+			return 1
+		fi
+		opt=$alt
+	fi
+
+	out=$("$cmd" "$opt" 2>/dev/null)
+	err=$("$cmd" "$opt" 2>&1 >/dev/null)
+	ret=$?
+
+	# hardcoded ... nologin should always return false
+	if test "$cmdb" = "nologin" &&
+			test "$opt" = "--help" -o "$opt" = "--version"; then
+		if test "$ret" = "0"; then
+			echo "$cmdb, $opt, should return false"
+		fi
+		ret=0
+	fi
+
+	return 0
+}
+
+
+function check_help {
+	local cb=$1
+	local c=$2
+
+	if ! exec_option "$cb" "$c" --help; then
+		return 1
+	fi
+
+	if test $ret != 0; then
+		echo "$cb: $opt, returns error"
+	else
+		if test -z "$out"; then
+			echo "$cb: $opt, no stdout"
+		fi
+		if test -n "$err"; then
+			echo "$cb: $opt, non-empty stderr"
+		fi
+	fi
+	return 0
+}
+
+function check_version {
+	local cb=$1
+	local c=$2
+
+	if ! exec_option "$cb" "$c" --version; then
+		return 1
+	fi
+
+	if test $ret != 0; then
+		echo "$cb: $opt, returns error"
+	else
+		if test -z "$out"; then
+			echo "$cb: $opt, no stdout"
+		fi
+		if test -n "$err"; then
+			echo "$cb: $opt, non-empty stderr"
+		fi
+	fi
+}
+
+function check_unknownopt {
+	local cb=$1
+	local c=$2
+	local nohelp=$3
+
+	if ! exec_option "$cb" "$c" --unknownopt; then
+		return 1
+	fi
+
+	if test $ret = 0; then
+		echo "$cb: $opt, returns no error"
+	fi
+	if test -n "$out"; then
+		echo "$cb: $opt, non-empty stdout"
+	fi
+	if test -z "$err"; then
+		echo "$cb: $opt, no stderr"
+	elif test -z "$nohelp" -o "$nohelp" != "yes"; then
+		out_len=$(echo "$out" | wc -l)
+		err_len=$(echo "$err" | wc -l)
+		if test "$err_len" -gt 2; then
+			# hardcoded ignore ... mkfs sends options to mkfs.ext2
+			if test "$cb" != "mkfs" -a "$cb" != "fsck"; then
+				echo "$cb: $opt, stderr too long: $err_len"
+			fi
+		elif test "$err_len" -lt 2; then
+			echo "$cb: $opt, stderr too short: $err_len"
+		fi
+	fi
+}
+
+for cb in $cmds; do
+	c="$builddir/$cb"
+	if ! type "$c" &>/dev/null; then
+		echo "$cb: does not exist"
+		continue
+	fi
+
+	nohelp="no"
+	if ! check_help "$cb" "$c"; then
+		nohelp="yes"
+	fi
+	check_version "$cb" "$c"
+	check_unknownopt "$cb" "$c" "$nohelp"
+done
+


### PR DESCRIPTION
This is the second part of the patch-set mentioned in #467

Finally we avoid printing any usage/help messages to stderr. I've grouped these invasive patches in a way to make review less annoying. Each file is only touched in exactly one patch.

The two "misc: never use usage(*)" patches are a *almost trivial*, except that I tried to invent a few useful "bad usage" warnings. The last two "cosmetics" patches are *absolute trivial*.
