### PR TITLE
Add options to filter by pseudo, real filesystems

### DIFF
--- a/misc-utils/findmnt.8
+++ b/misc-utils/findmnt.8
@@ -1,4 +1,4 @@
-.TH FINDMNT 8 "June 2015" "util-linux" "System Administration"
+.TH FINDMNT 8 "May 2018" "util-linux" "System Administration"
 .SH NAME
 findmnt \- find a filesystem
 .SH SYNOPSIS
@@ -183,6 +183,9 @@ available for umount and move actions
 available for umount and remount actions
 .RE
 .TP
+.BR "\-\-pseudo"
+Print only pseudo filesystems.
+.TP
 .BR \-R , " \-\-submounts"
 Print recursively all submounts for the selected filesystems.  The restrictions
 defined by options \fB\-t\fP, \fB\-O\fP, \fB\-S\fP, \fB\-T\fP and
@@ -192,6 +195,9 @@ default.  This option has no effect for \fB\-\-mtab\fP or \fB\-\-fstab\fP.
 .TP
 .BR \-r , " \-\-raw"
 Use raw output format.  All potentially unsafe characters are hex-escaped (\\x<code>).
+.TP
+.BR "\-\-real"
+Print only real filesystems.
 .TP
 .BR \-S , " \-\-source \fIspec\fP"
 Explicitly define the mount source.  Supported specifications are \fIdevice\fR,

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1247,7 +1247,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -t, --types <list>     limit the set of filesystems by FS types\n"), out);
 	fputs(_(" -U, --uniq             ignore filesystems with duplicate target\n"), out);
 	fputs(_(" -u, --notruncate       don't truncate text in columns\n"), out);
-	fputs(_(" -v, --nofsroot         don't print [/dir] for bind or btrfs mounts\n"), out);	
+	fputs(_(" -v, --nofsroot         don't print [/dir] for bind or btrfs mounts\n"), out);
 
 	fputc('\n', out);
 	fputs(_(" -x, --verify           verify mount table content (default is fstab)\n"), out);
@@ -1280,7 +1280,7 @@ int main(int argc, char *argv[])
 	struct libscols_table *table = NULL;
 
 	enum {
-                FINDMNT_OPT_VERBOSE = CHAR_MAX + 1,
+		FINDMNT_OPT_VERBOSE = CHAR_MAX + 1,
 		FINDMNT_OPT_TREE,
 		FINDMNT_OPT_OUTPUT_ALL,
 		FINDMNT_OPT_PSEUDO,
@@ -1332,7 +1332,7 @@ int main(int argc, char *argv[])
 	};
 
 	static const ul_excl_t excl[] = {	/* rows and cols in ASCII order */
-		{ 'C', 'c'},                    /* [no]canonicalize */
+		{ 'C', 'c'},			/* [no]canonicalize */
 		{ 'C', 'e' },			/* nocanonicalize, evaluate */
 		{ 'J', 'P', 'r','x' },		/* json,pairs,raw,verify */
 		{ 'M', 'T' },			/* mountpoint, target */

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -947,6 +947,12 @@ static int match_func(struct libmnt_fs *fs,
 			return rc;
 	}
 
+	if ((flags & FL_REAL) && mnt_fs_is_pseudofs(fs))
+	    return rc;
+
+	if ((flags & FL_PSEUDO) && !mnt_fs_is_pseudofs(fs))
+	    return rc;
+
 	return !rc;
 }
 
@@ -1229,8 +1235,10 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -o, --output <list>    the output columns to be shown\n"), out);
 	fputs(_("     --output-all       output all available columns\n"), out);
 	fputs(_(" -P, --pairs            use key=\"value\" output format\n"), out);
+	fputs(_("     --pseudo           print only pseudo-filesystems\n"), out);
 	fputs(_(" -R, --submounts        print all submounts for the matching filesystems\n"), out);
 	fputs(_(" -r, --raw              use raw output format\n"), out);
+	fputs(_("     --real             print only real filesystems\n"), out);
 	fputs(_(" -S, --source <string>  the device to mount (by name, maj:min, \n"
 	        "                          LABEL=, UUID=, PARTUUID=, PARTLABEL=)\n"), out);
 	fputs(_(" -T, --target <path>    the path to the filesystem to use\n"), out);
@@ -1274,7 +1282,9 @@ int main(int argc, char *argv[])
 	enum {
                 FINDMNT_OPT_VERBOSE = CHAR_MAX + 1,
 		FINDMNT_OPT_TREE,
-		FINDMNT_OPT_OUTPUT_ALL
+		FINDMNT_OPT_OUTPUT_ALL,
+		FINDMNT_OPT_PSEUDO,
+		FINDMNT_OPT_REAL
 	};
 
 	static const struct option longopts[] = {
@@ -1316,6 +1326,8 @@ int main(int argc, char *argv[])
 		{ "version",	    no_argument,       NULL, 'V'		 },
 		{ "verbose",	    no_argument,       NULL, FINDMNT_OPT_VERBOSE },
 		{ "tree",	    no_argument,       NULL, FINDMNT_OPT_TREE	 },
+		{ "real",	    no_argument,       NULL, FINDMNT_OPT_REAL	 },
+		{ "pseudo",	    no_argument,       NULL, FINDMNT_OPT_PSEUDO	 },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -1328,6 +1340,7 @@ int main(int argc, char *argv[])
 		{ 'P','l','r','x' },		/* pairs,list,raw,verify */
 		{ 'p','x' },			/* poll,verify */
 		{ 'm','p','s' },		/* mtab,poll,fstab */
+		{ FINDMNT_OPT_PSEUDO, FINDMNT_OPT_REAL },
 		{ 0 }
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
@@ -1488,6 +1501,12 @@ int main(int argc, char *argv[])
 			break;
 		case FINDMNT_OPT_TREE:
 			force_tree = 1;
+			break;
+		case FINDMNT_OPT_PSEUDO:
+			flags |= FL_PSEUDO;
+			break;
+		case FINDMNT_OPT_REAL:
+			flags |= FL_REAL;
 			break;
 		default:
 			errtryhelp(EXIT_FAILURE);

--- a/misc-utils/findmnt.h
+++ b/misc-utils/findmnt.h
@@ -18,6 +18,8 @@ enum {
 	FL_NOCACHE	= (1 << 14),
 	FL_STRICTTARGET = (1 << 15),
 	FL_VERBOSE	= (1 << 16),
+	FL_PSEUDO	= (1 << 17),
+	FL_REAL		= (1 << 18),
 
 	/* basic table settings */
 	FL_ASCII	= (1 << 20),


### PR DESCRIPTION
While looking for a way to show only non-pseudo filesystems with findmnt I came across [this thread](https://marc.info/?l=util-linux-ng&m=144975017926320&w=2). As far as I can tell no similar options have been implemented, so I went ahead and added `--pseduo` and `--real` flags. I can probably add a `--net` flag, too, but haven't investigated what all that would require yet; I also thought I'd see what the feedback for these two was before really digging into it.

Regarding whitespace: I fixed a couple of places that had spaces instead of tabs and a trailing tab that I assumed to be whitespace errors. If that is intentional let me know and I can drop that commit. I'm also curious about what to do with the ugly addition to `excl[]`.