### PR TITLE
tools: fix chown mistake add checkusage.sh to the dist

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -58,7 +58,6 @@ function check_root
 	local opts="$MAKE_CHECK_OPTS --parallel=1 --show-diff"
 
 	xconfigure \
-		--disable-makeinstall-chown \
 		--enable-all-programs \
 		|| return
 	$MAKE || return
@@ -73,7 +72,7 @@ function check_root
 
 function check_dist
 {
-	xconfigure --disable-makeinstall-chown \
+	xconfigure \
 		|| return
 	$MAKE distcheck || return
 }

--- a/Makefile.am
+++ b/Makefile.am
@@ -192,6 +192,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--disable-use-tty-group \
 	--disable-silent-rules \
 	--enable-all-programs \
+	--disable-makeinstall-chown \
 	--enable-static-programs \
 	--enable-gtk-doc \
 	--with-python \

--- a/tools/Makemodule.am
+++ b/tools/Makemodule.am
@@ -6,4 +6,5 @@ EXTRA_DIST += \
        	tools/checkdecl.sh \
       	tools/checkincludes.pl \
 	tools/checkmans.sh \
+	tools/checkusage.sh \
        	tools/checkxalloc.sh


### PR DESCRIPTION
OMG don't know why I removed --disable-makeinstall-chown. Took me a lot of time to figure out why travis was broken.

Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>