### PR TITLE
build: Add missing -lintl linkage to lib{smartcols,uuid}

### DIFF
--- a/libsmartcols/src/Makemodule.am
+++ b/libsmartcols/src/Makemodule.am
@@ -19,7 +19,7 @@ libsmartcols_la_SOURCES= \
 	libsmartcols/src/version.c \
 	libsmartcols/src/init.c
 
-libsmartcols_la_LIBADD = libcommon.la
+libsmartcols_la_LIBADD = libcommon.la $(LTLIBINTL)
 
 libsmartcols_la_CFLAGS = \
 	$(AM_CFLAGS) \

--- a/libuuid/src/Makemodule.am
+++ b/libuuid/src/Makemodule.am
@@ -31,7 +31,7 @@ libuuid_la_SOURCES = \
 EXTRA_libuuid_la_DEPENDENCIES = \
 	libuuid/src/libuuid.sym
 
-libuuid_la_LIBADD       = $(SOCKET_LIBS)
+libuuid_la_LIBADD       = $(SOCKET_LIBS) $(LTLIBINTL)
 
 libuuid_la_CFLAGS = \
 	$(AM_CFLAGS) \


### PR DESCRIPTION
Add missing $(LTLIBINTL) linkage to libsmartcols and libuuid. Those
libraries apparently use gettext functions (via libcommon). Failing
to link $(LTLIBINTL) explicitly may cause programs linking against
them to fail to link afterwards on FreeBSD.