### PR TITLE
 mount(8): umount does not (anymore?) say `none busy'

### DIFF
--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -183,8 +183,8 @@ mounting it, an arbitrary keyword, such as
 can be used instead of a device specification.
 (The customary choice
 .I none
-is less fortunate: the error message `none busy' from
-.B umount
+is less fortunate: the error message `none already mounted' from
+.B mount
 can be confusing.)
 
 .SS The files /etc/fstab, /etc/mtab and /proc/mounts


### PR DESCRIPTION
The closest I can get is with `mount`, so refer to that instead.

    # mount none -t proc /proc 
    mount: /proc: none already mounted or mount point busy.
    # umount /proc
    umount: /proc: target is busy.
    # (cd /root; umount proc)
    umount: /proc: target is busy.

Signed-off-by: Alan Jenkins <alan.christopher.jenkins@gmail.com>