### PR TITLE
findmnt.8: remove spurious spaces before "--tree" and "--verbose"

### DIFF
--- a/misc-utils/findmnt.8
+++ b/misc-utils/findmnt.8
@@ -216,7 +216,7 @@ to specify the filesystem types on which no action should be taken.  For
 more details see
 .BR mount (8).
 .TP
-.BR " \-\-tree"
+.BR "\-\-tree"
 Enable tree-like output if possible.  The options is silently ignored for
 tables where is missing child-parent relation (e.g. fstab).
 .TP
@@ -247,7 +247,7 @@ parsability and usability. It's possible to use this option also with \fB\-\-tab
 It's possible to specify source (device) or target (mountpoint) to filter mount table. The option
 \fB\-\-verbose\fP forces findmnt to print more details.
 .TP
-.BR " \-\-verbose"
+.BR "\-\-verbose"
 Force findmnt to print more information (\fB\-\-verify\fP only for now).
 .SH EXAMPLES
 .IP "\fBfindmnt \-\-fstab \-t nfs\fP"


### PR DESCRIPTION
The option list was unevenly aligned, which mildly annoyed the pedant in me.