### PR TITLE
rename: check source file existence early

### DIFF
--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -60,7 +60,11 @@ static int do_symlink(char *from, char *to, char *s, int verbose, int noact, int
 	int ret = 1;
 	struct stat sb;
 
-	if (faccessat(AT_FDCWD, s, F_OK, AT_SYMLINK_NOFOLLOW) != 0) {
+	if ( faccessat(AT_FDCWD, s, F_OK, AT_SYMLINK_NOFOLLOW) != 0 &&
+	     errno != EINVAL )
+	   /* Skip if AT_SYMLINK_NOFOLLOW is not supported; lstat() below will
+	      detect the access error */
+	{
 		warn(_("%s: not accessible"), s);
 		return 2;
 	}


### PR DESCRIPTION
This change makes rename detect inexisting files given on the command
line and consider them faliures.  This is particularly useful with
--no-act (to detect extraneous arguments).

It also prevents skipping non existing files (when the modified name
happens to exist).  This makes --verbose not print skipping messages of
false positives (the access error is printed instead).

This pull request is based on top of #610.