### PR TITLE
libfdisk: Fix uninitialized structure

### DIFF
--- a/libfdisk/src/script.c
+++ b/libfdisk/src/script.c
@@ -418,7 +418,7 @@ int fdisk_script_read_context(struct fdisk_script *dp, struct fdisk_context *cxt
 		rc = fdisk_script_set_header(dp, "unit", "sectors");
 
 	if (!rc && fdisk_is_label(cxt, GPT)) {
-		struct fdisk_labelitem item;
+		struct fdisk_labelitem item = FDISK_LABELITEM_INIT;
 		char buf[64];
 
 		/* first-lba */


### PR DESCRIPTION
Without this, 'sfdisk -d' with certain filenames would lead to
reading an 's' from the 'type' field in fdisk_reset_labelitem
and cause a crash due to prematurely freeing the 'data.str' field.

Signed-off-by: Roddy Shuler <roddy@endlessm.com>