### PR TITLE
lscpu: Decode ARM CPUs

### DIFF
--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -357,6 +357,7 @@ usrbin_exec_PROGRAMS += lscpu
 lscpu_SOURCES = \
 	sys-utils/lscpu.c \
 	sys-utils/lscpu.h \
+	sys-utils/lscpu-arm.h \
 	sys-utils/lscpu-dmi.c
 lscpu_LDADD = $(LDADD) libcommon.la libsmartcols.la $(RTAS_LIBS)
 lscpu_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)

--- a/sys-utils/lscpu-arm.h
+++ b/sys-utils/lscpu-arm.h
@@ -1,0 +1,189 @@
+/*
+ * lscpu-arm.h - ARM CPU identification tables
+ *
+ * Copyright (C) 2018 Riku Voipio <riku.voipio@iki.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * The information here is gathered from
+ *  - ARM manuals
+ *  - Linux kernel: arch/armX/include/asm/cputype.h
+ *  - GCC sources: config/arch/arch-cores.def
+ *  - Ancient wisdom
+ */
+#ifndef LSCPU_ARM_H
+#define LSCPU_ARM_H
+
+struct id_part {
+    const int id;
+    const char* name;
+};
+
+static const struct id_part arm_part[] = {
+    { 0x810, "ARM810" },
+    { 0x920, "ARM920" },
+    { 0x922, "ARM922" },
+    { 0x926, "ARM926" },
+    { 0x940, "ARM940" },
+    { 0x946, "ARM946" },
+    { 0x966, "ARM966" },
+    { 0xa20, "ARM1020" },
+    { 0xa22, "ARM1022" },
+    { 0xa26, "ARM1026" },
+    { 0xb02, "ARM11 MPCore" },
+    { 0xb36, "ARM1136" },
+    { 0xb56, "ARM1156" },
+    { 0xb76, "ARM1176" },
+    { 0xc05, "Cortex-A5" },
+    { 0xc07, "Cortex-A7" },
+    { 0xc08, "Cortex-A8" },
+    { 0xc09, "Cortex-A9" },
+    { 0xc0d, "Cortex-A12" },
+    { 0xc0f, "Cortex-A15" },
+    { 0xc0e, "Cortex-A17" },
+    { 0xc14, "Cortex-R4" },
+    { 0xc15, "Cortex-R5" },
+    { 0xc17, "Cortex-R7" },
+    { 0xc18, "Cortex-R8" },
+    { 0xc20, "Cortex-M0" },
+    { 0xc21, "Cortex-M1" },
+    { 0xc23, "Cortex-M3" },
+    { 0xc24, "Cortex-M4" },
+    { 0xc20, "Cortex-M7" },
+    { 0xc60, "Cortex-M0+" },
+    { 0xd01, "Cortex-A32" },
+    { 0xd03, "Cortex-A53" },
+    { 0xd04, "Cortex-A35" },
+    { 0xd05, "Cortex-A55" },
+    { 0xd07, "Cortex-A57" },
+    { 0xd08, "Cortex-A72" },
+    { 0xd09, "Cortex-A73" },
+    { 0xd0a, "Cortex-A75" },
+    { 0xd13, "Cortex-R52" },
+    { 0xd20, "Cortex-M23" },
+    { 0xd21, "Cortex-M33" },
+    { -1, "unknown" },
+};
+
+static const struct id_part brcm_part[] = {
+    { 0x516, "ThunderX2" },
+    { -1, "unknown" },
+};
+
+static const struct id_part dec_part[] = {
+    { 0xa10, "SA110" },
+    { 0xa11, "SA1100" },
+    { -1, "unknown" },
+};
+
+static const struct id_part cavium_part[] = {
+    { 0x0a0, "ThunderX" },
+    { 0x0a1, "ThunderX 88XX" },
+    { 0x0a2, "ThunderX 81XX" },
+    { 0x0a3, "ThunderX 83XX" },
+    { 0x0af, "ThunderX2 99xx" },
+    { -1, "unknown" },
+};
+
+static const struct id_part apm_part[] = {
+    { 0x000, "X-Gene" },
+    { -1, "unknown" },
+};
+
+static const struct id_part qcom_part[] = {
+    { 0x00f, "Scorpion" },
+    { 0x02d, "Scorpion" },
+    { 0x04d, "Krait" },
+    { 0x06f, "Krait" },
+    { 0x201, "Kryo" },
+    { 0x205, "Kryo" },
+    { 0x211, "Kryo" },
+    { 0x800, "Falkor V1/Kryo" },
+    { 0x801, "Kryo V2" },
+    { 0xc00, "Falkor" },
+    { 0xc01, "Saphira" },
+    { -1, "unknown" },
+};
+
+static const struct id_part samsung_part[] = {
+    { 0x001, "exynos-m1" },
+    { -1, "unknown" },
+
+};
+
+static const struct id_part nvidia_part[] = {
+    { 0x000, "Denver" },
+    { 0x003, "Denver 2" },
+    { -1, "unknown" },
+};
+
+static const struct id_part marvell_part[] = {
+    { 0x131, "Feroceon 88FR131" },
+    { 0x581, "PJ4/PJ4b" },
+    { 0x584, "PJ4B-MP" },
+    { -1, "unknown" },
+
+};
+
+static const struct id_part intel_part[] = {
+    { 0x200, "i80200" },
+    { 0x210, "PXA250A" },
+    { 0x212, "PXA210A" },
+    { 0x242, "i80321-400" },
+    { 0x243, "i80321-600" },
+    { 0x290, "PXA250B/PXA26x" },
+    { 0x292, "PXA210B" },
+    { 0x2c2, "i80321-400-B0" },
+    { 0x2c3, "i80321-600-B0" },
+    { 0x2d0, "PXA250C/PXA255/PXA26x" },
+    { 0x2d2, "PXA210C" },
+    { 0x411, "PXA27x" },
+    { 0x41c, "IPX425-533" },
+    { 0x41d, "IPX425-400" },
+    { 0x41f, "IPX425-266" },
+    { 0x682, "PXA32x" },
+    { 0x683, "PXA930/PXA935" },
+    { 0x688, "PXA30x" },
+    { 0x689, "PXA31x" },
+    { 0xb11, "SA1110" },
+    { 0xc12, "IPX1200" },
+    { -1, "unknown" },
+};
+
+static const struct id_part unknown_part[] = {
+    { -1, "unknown" },
+};
+
+struct hw_impl {
+   const int    id;
+   const struct id_part     *parts;
+   const char   *name;
+};
+
+static const struct hw_impl hw_implementer[] = {
+    { 0x41, arm_part,     "ARM" },
+    { 0x42, brcm_part,    "Broadcom" },
+    { 0x43, cavium_part,  "Cavium" },
+    { 0x44, dec_part,     "DEC" },
+    { 0x4e, nvidia_part,  "Nvidia" },
+    { 0x50, apm_part,     "APM" },
+    { 0x51, qcom_part,    "Qualcomm" },
+    { 0x53, samsung_part, "Samsung" },
+    { 0x56, marvell_part, "Marvell" },
+    { 0x69, intel_part,   "Intel" },
+    { -1,   unknown_part, "unknown" },
+};
+
+#endif /* LSCPU_ARM_H */

--- a/tests/expected/lscpu/lscpu-armv7
+++ b/tests/expected/lscpu/lscpu-armv7
@@ -3,7 +3,10 @@ On-line CPU(s) list: 0,1
 Thread(s) per core:  1
 Core(s) per socket:  2
 Socket(s):           1
+Vendor ID:           ARM
 Model:               4
+Model name:          Cortex-A15
+Stepping:            r0p4
 CPU max MHz:         1700.0000
 CPU min MHz:         200.0000
 BogoMIPS:            1694.10


### PR DESCRIPTION
Since the kernel developers have refused to make /proc/cpuinfo user
understandable, implement mapping in userspace. lscpu is available for
most users via util-linux, so store the information here.

Signed-off-by: Riku Voipio <riku.voipio@iki.fi>