### PR TITLE
libblkid: udf: Do not read more sectors as needed

### DIFF
--- a/libblkid/src/superblocks/udf.c
+++ b/libblkid/src/superblocks/udf.c
@@ -94,6 +94,7 @@ struct volume_descriptor {
 #define TAG_ID_PVD  1
 #define TAG_ID_AVDP 2
 #define TAG_ID_LVD  6
+#define TAG_ID_TD   8
 #define TAG_ID_LVID 9
 
 struct volume_structure_descriptor {
@@ -289,6 +290,8 @@ real_blksz:
 		if (type == 0)
 			break;
 		if (le32_to_cpu(vd->tag.location) != loc + b)
+			break;
+		if (type == TAG_ID_TD)
 			break;
 		if (type == TAG_ID_PVD) {
 			if (!have_volid) {


### PR DESCRIPTION
libblkid: udf: Stop scanning Volume Descriptors after we found Terminating Descriptor

Terminating Descriptor is the last descriptor in Volume Descriptor
Sequence. After it there can be unrecorded or empty sectors which we do not
have to scan.

___

libblkid: udf: Really try to read only first LVID

We do not want to scan whole LVID sequence.