### PR TITLE
bugfix: fix possible segfault during umount -a

### DIFF
--- a/libmount/src/context_umount.c
+++ b/libmount/src/context_umount.c
@@ -1003,10 +1003,11 @@ int mnt_context_next_umount(struct libmnt_context *cxt,
 	rc = mnt_context_get_mtab(cxt, &mtab);
 	cxt->mtab = NULL;		/* do not reset mtab */
 	mnt_reset_context(cxt);
-	cxt->mtab = mtab;
 
 	if (rc)
 		return rc;
+
+	cxt->mtab = mtab;
 
 	do {
 		rc = mnt_table_next_fs(mtab, itr, fs);


### PR DESCRIPTION
mnt_context_get_mtab() doesn't set its return **tb argument on error,
and so in mnt_context_next_umount() mtab will remain uninitialized on
error, later resulting in cxt->mtab containing garbage, possibly
resulting in segfault on exit.

Should be cherry-picked to affected stable branches.