### PR TITLE
Flesh out setpriv man page a bit

### DIFF
--- a/sys-utils/setpriv.1
+++ b/sys-utils/setpriv.1
@@ -10,11 +10,22 @@ setpriv \- run a program with different Linux privilege settings
 Sets or queries various Linux privilege settings that are inherited across
 .BR execve (2).
 .PP
-The difference between the commands setpriv and su (or runuser) is that setpriv does
-not use open PAM session and does not ask for password.
-It's simple non-set-user-ID wrapper around
-.B execve
-system call.
+In comparison to
+.BR su (1)
+and
+.BR runuser (1),
+.BR setpriv (1)
+neither uses PAM, nor does it prompt for a password.
+It is a simple, non-setuid wrapper around
+.BR execve (2),
+and can be used to drop privileges in the same way as
+.BR setuidgid (8)
+from
+.BR daemontools ,
+.BR chpst (8)
+from
+.BR runit ,
+or similar tools shipped by other service managers.
 .SH OPTION
 .TP
 .B \-\-clear\-groups

--- a/sys-utils/setpriv.1
+++ b/sys-utils/setpriv.1
@@ -16,7 +16,7 @@ and
 .BR runuser (1),
 .BR setpriv (1)
 neither uses PAM, nor does it prompt for a password.
-It is a simple, non-setuid wrapper around
+It is a simple, non-set-user-ID wrapper around
 .BR execve (2),
 and can be used to drop privileges in the same way as
 .BR setuidgid (8)
@@ -175,6 +175,20 @@ Be careful with this tool \-\- it may have unexpected security consequences.
 For example, setting no_new_privs and then execing a program that is
 SELinux\-confined (as this tool would do) may prevent the SELinux
 restrictions from taking effect.
+.SH EXAMPLE
+If you're looking for behaviour similar to
+.BR su (1)/ runuser "(1), or " sudo (8)
+(without the
+.B -g
+option), try something like:
+.sp
+.B "    setpriv \-\-reuid=1000 \-\-regid=1000 \-\-init\-groups"
+.PP
+If you want to mimic daemontools'
+.BR setuid (8),
+try:
+.sp
+.B "    setpriv \-\-reuid=1000 \-\-regid=1000 \-\-clear\-groups"
 .SH SEE ALSO
 .BR runuser (1),
 .BR su (1),

--- a/sys-utils/setpriv.1
+++ b/sys-utils/setpriv.1
@@ -105,8 +105,9 @@ given as textual group name.
 .sp
 For safety, you must specify one of
 .BR \-\-clear\-groups ,
-.BR \-\-groups ", or"
-.BR \-\-keep\-groups
+.BR \-\-groups ,
+.BR \-\-keep\-groups ", or"
+.BR \-\-init\-groups
 if you set any primary
 .IR gid .
 .TP


### PR DESCRIPTION
Having read [Don't abuse su for dropping user privileges](https://jdebp.eu/FGA/dont-abuse-su-for-dropping-privileges.html), I've been wondering how to correctly use su/runuser in init scripts, cron jobs and so on. I've found almost no use of setpriv on Debian code search nor across GitHub. Perhaps some examples might help potential users feel a bit more confident using the command?

Note that I've not copied the example of using --inh-caps=-all from elsewhere in the man page. My testing indicates that it's not necessary to include this option to mimic su's behaviour...

    # setpriv --inh-caps=+all -- su sam -c 'setpriv -d'
    uid: 1000
    euid: 1000
    gid: 1000
    egid: 1000
    Supplementary groups: 4,27,115,1000
    no_new_privs: 0
    Inheritable capabilities: chown,dac_override,dac_read_search,fowner,fsetid,kill,setgid,setuid,setpcap,linux_immutable,net_bind_service,net_broadcast,net_admin,net_raw,ipc_lock,ipc_owner,sys_module,sys_rawio,sys_chroot,sys_ptrace,sys_psacct,sys_admin,sys_boot,sys_nice,sys_resource,sys_time,sys_tty_config,mknod,lease,audit_write,audit_control,setfcap,mac_override,mac_admin,syslog,wake_alarm,block_suspend,audit_read
    Ambient capabilities: [none]
    Capability bounding set: chown,dac_override,dac_read_search,fowner,fsetid,kill,setgid,setuid,setpcap,linux_immutable,net_bind_service,net_broadcast,net_admin,net_raw,ipc_lock,ipc_owner,sys_module,sys_rawio,sys_chroot,sys_ptrace,sys_psacct,sys_admin,sys_boot,sys_nice,sys_resource,sys_time,sys_tty_config,mknod,lease,audit_write,audit_control,setfcap,mac_override,mac_admin,syslog,wake_alarm,block_suspend,audit_read
    Securebits: [none]
    AppArmor profile: unconfined

... but I would appreciate someone who actually understands capabilities confirming whether this is the case.