### PR TITLE
Fixed typo in mount.8

### DIFF
--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -279,7 +279,7 @@ using the command:
 .RE
 Note that \fBmount\fR is very strict about non-root users and all paths
 specified on command line are verified before fstab is parsed or a helper
-program is executed. It's strogly recommended to use a valid mountpoint to
+program is executed. It's strongly recommended to use a valid mountpoint to
 specify filesystem, otherwise \fBmount\fR may fail. For example it's bad idea
 to use NFS or CIFS source on command line.
 .PP


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/ubuntu/+source/util-linux/+bug/1712433 

Signed-off-by: Liam Ryan <liamryandev@gmail.com>