### PR TITLE
Example for renaming foo? does not work as described

### DIFF
--- a/misc-utils/rename.1
+++ b/misc-utils/rename.1
@@ -40,7 +40,7 @@ the commands
 .RS
 .PP
 .nf
-rename foo foo0 foo?
+rename foo foo00 foo?
 rename foo foo0 foo??
 .fi
 .PP


### PR DESCRIPTION
Command for renaming foo? should add 2 zeros to make all the file names have 3 digits as described in the example results.