### PR TITLE
New compression algorithms in zramctl utility.

### DIFF
--- a/sys-utils/zramctl.8
+++ b/sys-utils/zramctl.8
@@ -44,7 +44,7 @@ query the status of used zram devices.
 If no option is given, all non-zero size zram devices are shown.
 .SH OPTIONS
 .TP
-.BR \-a , " \-\-algorithm lzo" | lz4
+.BR \-a , " \-\-algorithm lzo" | lz4 | lz4hc | deflate | 842
 Set the compression algorithm to be used for compressing data in the zram device.
 .TP
 .BR \-f , " \-\-find"


### PR DESCRIPTION
The changes add the support for new compression algorithms in zramctl utility. Namely, lz4hc, deflate, and 842 are supported compared to the previous state.