### PR TITLE
rename: fix/reverse the semantics of --no-overwrite in --symlink mode

### DIFF
--- a/misc-utils/rename.1
+++ b/misc-utils/rename.1
@@ -26,7 +26,9 @@ Show which files were renamed, if any.
 Do not make any changes.
 .TP
 .BR \-o , " \-\-no\-overwrite"
-Do not overwrite existing files.
+Do not overwrite existing files.  When
+.BR \-\-symlink
+is active, do not overwrite symlinks pointing to existing targets.
 .TP
 .BR \-V , " \-\-version"
 Display version information and exit.

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -113,7 +113,8 @@ static int do_file(char *from, char *to, char *s, int verbose, int noact, int no
 	if (string_replace(from, to, file, s, &newname))
 		return 0;
 	if (nooverwrite && access(newname, F_OK) == 0) {
-		printf(_("Skipping existing file: `%s'\n"), newname);
+		if (verbose)
+			printf(_("Skipping existing file: `%s'\n"), newname);
 		ret = 0;
 	}
 	else if (!noact && rename(s, newname) != 0) {

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -79,7 +79,7 @@ static int do_symlink(char *from, char *to, char *s, int verbose, int noact, int
 
 	if (ret == 1 && nooverwrite && lstat(target, &sb) == 0) {
 		if (verbose)
-			printf(_("Skipping existing link: `%s'\n"), target);
+			printf(_("Skipping existing link: `%s' -> `%s'\n"), s, target);
 
 		ret = 0;
 	}

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -77,9 +77,9 @@ static int do_symlink(char *from, char *to, char *s, int verbose, int noact, int
 	if (string_replace(from, to, target, target, &newname))
 		ret = 0;
 
-	if (ret == 1 && nooverwrite && lstat(newname, &sb) == 0) {
+	if (ret == 1 && nooverwrite && lstat(target, &sb) == 0) {
 		if (verbose)
-			printf(_("Skipping existing link: `%s'\n"), newname);
+			printf(_("Skipping existing link: `%s'\n"), target);
 
 		ret = 0;
 	}


### PR DESCRIPTION
The previous behaviour was to overwrite a symlink only when the new
destination did not exist, i.e. to avoid creating a symlink to an
existing file!  It had not been documented and it seems
counter-intuitive to me.  So the new behavior protects symlinks pointing
to existing targets from being changed.