### PR TITLE
bash-completion: Exclude /dev/fd from fsck find

### DIFF
--- a/bash-completion/fsck
+++ b/bash-completion/fsck
@@ -32,7 +32,8 @@ _fsck_module()
 			return 0
 			;;
 	esac
-	COMPREPLY=( $(compgen -W "$(find -L /dev/ -type b 2>/dev/null)" -- $cur) )
+	COMPREPLY=( $(compgen -W "$(find -L /dev/ -path /dev/fd -prune \
+		-o -type b -print 2>/dev/null)" -- $cur) )
 	return 0
 }
 complete -F _fsck_module fsck


### PR DESCRIPTION
When the bash-completion for fsck runs `find -L /dev/ -type b` it descends into `/dev/fd` after opening `.` as file descriptor 3.  This causes find to search through `/dev/fd/3/` which includes everything below
the current directory, which can take a very long time.

To avoid this, prune `/dev/fd` in the find expression.

Thanks for considering,
Kevin

P.S.  If you'd like strace information to see exactly how `find` descends into `/dev/fd` let me know.