### PR TITLE
rename: fix --no-act to not set --no-overwrite

### DIFF
--- a/misc-utils/rename.1
+++ b/misc-utils/rename.1
@@ -26,7 +26,9 @@ Show which files were renamed, if any.
 Do not make any changes.
 .TP
 .BR \-o , " \-\-no\-overwrite"
-Do not overwrite existing files.
+Do not overwrite existing files.  When
+.BR \-\-symlink
+is active, do not overwrite symlinks pointing to existing targets.
 .TP
 .BR \-V , " \-\-version"
 Display version information and exit.

--- a/misc-utils/rename.1
+++ b/misc-utils/rename.1
@@ -23,7 +23,9 @@ Do not rename a symlink but its target.
 Show which files were renamed, if any.
 .TP
 .BR \-n , " \-\-no\-act"
-Do not make any changes.
+Do not make any changes; add
+.BR \-\-verbose
+to see what would be made.
 .TP
 .BR \-o , " \-\-no\-overwrite"
 Do not overwrite existing files.  When

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -113,7 +113,8 @@ static int do_file(char *from, char *to, char *s, int verbose, int noact, int no
 	if (string_replace(from, to, file, s, &newname))
 		return 0;
 	if (nooverwrite && access(newname, F_OK) == 0) {
-		printf(_("Skipping existing file: `%s'\n"), newname);
+		if (verbose)
+			printf(_("Skipping existing file: `%s'\n"), newname);
 		ret = 0;
 	}
 	else if (!noact && rename(s, newname) != 0) {

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -79,7 +79,7 @@ static int do_symlink(char *from, char *to, char *s, int verbose, int noact, int
 
 	if (ret == 1 && nooverwrite && lstat(target, &sb) == 0) {
 		if (verbose)
-			printf(_("Skipping existing link: `%s'\n"), target);
+			printf(_("Skipping existing link: `%s' -> `%s'\n"), s, target);
 
 		ret = 0;
 	}

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -174,12 +174,12 @@ int main(int argc, char **argv)
 		switch (c) {
 		case 'n':
 			noact = 1;
-			/* fallthrough */
-		case 'o':
-			nooverwrite = 1;
-                        break;
+			break;
 		case 'v':
 			verbose = 1;
+			break;
+		case 'o':
+			nooverwrite = 1;
 			break;
 		case 's':
 			do_rename = do_symlink;

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -77,9 +77,9 @@ static int do_symlink(char *from, char *to, char *s, int verbose, int noact, int
 	if (string_replace(from, to, target, target, &newname))
 		ret = 0;
 
-	if (ret == 1 && nooverwrite && lstat(newname, &sb) == 0) {
+	if (ret == 1 && nooverwrite && lstat(target, &sb) == 0) {
 		if (verbose)
-			printf(_("Skipping existing link: `%s'\n"), newname);
+			printf(_("Skipping existing link: `%s'\n"), target);
 
 		ret = 0;
 	}


### PR DESCRIPTION
This fixes a bug introduced by commit fabb90676 ("Added --no-override
option to rename.", 2017-05-27) where the fallthrough meant to let
--no-act set --verbose was changed to set --no-override (the previous
code was too smart).                                        
                                                                    
Do not let --no-act set --verbose anymore but update the manual to
recommend adding option --verbose.  This is to be able to make --no-act
detect only non existing file arguments (in a future commit).