### PR TITLE
cal: Use ALTMON_* correctly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -305,6 +305,59 @@ AC_CHECK_HEADERS([langinfo.h],
 		[AM_CONDITIONAL([HAVE_LANGINFO], [true])],
 		[AM_CONDITIONAL([HAVE_LANGINFO], [false])])
 
+
+AC_MSG_CHECKING([whether langinfo.h defines ALTMON_x constants])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+	#include <langinfo.h>
+]], [[
+	char *str;
+	str = nl_langinfo (ALTMON_1);
+	str = nl_langinfo (ALTMON_2);
+	str = nl_langinfo (ALTMON_3);
+	str = nl_langinfo (ALTMON_4);
+	str = nl_langinfo (ALTMON_5);
+	str = nl_langinfo (ALTMON_6);
+	str = nl_langinfo (ALTMON_7);
+	str = nl_langinfo (ALTMON_8);
+	str = nl_langinfo (ALTMON_9);
+	str = nl_langinfo (ALTMON_10);
+	str = nl_langinfo (ALTMON_11);
+	str = nl_langinfo (ALTMON_12);
+]])], [
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([HAVE_LANGINFO_ALTMON], [1],
+		[Define if langinfo.h defines ALTMON_x constants])
+], [
+	AC_MSG_RESULT([no])
+])
+
+
+AC_MSG_CHECKING([whether langinfo.h defines _NL_ABALTMON_x constants])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+	#include <langinfo.h>
+]], [[
+	char *str;
+	str = nl_langinfo (_NL_ABALTMON_1);
+	str = nl_langinfo (_NL_ABALTMON_2);
+	str = nl_langinfo (_NL_ABALTMON_3);
+	str = nl_langinfo (_NL_ABALTMON_4);
+	str = nl_langinfo (_NL_ABALTMON_5);
+	str = nl_langinfo (_NL_ABALTMON_6);
+	str = nl_langinfo (_NL_ABALTMON_7);
+	str = nl_langinfo (_NL_ABALTMON_8);
+	str = nl_langinfo (_NL_ABALTMON_9);
+	str = nl_langinfo (_NL_ABALTMON_10);
+	str = nl_langinfo (_NL_ABALTMON_11);
+	str = nl_langinfo (_NL_ABALTMON_12);
+]])], [
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([HAVE_LANGINFO_NL_ABALTMON], [1],
+		[Define if langinfo.h defines _NL_ABALTMON_x constants])
+], [
+	AC_MSG_RESULT([no])
+])
+
+
 dnl Convert some ac_cv_header_* variables to have_*
 dnl
 have_linux_version_h=$ac_cv_header_linux_version_h

--- a/include/nls.h
+++ b/include/nls.h
@@ -122,4 +122,34 @@ enum {
 
 #endif /* !HAVE_LANGINFO_H */
 
+#ifndef HAVE_LANGINFO_ALTMON
+# define ALTMON_1 MON_1
+# define ALTMON_2 MON_2
+# define ALTMON_3 MON_3
+# define ALTMON_4 MON_4
+# define ALTMON_5 MON_5
+# define ALTMON_6 MON_6
+# define ALTMON_7 MON_7
+# define ALTMON_8 MON_8
+# define ALTMON_9 MON_9
+# define ALTMON_10 MON_10
+# define ALTMON_11 MON_11
+# define ALTMON_12 MON_12
+#endif /* !HAVE_LANGINFO_ALTMON */
+
+#ifndef HAVE_LANGINFO_NL_ABALTMON
+# define _NL_ABALTMON_1 ABMON_1
+# define _NL_ABALTMON_2 ABMON_2
+# define _NL_ABALTMON_3 ABMON_3
+# define _NL_ABALTMON_4 ABMON_4
+# define _NL_ABALTMON_5 ABMON_5
+# define _NL_ABALTMON_6 ABMON_6
+# define _NL_ABALTMON_7 ABMON_7
+# define _NL_ABALTMON_8 ABMON_8
+# define _NL_ABALTMON_9 ABMON_9
+# define _NL_ABALTMON_10 ABMON_10
+# define _NL_ABALTMON_11 ABMON_11
+# define _NL_ABALTMON_12 ABMON_12
+#endif /* !HAVE_LANGINFO_NL_ABALTMON */
+
 #endif /* UTIL_LINUX_NLS_H */

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -574,7 +574,7 @@ static void init_monthnames(struct cal_control *ctl)
 		return;		/* already initialized */
 
 	for (i = 0; i < MONTHS_IN_YEAR; i++)
-		ctl->full_month[i] = nl_langinfo(MON_1 + i);
+		ctl->full_month[i] = nl_langinfo(ALTMON_1 + i);
 }
 
 static void init_abbr_monthnames(struct cal_control *ctl)
@@ -585,7 +585,7 @@ static void init_abbr_monthnames(struct cal_control *ctl)
 		return;		/* already initialized */
 
 	for (i = 0; i < MONTHS_IN_YEAR; i++)
-		ctl->abbr_month[i] = nl_langinfo(ABMON_1 + i);
+		ctl->abbr_month[i] = nl_langinfo(_NL_ABALTMON_1 + i);
 }
 
 static int monthname_to_number(struct cal_control *ctl, const char *name)


### PR DESCRIPTION
cal: use ```ALTMON_*``` and ```_NL_ABALTMON_*``` constants to display
months in a standalone form correctly.  These constants have just
been newly added to glibc.  ```ALTMON_x``` has been used in BSD family
since 1990s and has been accepted as the future POSIX extension.
```_NL_ABALTMON_*``` is exclusively a GNU extension but it is expected
to be added to POSIX in future.

More info: https://sourceware.org/bugzilla/show_bug.cgi?id=10871