### PR TITLE
(u)mount in different namespace

### DIFF
--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -20,6 +20,7 @@ mnt_resolve_target
 <SECTION>
 <FILE>context</FILE>
 libmnt_context
+libmnt_ns
 mnt_free_context
 mnt_new_context
 mnt_reset_context
@@ -53,11 +54,13 @@ mnt_context_get_mtab
 mnt_context_get_mtab_userdata
 mnt_context_get_options
 mnt_context_get_optsmode
+mnt_context_get_origin_ns
 mnt_context_get_source
 mnt_context_get_status
 mnt_context_get_syscall_errno
 mnt_context_get_table
 mnt_context_get_target
+mnt_context_get_target_ns
 mnt_context_get_user_mflags
 mnt_context_helper_executed
 mnt_context_helper_setopt
@@ -95,8 +98,12 @@ mnt_context_set_source
 mnt_context_set_syscall_status
 mnt_context_set_tables_errcb
 mnt_context_set_target
+mnt_context_set_target_ns
 mnt_context_set_user_mflags
 mnt_context_strerror
+mnt_context_switch_ns
+mnt_context_switch_origin_ns
+mnt_context_switch_target_ns
 mnt_context_syscall_called
 mnt_context_tab_applied
 mnt_context_wait_for_children
@@ -110,6 +117,7 @@ MNT_ERR_NOFSTYPE
 MNT_ERR_NOSOURCE
 MNT_ERR_LOOPOVERLAP
 MNT_ERR_LOCK
+MNT_ERR_NAMESPACE
 <SUBSECTION>
 MNT_EX_SUCCESS
 MNT_EX_USAGE

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -113,13 +113,14 @@ void mnt_free_context(struct libmnt_context *cxt)
  * Resets all information in the context that is directly related to
  * the latest mount (spec, source, target, mount options, ...).
  *
- * The match patterns, cached fstab, cached canonicalized paths and tags and
- * [e]uid are not reset. You have to use
+ * The match patterns, target namespace, cached fstab, cached canonicalized
+ * paths and tags and [e]uid are not reset. You have to use
  *
  *	mnt_context_set_fstab(cxt, NULL);
  *	mnt_context_set_cache(cxt, NULL);
  *	mnt_context_set_fstype_pattern(cxt, NULL);
  *	mnt_context_set_options_pattern(cxt, NULL);
+ *	mnt_context_set_target_ns(cxt, NULL);
  *
  *
  * to reset this stuff.

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -213,6 +213,8 @@ int mnt_context_reset_status(struct libmnt_context *cxt)
 
 static int context_init_paths(struct libmnt_context *cxt, int writable)
 {
+	struct libmnt_ns *ns_old;
+
 	assert(cxt);
 
 #ifdef USE_LIBMOUNT_SUPPORT_MTAB
@@ -233,12 +235,19 @@ static int context_init_paths(struct libmnt_context *cxt, int writable)
 
 	cxt->mtab_writable = 0;
 
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
+
 #ifdef USE_LIBMOUNT_SUPPORT_MTAB
 	mnt_has_regular_mtab(&cxt->mtab_path, &cxt->mtab_writable);
 	if (!cxt->mtab_writable)
 #endif
 		/* use /run/mount/utab if /etc/mtab is useless */
 		mnt_has_regular_utab(&cxt->utab_path, &cxt->utab_writable);
+
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 
 	cxt->flags |= MNT_FL_TABPATHS_CHECKED;
 	return 0;
@@ -1031,6 +1040,8 @@ int mnt_context_set_fstab(struct libmnt_context *cxt, struct libmnt_table *tb)
  */
 int mnt_context_get_fstab(struct libmnt_context *cxt, struct libmnt_table **tb)
 {
+	struct libmnt_ns *ns_old;
+
 	if (!cxt)
 		return -EINVAL;
 	if (!cxt->fstab) {
@@ -1041,8 +1052,17 @@ int mnt_context_get_fstab(struct libmnt_context *cxt, struct libmnt_table **tb)
 			return -ENOMEM;
 		if (cxt->table_errcb)
 			mnt_table_set_parser_errcb(cxt->fstab, cxt->table_errcb);
+
+		ns_old = mnt_context_switch_target_ns(cxt);
+		if (!ns_old)
+			return -MNT_ERR_NAMESPACE;
+
 		mnt_table_set_cache(cxt->fstab, mnt_context_get_cache(cxt));
 		rc = mnt_table_parse_fstab(cxt->fstab, NULL);
+
+		if (!mnt_context_switch_ns(cxt, ns_old))
+			return -MNT_ERR_NAMESPACE;
+
 		if (rc)
 			return rc;
 	}
@@ -1064,16 +1084,23 @@ int mnt_context_get_fstab(struct libmnt_context *cxt, struct libmnt_table **tb)
  */
 int mnt_context_get_mtab(struct libmnt_context *cxt, struct libmnt_table **tb)
 {
+	int rc = 0;
+	struct libmnt_ns *ns_old = NULL;
+
 	if (!cxt)
 		return -EINVAL;
 	if (!cxt->mtab) {
-		int rc;
+		ns_old = mnt_context_switch_target_ns(cxt);
+		if (!ns_old)
+			return -MNT_ERR_NAMESPACE;
 
 		context_init_paths(cxt, 0);
 
 		cxt->mtab = mnt_new_table();
-		if (!cxt->mtab)
-			return -ENOMEM;
+		if (!cxt->mtab) {
+			rc = -ENOMEM;
+			goto end;
+		}
 
 		if (cxt->table_errcb)
 			mnt_table_set_parser_errcb(cxt->mtab, cxt->table_errcb);
@@ -1094,7 +1121,7 @@ int mnt_context_get_mtab(struct libmnt_context *cxt, struct libmnt_table **tb)
 		else
 			rc = mnt_table_parse_mtab(cxt->mtab, cxt->mtab_path);
 		if (rc)
-			return rc;
+			goto end;
 	}
 
 	if (tb)
@@ -1102,7 +1129,12 @@ int mnt_context_get_mtab(struct libmnt_context *cxt, struct libmnt_table **tb)
 
 	DBG(CXT, ul_debugobj(cxt, "mtab requested [nents=%d]",
 				mnt_table_get_nents(cxt->mtab)));
-	return 0;
+
+end:
+	if (ns_old && !mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
+
+	return rc;
 }
 
 /*
@@ -1132,6 +1164,11 @@ int mnt_context_get_mtab_for_target(struct libmnt_context *cxt,
 	struct libmnt_cache *cache = NULL;
 	char *cn_tgt = NULL;
 	int rc;
+	struct libmnt_ns *ns_old;
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	if (mnt_context_is_nocanonicalize(cxt))
 		mnt_context_set_tabfilter(cxt, mtab_filter, (void *) tgt);
@@ -1145,6 +1182,9 @@ int mnt_context_get_mtab_for_target(struct libmnt_context *cxt,
 
 	rc = mnt_context_get_mtab(cxt, mtab);
 	mnt_context_set_tabfilter(cxt, NULL, NULL);
+
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 
 	if (cn_tgt && !cache)
 		free(cn_tgt);
@@ -1198,6 +1238,7 @@ int mnt_context_get_table(struct libmnt_context *cxt,
 			  const char *filename, struct libmnt_table **tb)
 {
 	int rc;
+	struct libmnt_ns *ns_old;
 
 	if (!cxt || !tb)
 		return -EINVAL;
@@ -1209,14 +1250,24 @@ int mnt_context_get_table(struct libmnt_context *cxt,
 	if (cxt->table_errcb)
 		mnt_table_set_parser_errcb(*tb, cxt->table_errcb);
 
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
+
 	rc = mnt_table_parse_file(*tb, filename);
+
 	if (rc) {
 		mnt_unref_table(*tb);
-		return rc;
+		goto end;
 	}
 
 	mnt_table_set_cache(*tb, mnt_context_get_cache(cxt));
-	return 0;
+
+end:
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
+
+	return rc;
 }
 
 /**
@@ -1522,6 +1573,7 @@ int mnt_context_prepare_srcpath(struct libmnt_context *cxt)
 	struct libmnt_cache *cache;
 	const char *t, *v, *src;
 	int rc = 0;
+	struct libmnt_ns *ns_old;
 
 	assert(cxt);
 	assert(cxt->fs);
@@ -1542,6 +1594,10 @@ int mnt_context_prepare_srcpath(struct libmnt_context *cxt)
 		return 0;
 
 	DBG(CXT, ul_debugobj(cxt, "srcpath '%s'", src));
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	cache = mnt_context_get_cache(cxt);
 
@@ -1565,7 +1621,7 @@ int mnt_context_prepare_srcpath(struct libmnt_context *cxt)
 
 	if (rc) {
 		DBG(CXT, ul_debugobj(cxt, "failed to prepare srcpath [rc=%d]", rc));
-		return rc;
+		goto end;
 	}
 
 	if (!path)
@@ -1574,7 +1630,7 @@ int mnt_context_prepare_srcpath(struct libmnt_context *cxt)
 	if ((cxt->mountflags & (MS_BIND | MS_MOVE | MS_REMOUNT))
 	    || mnt_fs_is_pseudofs(cxt->fs)) {
 		DBG(CXT, ul_debugobj(cxt, "REMOUNT/BIND/MOVE/pseudo FS source: %s", path));
-		return rc;
+		goto end;
 	}
 
 	/*
@@ -1583,12 +1639,16 @@ int mnt_context_prepare_srcpath(struct libmnt_context *cxt)
 	if (mnt_context_is_loopdev(cxt)) {
 		rc = mnt_context_setup_loopdev(cxt);
 		if (rc)
-			return rc;
+			goto end;
 	}
 
 	DBG(CXT, ul_debugobj(cxt, "final srcpath '%s'",
 				mnt_fs_get_source(cxt->fs)));
-	return 0;
+
+end:
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
+	return rc;
 }
 
 /* create a mountpoint if X-mount.mkdir[=<mode>] specified */
@@ -1641,6 +1701,7 @@ int mnt_context_prepare_target(struct libmnt_context *cxt)
 	const char *tgt;
 	struct libmnt_cache *cache;
 	int rc = 0;
+	struct libmnt_ns *ns_old;
 
 	assert(cxt);
 	assert(cxt->fs);
@@ -1652,6 +1713,10 @@ int mnt_context_prepare_target(struct libmnt_context *cxt)
 	if (!tgt)
 		return 0;
 
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
+
 	/* mkdir target */
 	if (cxt->action == MNT_ACT_MOUNT
 	    && !mnt_context_is_restricted(cxt)
@@ -1659,8 +1724,11 @@ int mnt_context_prepare_target(struct libmnt_context *cxt)
 		cxt->user_mountflags & MNT_MS_XFSTABCOMM)) {
 
 		rc = mkdir_target(tgt, cxt->fs);
-		if (rc)
+		if (rc) {
+			if (!mnt_context_switch_ns(cxt, ns_old))
+				return -MNT_ERR_NAMESPACE;
 			return rc;	/* mkdir or parse error */
+		}
 	}
 
 	/* canonicalize the path */
@@ -1670,6 +1738,9 @@ int mnt_context_prepare_target(struct libmnt_context *cxt)
 		if (path && strcmp(path, tgt) != 0)
 			rc = mnt_fs_set_target(cxt->fs, path);
 	}
+
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 
 	if (rc)
 		DBG(CXT, ul_debugobj(cxt, "failed to prepare target '%s'", tgt));
@@ -1686,12 +1757,17 @@ int mnt_context_prepare_target(struct libmnt_context *cxt)
 int mnt_context_guess_srcpath_fstype(struct libmnt_context *cxt, char **type)
 {
 	int rc = 0;
+	struct libmnt_ns *ns_old;
 	const char *dev = mnt_fs_get_srcpath(cxt->fs);
 
 	*type = NULL;
 
 	if (!dev)
 		goto done;
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	if (access(dev, F_OK) == 0) {
 		struct libmnt_cache *cache = mnt_context_get_cache(cxt);
@@ -1709,6 +1785,9 @@ int mnt_context_guess_srcpath_fstype(struct libmnt_context *cxt, char **type)
 		else if (!strncmp(dev, "//", 2))
 			*type = strdup("cifs");
 	}
+
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 
 done:
 	return rc;
@@ -1771,6 +1850,7 @@ int mnt_context_prepare_helper(struct libmnt_context *cxt, const char *name,
 {
 	char search_path[] = FS_SEARCH_PATH;		/* from config.h */
 	char *p = NULL, *path;
+	struct libmnt_ns *ns_old;
 
 	assert(cxt);
 	assert(cxt->fs);
@@ -1788,6 +1868,10 @@ int mnt_context_prepare_helper(struct libmnt_context *cxt, const char *name,
 	    || strstr(type, "/..")		/* don't try to smuggle path */
 	    || mnt_fs_is_swaparea(cxt->fs))
 		return 0;
+
+	ns_old = mnt_context_switch_origin_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	path = strtok_r(search_path, ":", &p);
 	while (path) {
@@ -1816,6 +1900,9 @@ int mnt_context_prepare_helper(struct libmnt_context *cxt, const char *name,
 		if (rc)
 			continue;
 
+		if (!mnt_context_switch_ns(cxt, ns_old))
+			return -MNT_ERR_NAMESPACE;
+
 		free(cxt->helper);
 		cxt->helper = strdup(helper);
 		if (!cxt->helper)
@@ -1823,6 +1910,8 @@ int mnt_context_prepare_helper(struct libmnt_context *cxt, const char *name,
 		return 0;
 	}
 
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 	return 0;
 }
 
@@ -1925,6 +2014,8 @@ int mnt_context_prepare_update(struct libmnt_context *cxt)
 int mnt_context_update_tabs(struct libmnt_context *cxt)
 {
 	unsigned long fl;
+	int rc = 0;
+	struct libmnt_ns *ns_old;
 
 	assert(cxt);
 
@@ -1937,6 +2028,10 @@ int mnt_context_update_tabs(struct libmnt_context *cxt)
 		return 0;
 	}
 
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
+
 	/* check utab update when external helper executed */
 	if (mnt_context_helper_executed(cxt)
 	    && mnt_context_get_helper_status(cxt) == 0
@@ -1944,11 +2039,11 @@ int mnt_context_update_tabs(struct libmnt_context *cxt)
 
 		if (mnt_update_already_done(cxt->update, cxt->lock)) {
 			DBG(CXT, ul_debugobj(cxt, "don't update: error evaluate or already updated"));
-			return 0;
+			goto end;
 		}
 	} else if (cxt->helper) {
 		DBG(CXT, ul_debugobj(cxt, "don't update: external helper"));
-		return 0;
+		goto end;
 	}
 
 	if (cxt->syscall_status != 0
@@ -1956,7 +2051,7 @@ int mnt_context_update_tabs(struct libmnt_context *cxt)
 		 mnt_context_get_helper_status(cxt) == 0)) {
 
 		DBG(CXT, ul_debugobj(cxt, "don't update: syscall/helper failed/not called"));
-		return 0;
+		goto end;
 	}
 
 	fl = mnt_update_get_mflags(cxt->update);
@@ -1967,7 +2062,12 @@ int mnt_context_update_tabs(struct libmnt_context *cxt)
 		mnt_update_force_rdonly(cxt->update,
 				cxt->mountflags & MS_RDONLY);
 
-	return mnt_update_table(cxt->update, cxt->lock);
+	rc = mnt_update_table(cxt->update, cxt->lock);
+
+end:
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
+	return rc;
 }
 
 static int apply_table(struct libmnt_context *cxt, struct libmnt_table *tb,
@@ -2055,6 +2155,7 @@ static int apply_table(struct libmnt_context *cxt, struct libmnt_table *tb,
 int mnt_context_apply_fstab(struct libmnt_context *cxt)
 {
 	int rc = -1, isremount = 0, iscmdbind = 0;
+	struct libmnt_ns *ns_old;
 	struct libmnt_table *tab = NULL;
 	const char *src = NULL, *tgt = NULL;
 	unsigned long mflags = 0;
@@ -2116,6 +2217,10 @@ int mnt_context_apply_fstab(struct libmnt_context *cxt)
 	/* let's initialize cxt->fs */
 	ignore_result( mnt_context_get_fs(cxt) );
 
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
+
 	/* try fstab */
 	if (cxt->optsmode & MNT_OMODE_FSTAB) {
 		DBG(CXT, ul_debugobj(cxt, "trying to apply fstab (src=%s, target=%s)", src, tgt));
@@ -2135,6 +2240,10 @@ int mnt_context_apply_fstab(struct libmnt_context *cxt)
 		if (!rc)
 			rc = apply_table(cxt, tab, MNT_ITER_BACKWARD);
 	}
+
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
+
 	if (rc) {
 		if (!mnt_context_is_restricted(cxt)
 		    && tgt && !src
@@ -2469,9 +2578,14 @@ int mnt_context_is_fs_mounted(struct libmnt_context *cxt,
 {
 	struct libmnt_table *mtab, *orig;
 	int rc;
+	struct libmnt_ns *ns_old;
 
 	if (!cxt || !fs || !mounted)
 		return -EINVAL;
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	orig = cxt->mtab;
 	rc = mnt_context_get_mtab(cxt, &mtab);
@@ -2487,6 +2601,9 @@ int mnt_context_is_fs_mounted(struct libmnt_context *cxt,
 		return rc;
 
 	*mounted = mnt_table_is_fs_mounted(mtab, fs);
+
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 	return 0;
 }
 

--- a/libmount/src/context_loopdev.c
+++ b/libmount/src/context_loopdev.c
@@ -89,6 +89,7 @@ is_mounted_same_loopfile(struct libmnt_context *cxt,
 	struct libmnt_cache *cache;
 	const char *bf;
 	int rc = 0;
+	struct libmnt_ns *ns_old;
 
 	assert(cxt);
 	assert(cxt->fs);
@@ -96,6 +97,10 @@ is_mounted_same_loopfile(struct libmnt_context *cxt,
 
 	if (mnt_context_get_mtab(cxt, &tb))
 		return 0;
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	DBG(LOOP, ul_debugobj(cxt, "checking if %s mounted on %s",
 				backing_file, target));
@@ -132,6 +137,9 @@ is_mounted_same_loopfile(struct libmnt_context *cxt,
 	}
 	if (rc)
 		DBG(LOOP, ul_debugobj(cxt, "%s already mounted", backing_file));
+
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 	return rc;
 }
 

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -171,6 +171,7 @@ static int is_option(const char *name, size_t namesz,
 static int fix_optstr(struct libmnt_context *cxt)
 {
 	int rc = 0;
+	struct libmnt_ns *ns_old;
 	char *next;
 	char *name, *val;
 	size_t namesz, valsz;
@@ -329,8 +330,17 @@ static int fix_optstr(struct libmnt_context *cxt)
 			goto done;
 	}
 
-	if (!rc && cxt->restricted && (cxt->user_mountflags & MNT_MS_USER))
+
+	if (!rc && cxt->restricted && (cxt->user_mountflags & MNT_MS_USER)) {
+		ns_old = mnt_context_switch_origin_ns(cxt);
+		if (!ns_old)
+			return -MNT_ERR_NAMESPACE;
+
 		rc = mnt_optstr_fix_user(&fs->user_optstr);
+
+		if (!mnt_context_switch_ns(cxt, ns_old))
+			return -MNT_ERR_NAMESPACE;
+	}
 
 	/* refresh merged optstr */
 	free(fs->optstr);
@@ -616,6 +626,9 @@ static int exec_helper(struct libmnt_context *cxt)
 		if (setuid(getuid()) < 0)
 			_exit(EXIT_FAILURE);
 
+		if (!mnt_context_switch_origin_ns(cxt))
+			_exit(EXIT_FAILURE);
+
 		type = mnt_fs_get_fstype(cxt->fs);
 
 		args[i++] = cxt->helper;		/* 1 */
@@ -876,6 +889,7 @@ static int do_mount_by_pattern(struct libmnt_context *cxt, const char *pattern)
 	int neg = pattern && strncmp(pattern, "no", 2) == 0;
 	int rc = -EINVAL;
 	char **filesystems, **fp;
+	struct libmnt_ns *ns_old;
 
 	assert(cxt);
 	assert((cxt->flags & MNT_FL_MOUNTFLAGS_MERGED));
@@ -893,7 +907,12 @@ static int do_mount_by_pattern(struct libmnt_context *cxt, const char *pattern)
 	/*
 	 * Apply pattern to /etc/filesystems and /proc/filesystems
 	 */
+	ns_old = mnt_context_switch_origin_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 	rc = mnt_get_filesystems(&filesystems, neg ? pattern : NULL);
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 	if (rc)
 		return rc;
 
@@ -923,6 +942,7 @@ static int do_mount_by_pattern(struct libmnt_context *cxt, const char *pattern)
 int mnt_context_prepare_mount(struct libmnt_context *cxt)
 {
 	int rc = -EINVAL;
+	struct libmnt_ns *ns_old;
 
 	if (!cxt || !cxt->fs || mnt_fs_is_swaparea(cxt->fs))
 		return -EINVAL;
@@ -935,6 +955,10 @@ int mnt_context_prepare_mount(struct libmnt_context *cxt)
 	assert(cxt->syscall_status == 1);
 
 	cxt->action = MNT_ACT_MOUNT;
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	DBG(CXT, ul_debugobj(cxt, "mount: preparing"));
 
@@ -955,9 +979,14 @@ int mnt_context_prepare_mount(struct libmnt_context *cxt)
 		rc = mnt_context_prepare_helper(cxt, "mount", NULL);
 	if (rc) {
 		DBG(CXT, ul_debugobj(cxt, "mount: preparing failed"));
-		return rc;
+		goto end;
 	}
 	cxt->flags |= MNT_FL_PREPARED;
+
+end:
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
+
 	return rc;
 }
 
@@ -987,6 +1016,7 @@ int mnt_context_do_mount(struct libmnt_context *cxt)
 {
 	const char *type;
 	int res;
+	struct libmnt_ns *ns_old;
 
 	assert(cxt);
 	assert(cxt->fs);
@@ -1000,6 +1030,10 @@ int mnt_context_do_mount(struct libmnt_context *cxt)
 
 	if (!(cxt->flags & MNT_FL_MOUNTDATA))
 		cxt->mountdata = (char *) mnt_fs_get_fs_options(cxt->fs);
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	type = mnt_fs_get_fstype(cxt->fs);
 	if (type) {
@@ -1052,6 +1086,8 @@ int mnt_context_do_mount(struct libmnt_context *cxt)
 		}
 	}
 #endif
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 
 	return res;
 }
@@ -1111,11 +1147,16 @@ int mnt_context_finalize_mount(struct libmnt_context *cxt)
 int mnt_context_mount(struct libmnt_context *cxt)
 {
 	int rc;
+	struct libmnt_ns *ns_old;
 
 	assert(cxt);
 	assert(cxt->fs);
 	assert(cxt->helper_exec_status == 1);
 	assert(cxt->syscall_status == 1);
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 again:
 	rc = mnt_context_prepare_mount(cxt);
@@ -1151,6 +1192,8 @@ again:
 			goto again;
 		}
 	}
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 	return rc;
 }
 
@@ -1305,6 +1348,11 @@ static int is_shared_tree(struct libmnt_context *cxt, const char *dir)
 	unsigned long mflags = 0;
 	char *mnt = NULL, *p;
 	int rc = 0;
+	struct libmnt_ns *ns_old;
+
+	ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		return -MNT_ERR_NAMESPACE;
 
 	if (!dir)
 		return 0;
@@ -1326,6 +1374,8 @@ static int is_shared_tree(struct libmnt_context *cxt, const char *dir)
 		&& (mflags & MS_SHARED);
 done:
 	free(mnt);
+	if (!mnt_context_switch_ns(cxt, ns_old))
+		return -MNT_ERR_NAMESPACE;
 	return rc;
 }
 

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1413,6 +1413,10 @@ int mnt_context_get_mount_excode(
 			if (buf)
 				snprintf(buf, bufsz, _("locking failed"));
 			return MNT_EX_FILEIO;
+		case -MNT_ERR_NAMESPACE:
+			if (buf)
+				snprintf(buf, bufsz, _("failed to switch namespace"));
+			return MNT_EX_SYSERR;
 		default:
 			return mnt_context_get_generic_excode(rc, buf, bufsz, _("mount failed: %m"));
 		}
@@ -1426,6 +1430,10 @@ int mnt_context_get_mount_excode(
 			if (buf)
 				snprintf(buf, bufsz, _("filesystem was mounted, but failed to update userspace mount table"));
 			return MNT_EX_FILEIO;
+		} else if (rc == -MNT_ERR_NAMESPACE) {
+			if (buf)
+				snprintf(buf, bufsz, _("filesystem was mounted, but failed to switch namespace back"));
+			return MNT_EX_SYSERR;
 
 		} else if (rc < 0)
 			return mnt_context_get_generic_excode(rc, buf, bufsz,

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -565,6 +565,10 @@ int mnt_context_mount_setopt(struct libmnt_context *cxt, int c, char *arg)
 		if (arg)
 			rc = mnt_context_set_fstype(cxt, arg);
 		break;
+	case 'N':
+		if (arg)
+			rc = mnt_context_set_target_ns(cxt, arg);
+		break;
 	default:
 		return 1;
 	}
@@ -574,7 +578,8 @@ int mnt_context_mount_setopt(struct libmnt_context *cxt, int c, char *arg)
 
 static int exec_helper(struct libmnt_context *cxt)
 {
-	char *o = NULL;
+	char *o = NULL, *namespace = NULL;
+	struct libmnt_ns *ns_tgt = mnt_context_get_target_ns(cxt);
 	int rc;
 	pid_t pid;
 
@@ -589,13 +594,20 @@ static int exec_helper(struct libmnt_context *cxt)
 	if (rc)
 		return -EINVAL;
 
+	if (ns_tgt->fd != -1
+	    && asprintf(&namespace, "/proc/%i/fd/%i",
+			getpid(), ns_tgt->fd) == -1) {
+		free(o);
+		return -ENOMEM;
+	}
+
 	DBG_FLUSH;
 
 	pid = fork();
 	switch (pid) {
 	case 0:
 	{
-		const char *args[12], *type;
+		const char *args[14], *type;
 		int i = 0;
 
 		if (setgid(getgid()) < 0)
@@ -628,7 +640,11 @@ static int exec_helper(struct libmnt_context *cxt)
 			args[i++] = "-t";		/* 10 */
 			args[i++] = type;		/* 11 */
 		}
-		args[i] = NULL;				/* 12 */
+		if (namespace) {
+			args[i++] = "-N";		/* 11 */
+			args[i++] = namespace;		/* 12 */
+		}
+		args[i] = NULL;				/* 13 */
 		for (i = 0; args[i]; i++)
 			DBG(CXT, ul_debugobj(cxt, "argv[%d] = \"%s\"",
 							i, args[i]));

--- a/libmount/src/context_umount.c
+++ b/libmount/src/context_umount.c
@@ -1075,6 +1075,10 @@ int mnt_context_get_umount_excode(
 			if (buf)
 				snprintf(buf, bufsz, _("locking failed"));
 			return MNT_EX_FILEIO;
+		} else if (rc == -MNT_ERR_NAMESPACE) {
+			if (buf)
+				snprintf(buf, bufsz, _("failed to switch namespace"));
+			return MNT_EX_SYSERR;
 		}
 		return mnt_context_get_generic_excode(rc, buf, bufsz,
 					_("umount failed: %m"));
@@ -1088,6 +1092,10 @@ int mnt_context_get_umount_excode(
 			if (buf)
 				snprintf(buf, bufsz, _("filesystem was unmounted, but failed to update userspace mount table"));
 			return MNT_EX_FILEIO;
+		} else if (rc == -MNT_ERR_NAMESPACE) {
+			if (buf)
+				snprintf(buf, bufsz, _("filesystem was unmounted, but failed to switch namespace back"));
+			return MNT_EX_SYSERR;
 
 		} else if (rc < 0)
 			return mnt_context_get_generic_excode(rc, buf, bufsz,

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -205,6 +205,12 @@ enum {
  * failed to lock mtab/utab or so.
  */
 #define MNT_ERR_LOCK         5008
+/**
+ * MNT_ERR_NAMESPACE:
+ *
+ * failed to switch namespace
+ */
+#define MNT_ERR_NAMESPACE    5009
 
 
 /*

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -128,6 +128,13 @@ struct libmnt_monitor;
  */
 struct libmnt_tabdiff;
 
+/**
+ * libmnt_ns:
+ *
+ * Describes mount namespace
+ */
+struct libmnt_ns;
+
 /*
  * Actions
  */
@@ -814,6 +821,13 @@ extern int mnt_context_strerror(struct libmnt_context *cxt, char *buf,
 
 extern int mnt_context_get_excode(struct libmnt_context *cxt,
                         int rc, char *buf, size_t bufsz);
+
+extern int mnt_context_set_target_ns(struct libmnt_context *cxt, const char *path);
+extern struct libmnt_ns *mnt_context_get_target_ns(struct libmnt_context *cxt);
+extern struct libmnt_ns *mnt_context_get_origin_ns(struct libmnt_context *cxt);
+extern struct libmnt_ns *mnt_context_switch_ns(struct libmnt_context *cxt, struct libmnt_ns *ns);
+extern struct libmnt_ns *mnt_context_switch_origin_ns(struct libmnt_context *cxt);
+extern struct libmnt_ns *mnt_context_switch_target_ns(struct libmnt_context *cxt);
 
 
 /* context_mount.c */

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -322,3 +322,12 @@ MOUNT_2.30 {
 	mnt_context_enable_rwonly_mount;
 	mnt_context_get_excode;
 } MOUNT_2.28;
+
+MOUNT_2.33 {
+	mnt_context_get_origin_ns;
+	mnt_context_get_target_ns;
+	mnt_context_set_target_ns;
+	mnt_context_switch_ns;
+	mnt_context_switch_origin_ns;
+	mnt_context_switch_target_ns;
+} MOUNT_2.30;

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -268,6 +268,11 @@ struct libmnt_addmount {
 	struct list_head	mounts;
 };
 
+struct libmnt_ns {
+	int fd; /* file descriptor of namespace, -1 when inactive */
+	struct libmnt_cache *cache; /* paths cache associated with NS */
+};
+
 /*
  * Mount context -- high-level API
  */
@@ -328,6 +333,9 @@ struct libmnt_context
 
 
 	int	syscall_status;	/* 1: not called yet, 0: success, <0: -errno */
+
+	struct libmnt_ns ns_orig, ns_tgt; /* structs with namespaces info */
+	struct libmnt_ns *ns_cur; /* pointer to current namespace */
 
 	unsigned int	enabled_textdomain : 1;		/* bindtextdomain() called */
 };

--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -643,6 +643,10 @@ This is necessary for example when
 .I /etc
 is on a read-only filesystem.
 .TP
+.BR \-N , " \-\-namespace " \fIns
+Perform mount in namespace specified by \fIns\fR.
+\fIns\fR is typically in form \fI/proc/[pid]/ns/mnt\fR.
+.TP
 .BR \-O , " \-\-test\-opts " \fIopts
 Limit the set of filesystems to which the
 .B \-a

--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -645,7 +645,9 @@ is on a read-only filesystem.
 .TP
 .BR \-N , " \-\-namespace " \fIns
 Perform mount in namespace specified by \fIns\fR.
-\fIns\fR is typically in form \fI/proc/[pid]/ns/mnt\fR.
+\fIns\fR is either PID of process running in that namespace
+or special file representing that namespace.
+See \fBnamespaces\fR(7) for more information.
 .TP
 .BR \-O , " \-\-test\-opts " \fIopts
 Limit the set of filesystems to which the

--- a/sys-utils/mount.c
+++ b/sys-utils/mount.c
@@ -574,6 +574,7 @@ int main(int argc, char **argv)
 		{ "options-mode",     required_argument, NULL, MOUNT_OPT_OPTMODE     },
 		{ "options-source",   required_argument, NULL, MOUNT_OPT_OPTSRC      },
 		{ "options-source-force",   no_argument, NULL, MOUNT_OPT_OPTSRC_FORCE},
+		{ "namespace",        required_argument, NULL, 'N'                   },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -599,7 +600,7 @@ int main(int argc, char **argv)
 
 	mnt_context_set_tables_errcb(cxt, table_parser_errcb);
 
-	while ((c = getopt_long(argc, argv, "aBcfFhilL:Mno:O:rRsU:vVwt:T:",
+	while ((c = getopt_long(argc, argv, "aBcfFhilL:Mno:O:rRsU:vVwt:T:N:",
 					longopts, NULL)) != -1) {
 
 		/* only few options are allowed for non-root users */
@@ -687,6 +688,15 @@ int main(int argc, char **argv)
 		case 'R':
 			oper |= (MS_BIND | MS_REC);
 			break;
+		case 'N':
+		{
+			int tmp;
+			if ((tmp = mnt_context_set_target_ns(cxt, optarg))) {
+				errno = -tmp;
+				err(MNT_EX_SYSERR, _("failed to set target namespace"));
+			}
+	 		break;
+		}
 		case MOUNT_OPT_SHARED:
 			append_option(cxt, "shared");
 			propa = 1;

--- a/sys-utils/mount.c
+++ b/sys-utils/mount.c
@@ -431,6 +431,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	" -v, --verbose           say what is being done\n"));
 	fprintf(out, _(
 	" -w, --rw, --read-write  mount the filesystem read-write (default)\n"));
+	fprintf(out, _(
+	" -N, --namespace <ns>    perform mount in another namespace\n"));
 
 	fputs(USAGE_SEPARATOR, out);
 	printf(USAGE_HELP_OPTIONS(25));

--- a/sys-utils/umount.8
+++ b/sys-utils/umount.8
@@ -122,7 +122,9 @@ anymore.
 .TP
 .BR \-N , " \-\-namespace " \fIns
 Perform umount in namespace specified by \fIns\fR.
-\fIns\fR is typically in form \fI/proc/[pid]/ns/mnt\fR.
+\fIns\fR is either PID of process running in that namespace
+or special file representing that namespace.
+See \fBnamespaces\fR(7) for more information.
 .TP
 .BR \-n , " \-\-no\-mtab"
 Unmount without writing in

--- a/sys-utils/umount.8
+++ b/sys-utils/umount.8
@@ -120,6 +120,10 @@ Lazy unmount.  Detach the filesystem from the file hierarchy now,
 and clean up all references to this filesystem as soon as it is not busy
 anymore.
 .TP
+.BR \-N , " \-\-namespace " \fIns
+Perform umount in namespace specified by \fIns\fR.
+\fIns\fR is typically in form \fI/proc/[pid]/ns/mnt\fR.
+.TP
 .BR \-n , " \-\-no\-mtab"
 Unmount without writing in
 .IR /etc/mtab .

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -398,6 +398,19 @@ static char *sanitize_path(const char *path)
 	return p;
 }
 
+static pid_t parse_pid(const char *str)
+{
+	char *end;
+	pid_t ret;
+
+	errno = 0;
+	ret = strtoul(str, &end, 10);
+
+	if (ret < 0 || errno || end == str || (end && *end))
+		return 0;
+	return ret;
+}
+
 int main(int argc, char **argv)
 {
 	int c, rc = 0, all = 0, recursive = 0, alltargets = 0;
@@ -514,9 +527,15 @@ int main(int argc, char **argv)
 		case 'N':
 		{
 			int tmp;
-			if ((tmp = mnt_context_set_target_ns(cxt, optarg))) {
+			char path[PATH_MAX];
+			pid_t pid = parse_pid(optarg);
+
+			if (pid)
+				snprintf(path, sizeof(path), "/proc/%i/ns/mnt", pid);
+
+			if ((tmp = mnt_context_set_target_ns(cxt, pid ? path : optarg))) {
 				errno = -tmp;
-				err(MNT_EX_SYSERR, _("failed to set target namespace"));
+				err(MNT_EX_SYSERR, _("failed to set target namespace to %s"), pid ? path : optarg);
 			}
 	 		break;
 		}

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -424,6 +424,7 @@ int main(int argc, char **argv)
 		{ "types",           required_argument, NULL, 't'             },
 		{ "verbose",         no_argument,       NULL, 'v'             },
 		{ "version",         no_argument,       NULL, 'V'             },
+		{ "namespace",       required_argument, NULL, 'N'             },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -449,7 +450,7 @@ int main(int argc, char **argv)
 
 	mnt_context_set_tables_errcb(cxt, table_parser_errcb);
 
-	while ((c = getopt_long(argc, argv, "aAcdfhilnRrO:t:vV",
+	while ((c = getopt_long(argc, argv, "aAcdfhilnRrO:t:vVN:",
 					longopts, NULL)) != -1) {
 
 
@@ -509,6 +510,15 @@ int main(int argc, char **argv)
 		case 'V':
 			print_version();
 			break;
+		case 'N':
+		{
+			int tmp;
+			if ((tmp = mnt_context_set_target_ns(cxt, optarg))) {
+				errno = -tmp;
+				err(MNT_EX_SYSERR, _("failed to set target namespace"));
+			}
+	 		break;
+		}
 		default:
 			errtryhelp(MNT_EX_USAGE);
 		}

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -219,7 +219,12 @@ static int umount_one(struct libmnt_context *cxt, const char *spec)
 
 static struct libmnt_table *new_mountinfo(struct libmnt_context *cxt)
 {
-	struct libmnt_table *tb = mnt_new_table();
+	struct libmnt_table *tb;
+	struct libmnt_ns *ns_old = mnt_context_switch_target_ns(cxt);
+	if (!ns_old)
+		err(MNT_EX_SYSERR, _("failed to switch namespace"));
+
+	tb = mnt_new_table();
 	if (!tb)
 		err(MNT_EX_SYSERR, _("libmount table allocation failed"));
 
@@ -231,6 +236,9 @@ static struct libmnt_table *new_mountinfo(struct libmnt_context *cxt)
 		mnt_unref_table(tb);
 		tb = NULL;
 	}
+
+	if (!(mnt_context_switch_ns(cxt, ns_old)))
+		err(MNT_EX_SYSERR, _("failed to switch namespace"));
 
 	return tb;
 }

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -100,6 +100,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -r, --read-only         in case unmounting fails, try to remount read-only\n"), out);
 	fputs(_(" -t, --types <list>      limit the set of filesystem types\n"), out);
 	fputs(_(" -v, --verbose           say what is being done\n"), out);
+	fputs(_(" -N, --namespace <ns>    perform umount in another namespace\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
 	printf(USAGE_HELP_OPTIONS(25));


### PR DESCRIPTION
RFC
This patchset adds  `--namespace` option to perform `mount(2)` in different namespace.
Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1199554