### PR TITLE
lscpu: Treat read failure on Xen Hypervisor properties as non-fatal

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -954,9 +954,6 @@ read_hypervisor(struct lscpu_desc *desc, struct lscpu_modifier *mod)
 								== XEN_FEATURES_PVH_MASK)
 					desc->virtype = VIRT_PARA;
 				fclose(fd);
-			} else {
-				err(EXIT_FAILURE, _("failed to read from: %s"),
-						_PATH_SYS_HYP_FEATURES);
 			}
 		}
 	} else if (read_hypervisor_powerpc(desc) > 0) {}


### PR DESCRIPTION
At least on the Sydney Amazon EC2 region this file doesn't show up,
and the fatal exit code causes the rest of the useful information
to not show up.