### PR TITLE
lib/randutils.c: Improvements for getrandom usage

### DIFF
--- a/lib/randutils.c
+++ b/lib/randutils.c
@@ -100,7 +100,7 @@ void random_get_bytes(void *buf, size_t nbytes)
 
 #ifdef HAVE_GETRANDOM
 	errno = 0;
-	while (getrandom(buf, nbytes, 0) < 0) {
+	while (getrandom(buf, nbytes, 0) != (ssize_t)nbytes) {
 		if (errno == EINTR)
 			continue;
 		break;


### PR DESCRIPTION
1) Use the previous “read from /dev/urandom” codepath on kernels which don't support the getrandom() syscall.
2) Check that getrandom() read the number of bytes requested.