### PR TITLE
lslocks: fix memory leak in add_scols_line

### DIFF
--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -434,6 +434,10 @@ static void add_scols_line(struct libscols_table *table, struct lock *l, struct 
 
 		if (str && scols_line_set_data(line, i, str))
 			err(EXIT_FAILURE, _("failed to add output data"));
+
+        if (str != NULL){
+            free(str);
+        }
 	}
 }
 


### PR DESCRIPTION
Free str after at the end of iteration.