### PR TITLE
setpriv: fix manpage typo

### DIFF
--- a/sys-utils/setpriv.1
+++ b/sys-utils/setpriv.1
@@ -111,7 +111,7 @@ does not change capabilities, although the exec call at the end might change
 capabilities.  This means that, if you are root, you probably want to do
 something like:
 .sp
-.B "        setpriv \-\-reuid=1000 \-\-regid=1000 \-\-caps=\-all"
+.B "        setpriv \-\-reuid=1000 \-\-regid=1000 \-\-inh\-caps=\-all"
 .TP
 .BR \-\-securebits " (" + | \- ) \fIsecurebit ...
 Set or clear securebits.  The argument is a comma-separated list.


### PR DESCRIPTION
The example given in the man page didn't work. Judging by commit
db663995bd93e170a43b1a7050c7a738782dabfb, --inh-caps= used to be called
--caps= but the man page was not updated after the change was made.