### PR TITLE
Test locks improvements

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -68,7 +68,7 @@ function check_nonroot
 
 function check_root
 {
-	local opts="$MAKE_CHECK_OPTS --parallel=1 --show-diff"
+	local opts="$MAKE_CHECK_OPTS --show-diff"
 
 	xconfigure \
 		--enable-all-programs \

--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -79,6 +79,9 @@ function check_root
 	osx_prepare_check
 	sudo -E $MAKE check TS_OPTS="$opts" || return
 
+	# root on osx has not enough permission for make install ;)
+	[ "$TRAVIS_OS_NAME" = "osx" ] && return
+
 	# keep PATH to make sure sudo would find $CC
 	sudo env "PATH=$PATH" $MAKE install || return
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       compiler: clang
-      env: MAKE_CHECK="nonroot"
+      env: MAKE_CHECK="root"
 
 branches:
   only:

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -744,7 +744,7 @@ function ts_lock {
 	fd=$(ts_find_free_fd) || ts_skip "failed to find lock fd"
 
 	eval "exec $fd>$lockfile"
-	flock --exclusive --timeout 30 $fd || ts_skip "failed to lock $resource"
+	flock --exclusive "$fd" || ts_skip "failed to lock $resource"
 	TS_LOCKFILE_FD["$resource"]="$fd"
 
 	###echo "[$$ $TS_TESTNAME] Locked   $resource"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -27,8 +27,21 @@ paraller_jobs=1
 
 function num_cpus()
 {
-	if lscpu -p &>/dev/null; then
-		lscpu -p | grep -cv '^#'
+	local num
+
+	# coreutils
+	if num=$(nproc --all 2>/dev/null); then
+		:
+	# BSD, OSX
+	elif num=$(sysctl -n hw.ncpu 2>/dev/null); then
+		:
+	else
+		num=$(grep -c "^processor" /proc/cpuinfo 2>/dev/null)
+	fi
+
+	# translate garbage output to "1"
+	if test "$num" -gt "0" 2>/dev/null ;then
+		echo "$num"
 	else
 		echo 1
 	fi

--- a/tests/ts/libmount/context
+++ b/tests/ts/libmount/context
@@ -111,7 +111,9 @@ ts_init_subtest "mount-by-uuid"
 mkdir -p $MOUNTPOINT &> /dev/null
 ts_run $TESTPROG --mount UUID="$UUID" $MOUNTPOINT >> $TS_OUTPUT 2>&1
 is_mounted $DEVICE  || echo "$DEVICE not mounted" >> $TS_OUTPUT 2>&1
+sleep 1
 ts_run $TESTPROG --umount $MOUNTPOINT >> $TS_OUTPUT 2>&1
+sleep 1
 is_mounted $DEVICE && echo "$DEVICE still mounted" >> $TS_OUTPUT 2>&1
 ts_finalize_subtest
 

--- a/tests/ts/minix/mkfs
+++ b/tests/ts/minix/mkfs
@@ -41,6 +41,7 @@ mkfs_and_mount_minix() {
 	ts_mount "minix" $dev $TS_MOUNTPOINT
 	ts_is_mounted $dev || ts_die "Cannot find $dev in /proc/mounts"
 	ts_log "umount the image"
+	udevadm settle
 	$TS_CMD_UMOUNT $dev
 	ts_finalize_subtest
 }

--- a/tests/ts/mount/label
+++ b/tests/ts/mount/label
@@ -34,7 +34,7 @@ ts_device_init
 DEVICE=$TS_LODEV
 
 mkfs.ext3 -L $LABEL $DEVICE &> /dev/null || ts_die "Cannot make ext3 on $DEVICE"
-
+udevadm settle
 ts_device_has "LABEL" $LABEL $DEVICE \
  || ts_die "Cannot find LABEL '$LABEL' on $DEVICE"
 

--- a/tests/ts/mount/umount-alltargets
+++ b/tests/ts/mount/umount-alltargets
@@ -79,6 +79,8 @@ function multi_mount() {
 	ts_log "prepare: Mount /dev/xxx1 to mnt3"
 	[ -d "${MNT}3" ] || mkdir -p ${MNT}3
 	$TS_CMD_MOUNT $DEV ${MNT}3 >> $TS_OUTPUT 2>&1
+
+	udevadm settle
 }
 
 # use the same top-level mountpoint for all sub-tests

--- a/tests/ts/mount/umount-recursive
+++ b/tests/ts/mount/umount-recursive
@@ -87,6 +87,7 @@ ts_log "E) Mount child-bind"
 mkdir -p $TS_MOUNTPOINT/bindC
 $TS_CMD_MOUNT --bind $TS_MOUNTPOINT/mntB/mntC $TS_MOUNTPOINT/bindC
 
+udevadm settle
 $TS_CMD_UMOUNT --recursive $TS_MOUNTPOINT >> $TS_OUTPUT 2>&1
 [ $? == 0 ] || ts_die "umount failed"
 

--- a/tests/ts/swapon/label
+++ b/tests/ts/swapon/label
@@ -35,6 +35,8 @@ DEVICE=$TS_LODEV
 $TS_CMD_MKSWAP -L $LABEL $DEVICE > /dev/null 2>> $TS_OUTPUT \
  || ts_die "Cannot make swap on $DEVICE"
 
+udevadm settle
+
 ts_device_has "LABEL" $LABEL $DEVICE \
  || ts_die "Cannot find LABEL '$LABEL' on $DEVICE"
 


### PR DESCRIPTION
To begin with, the parallel checks for user root still seem a bit unstable before and after this patch-set, at least on my personal devel machine. Most issues doesn't seem to be flock related but slow kernel/udev events or whatever it is.  Adding "udevadm settle" does not help for all cases. The issues get worse when machines are under heavy load. --parallel is just an amplifier here.

Anyways, this pull request should make things a bit better and more portable.

The major Linux bugfix here is patch 4 "tests: don't use unlocked resources". Though the bug would be shadowed by the next patch as well.

Finally we are enabling parallel root tests on travis, Let's see.