### PR TITLE
discard null_blk_device

### DIFF
--- a/disk-utils/mkfs.c
+++ b/disk-utils/mkfs.c
@@ -117,6 +117,12 @@ int main(int argc, char **argv)
 		errtryhelp(EXIT_FAILURE);
 	}
 
+    /* If device is null_blk device, can't support */
+    if (strstr(argv[optind],"null")) {
+        warnx(_("null block device not supported"));
+        errtryhelp(EXIT_FAILURE);
+    }
+
 	/* If -t wasn't specified, use the default */
 	if (fstype == NULL)
 		fstype = DEFAULT_FSTYPE;

--- a/disk-utils/mkfs.c
+++ b/disk-utils/mkfs.c
@@ -117,11 +117,11 @@ int main(int argc, char **argv)
 		errtryhelp(EXIT_FAILURE);
 	}
 
-    /* If device is null_blk device, can't support */
-    if (strstr(argv[optind],"null")) {
-        warnx(_("null block device not supported"));
-        errtryhelp(EXIT_FAILURE);
-    }
+        /* If device is null_blk device, can't support */
+	if (strstr(argv[optind],"null")) {
+		warnx(_("null block device not supported"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	/* If -t wasn't specified, use the default */
 	if (fstype == NULL)


### PR DESCRIPTION
null_blk is new module for simulating multi queue device. ( https://www.kernel.org/doc/Documentation/block/null_blk.txt ) So It can't make any file system feature on that. but mkfs passed this thing.
