### PR TITLE
fdisk: implement dialog cancelling using ^C

### DIFF
--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -21,6 +21,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <limits.h>
+#include <signal.h>
 #include <libsmartcols.h>
 #ifdef HAVE_LIBREADLINE
 # define _FUNCTION_DEF
@@ -68,6 +69,12 @@ static void fdiskprog_init_debug(void)
 	__UL_INIT_DEBUG(fdisk, FDISKPROG_DEBUG_, 0, FDISK_DEBUG);
 }
 
+static int got_sigint = 0;
+static void int_handler(int sig __attribute__((unused)))
+{
+	got_sigint = 1;
+}
+
 #ifdef HAVE_LIBREADLINE
 static char *rl_fgets(char *s, int n, FILE *stream, const char *prompt)
 {
@@ -105,9 +112,25 @@ int get_user_reply(struct fdisk_context *cxt, const char *prompt,
 {
 	char *p;
 	size_t sz;
+	int ret = 0;
+	struct sigaction oldact, act = {
+		.sa_handler = int_handler,
+	};
+
+	sigemptyset(&act.sa_mask);
+
+	got_sigint = 0;
+	sigaction(SIGINT, &act, &oldact);
 
 	do {
-		if (!wrap_fgets(buf, bufsz, stdout, prompt)) {
+		char *tmp = wrap_fgets(buf, bufsz, stdout, prompt);
+
+		if (got_sigint) {
+			ret = -ECANCELED;
+			goto end;
+		}
+
+		if (!tmp) {
 			if (fdisk_label_is_changed(fdisk_get_label(cxt, NULL))) {
 				if (wrap_fgets(buf, bufsz, stderr,
 						_("\nDo you really want to quit? "))
@@ -129,7 +152,9 @@ int get_user_reply(struct fdisk_context *cxt, const char *prompt,
 		*(buf + sz - 1) = '\0';
 
 	DBG(ASK, ul_debug("user's reply: >>>%s<<<", buf));
-	return 0;
+end:
+	sigaction(SIGINT, &oldact, NULL);
+	return ret;
 }
 
 static int ask_menu(struct fdisk_context *cxt, struct fdisk_ask *ask,

--- a/libfdisk/src/dos.c
+++ b/libfdisk/src/dos.c
@@ -1737,10 +1737,10 @@ static int dos_add_partition(struct fdisk_context *cxt,
 			fdisk_ask_menu_add_item(ask, 'l', _("logical"), _("numbered from 5"));
 
 		rc = fdisk_do_ask(cxt, ask);
-		if (rc)
-			return rc;
 		fdisk_ask_menu_get_result(ask, &c);
 		fdisk_unref_ask(ask);
+		if (rc)
+			return rc;
 
 		if (c == 'p') {
 			rc = get_partition_unused_primary(cxt, pa, &res);

--- a/libfdisk/src/gpt.c
+++ b/libfdisk/src/gpt.c
@@ -2302,6 +2302,8 @@ static int gpt_add_partition(
 				ask = fdisk_new_ask();
 			else
 				fdisk_reset_ask(ask);
+			if (!ask)
+				return -ENOMEM;
 
 			/* First sector */
 			fdisk_ask_set_query(ask, _("First sector"));

--- a/libfdisk/src/partition.c
+++ b/libfdisk/src/partition.c
@@ -70,6 +70,8 @@ void fdisk_reset_partition(struct fdisk_partition *pa)
 	free(pa->fstype);
 	free(pa->fsuuid);
 	free(pa->fslabel);
+	free(pa->start_chs);
+	free(pa->end_chs);
 
 	memset(pa, 0, sizeof(*pa));
 	pa->refcount = ref;


### PR DESCRIPTION
Doesn't fully work with readline (6.3). Readline doesn't return upon receiving signal.