### PR TITLE
column: fix infinite loop caused by 0 width wrapped columns

### DIFF
--- a/libsmartcols/src/table_print.c
+++ b/libsmartcols/src/table_print.c
@@ -1341,6 +1341,10 @@ static int recount_widths(struct libscols_table *tb, struct libscols_buffer *buf
 				width--;
 				break;
 			}
+
+			/* hide zero width columns */
+			if (cl->width == 0)
+				cl->flags |= SCOLS_FL_HIDDEN;
 		}
 
 		/* the current stage is without effect, go to the next */


### PR DESCRIPTION
Im certain this isnt the best way to solve it, but it seems to work.

a short example of the problem `column -t -W2 -c11 <<< "cat dog bird"`
i assume the expected output for the zero width dog column should drop the dog and just print `cat  bird`

in recount_widths during the 3 stage truncating, when content cannot fit, it will shrink wrappable columns to their min width.
in the case of a 0 min-width, when it starts printing it will forever print 0 bytes of "pending data" and however much padding there is

this change will set the SCOLS_FL_HIDDEN flag whenever a column reaches 0 width.

relevant debug
```
24992: libsmartcols:      TAB: [0x564df9755130]: recounting widths (termwidth=11)
24992: libsmartcols:      COL: [0x564df9755210]:          (null) seq=0, width=3, hint=0, avg=0, max=3, min=0, extreme=not
24992: libsmartcols:      COL: [0x564df97553b0]:          (null) seq=1, width=3, hint=0, avg=0, max=3, min=0, extreme=not
24992: libsmartcols:      COL: [0x564df9755500]:          (null) seq=2, width=4, hint=0, avg=4, max=4, min=0, extreme=not
24992: libsmartcols:      TAB: [0x564df9755130]:  reduce width - #1 stage (current=14, wanted=11)
24992: libsmartcols:      TAB: [0x564df9755210]:    checking (null) (width=3, treeart=0)
24992: libsmartcols:      TAB: [0x564df97553b0]:    checking (null) (width=3, treeart=0)
24992: libsmartcols:      TAB: [0x564df9755500]:    checking (null) (width=4, treeart=0)
24992: libsmartcols:      TAB: [0x564df9755130]:  reduce width - #2 stage (current=14, wanted=11)
24992: libsmartcols:      TAB: [0x564df9755210]:    checking (null) (width=3, treeart=0)
24992: libsmartcols:      TAB: [0x564df97553b0]:    checking (null) (width=3, treeart=0)
24992: libsmartcols:      TAB: [0x564df9755130]:      reducing (all with flag)
24992: libsmartcols:      TAB: [0x564df9755500]:    checking (null) (width=4, treeart=0)
24992: libsmartcols:      TAB: [0x564df9755130]:  reduce width - #2 stage (current=13, wanted=11)
24992: libsmartcols:      TAB: [0x564df9755210]:    checking (null) (width=3, treeart=0)
24992: libsmartcols:      TAB: [0x564df97553b0]:    checking (null) (width=2, treeart=0)
24992: libsmartcols:      TAB: [0x564df9755130]:      reducing (all with flag)
24992: libsmartcols:      TAB: [0x564df9755500]:    checking (null) (width=4, treeart=0)
24992: libsmartcols:      TAB: [0x564df9755130]:  reduce width - #2 stage (current=12, wanted=11)
24992: libsmartcols:      TAB: [0x564df9755210]:    checking (null) (width=3, treeart=0)
24992: libsmartcols:      TAB: [0x564df97553b0]:    checking (null) (width=1, treeart=0)
24992: libsmartcols:      TAB: [0x564df9755130]:      reducing (all with flag)
24992: libsmartcols:      TAB: [0x564df9755500]:    checking (null) (width=4, treeart=0)
24992: libsmartcols:      TAB: [0x564df9755130]:  final width: 11 (rc=0)
24992: libsmartcols:      COL: [0x564df9755210]:          (null) seq=0, width=3, hint=0, avg=0, max=3, min=0, extreme=not
24992: libsmartcols:      COL: [0x564df97553b0]:          (null) seq=1, width=0, hint=0, avg=0, max=3, min=0, extreme=not
24992: libsmartcols:      COL: [0x564df9755500]:          (null) seq=2, width=4, hint=0, avg=4, max=4, min=0, extreme=not
24992: libsmartcols:      TAB: [0x564df9755130]: printing range
24992: libsmartcols:      TAB: [0x564df9755130]: printing line, line=0x564df97552f0, buff=0x564df97550f0
24992: libsmartcols:      TAB: [0x564df9755130]:  -> data, column=0x564df9755210, line=0x564df97552f0, cell=0x564df97555e0, buff=0x564df97550f0
24992: libsmartcols:      TAB: [0x564df9755130]:  -> data, column=0x564df97553b0, line=0x564df97552f0, cell=0x564df9755600, buff=0x564df97550f0
24992: libsmartcols:      COL: [0x564df97553b0]: setting pending data
24992: libsmartcols:      TAB: [0x564df9755130]:  -> data, column=0x564df9755500, line=0x564df97552f0, cell=0x564df9755620, buff=0x564df97550f0
cat    bird
24992: libsmartcols:      COL: [0x564df97553b0]: printing pending data
24992: libsmartcols:      COL: [0x564df97553b0]: step pending data 3 -= 0

24992: libsmartcols:      COL: [0x564df97553b0]: printing pending data
24992: libsmartcols:      COL: [0x564df97553b0]: step pending data 3 -= 0

and loop forever
```