### PR TITLE
Update last.c

### DIFF
--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -457,7 +457,7 @@ static int list(const struct last_control *ctl, struct utmpx *p, time_t logout_t
 		sprintf(length, "(%d+%02d:%02d)", days, abs(hours), abs(mins)); /* hours and mins always shown as positive (w/o minus sign!) even if secs < 0 */
 	} else if (hours) {
 		sprintf(length, " (%02d:%02d)", hours, abs(mins));  /* mins always shown as positive (w/o minus sign!) even if secs < 0 */
-	} else if (secs > 0) {
+	} else if (secs >= 0) {
 		sprintf(length, " (%02d:%02d)", hours, mins); 
 	} else {
 		sprintf(length, " (-00:%02d)", abs(mins));  /* mins always shown as positive (w/o minus sign!) even if secs < 0 */


### PR DESCRIPTION
Under strange circumstances, the output of command 'last reboot' showed the last time as a negative time, with both the hours and the mins value having a minus sign. Example, taken from my workstation:

$last reboot
[...]
reboot   system boot  4.4.0-79-generic Wed Jun 14 09:20 - 07:33  (-1:-47)   
[...]

I am aware this should happen only infrequently. Nevertheless, I propose a more robust behaviour: show a minus sign only for the most significant value (days or hours) and show the rest always as positive. In the special case of ((secs < 0) && (secs >= -59)), print mins as "-00".

P.S.: I'm an experienced C programmer but new to GitHub.  In the implementation, the chain of "else if" statements does not look elegant, so I am open for improvements and comments.