### PR TITLE
2018wk19 various fixes

### DIFF
--- a/bash-completion/swapon
+++ b/bash-completion/swapon
@@ -25,16 +25,28 @@ _swapon_module()
 			COMPREPLY=( $(compgen -P "$prefix" -W "$OUTPUT" -S ',' -- $realcur) )
 			return 0
 			;;
-		'-U')
+		'-U'|'UUID=')
 			local UUIDS
 			UUIDS="$(lsblk -nrp -o FSTYPE,UUID | awk '$1 ~ /swap/ { print $2 }')"
 			COMPREPLY=( $(compgen -W "$UUIDS" -- $cur) )
 			return 0
 			;;
-		'-L')
+		'-L'|'LABEL=')
 			local LABELS
 			LABELS="$(lsblk -nrp -o FSTYPE,LABEL | awk '$1 ~ /swap/ { print $2 }')"
 			COMPREPLY=( $(compgen -W "$LABELS" -- $cur) )
+			return 0
+			;;
+		'PARTUUID=')
+			local PARTUUIDS
+			PARTUUIDS="$(lsblk -nrp -o FSTYPE,PARTUUID | awk '$1 ~ /swap/ { print $2 }')"
+			COMPREPLY=( $(compgen -W "$PARTUUIDS" -- $cur) )
+			return 0
+			;;
+		'PARTLABEL=')
+			local PARTLABELS
+			PARTLABELS="$(lsblk -nrp -o FSTYPE,PARTLABEL | awk '$1 ~ /swap/ { print $2 }')"
+			COMPREPLY=( $(compgen -W "$PARTLABELS" -- $cur) )
 			return 0
 			;;
 		'-h'|'--help'|'-V'|'--version')
@@ -55,6 +67,8 @@ _swapon_module()
 				--raw
 				--bytes
 				--verbose
+				-L
+				-U
 				--help
 				--version"
 			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
@@ -63,7 +77,8 @@ _swapon_module()
 	esac
 	local DEVS
 	DEVS="$(lsblk -nrp -o FSTYPE,NAME | awk '$1 ~ /swap/ { print $2 }')"
-	COMPREPLY=( $(compgen -W "$DEVS" -- $cur) )
+	compopt -o nospace
+	COMPREPLY=( $(compgen -fW "$DEVS LABEL= UUID= PARTLABEL= PARTUUID=" -- $cur) )
 	return 0
 }
 complete -F _swapon_module swapon

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -657,7 +657,7 @@ int print_partition_info(struct fdisk_context *cxt)
 			goto clean_data;
 		if (!data || !*data)
 			continue;
-		fdisk_info(cxt, _("%15s: %s"), fdisk_field_get_name(fd), data);
+		fdisk_info(cxt, "%15s: %s", fdisk_field_get_name(fd), data);
 		free(data);
 	}
 

--- a/include/linux_version.h
+++ b/include/linux_version.h
@@ -1,6 +1,8 @@
 #ifndef LINUX_VERSION_H
 #define LINUX_VERSION_H
 
+#include <inttypes.h>
+
 #ifdef HAVE_LINUX_VERSION_H
 # include <linux/version.h>
 #endif
@@ -9,6 +11,6 @@
 # define KERNEL_VERSION(a,b,c) (((a) << 16) + ((b) << 8) + (c))
 #endif
 
-int get_linux_version(void);
+uint32_t get_linux_version(void);
 
 #endif /* LINUX_VERSION_H */

--- a/include/pt-mbr.h
+++ b/include/pt-mbr.h
@@ -22,9 +22,11 @@ static inline struct dos_partition *mbr_get_partition(unsigned char *mbr, int i)
 }
 
 /* assemble badly aligned little endian integer */
-static inline unsigned int __dos_assemble_4le(const unsigned char *p)
+static inline uint32_t __dos_assemble_4le(const unsigned char *p)
 {
-	return p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
+	uint32_t last_byte = p[3];
+
+	return p[0] | (p[1] << 8) | (p[2] << 16) | (last_byte << 24);
 }
 
 static inline void __dos_store_4le(unsigned char *p, unsigned int val)

--- a/lib/linux_version.c
+++ b/lib/linux_version.c
@@ -1,22 +1,32 @@
 #include <stdio.h>
 #include <sys/utsname.h>
+#include <inttypes.h>
+#include <stdint.h>
 
 #include "c.h"
 #include "linux_version.h"
 
-int get_linux_version (void)
+uint32_t get_linux_version (void)
 {
-	static int kver = -1;
+	static uint32_t kver = UINT32_MAX;
 	struct utsname uts;
-	int x = 0, y = 0, z = 0;
+	/* The KERNEL_VERSION macro makes assumption these are 8 bit
+	 * variables, see bit shift in linux/version.h system header */
+	uint8_t x = 0, y = 0, z = 0;
 	int n;
 
-	if (kver != -1)
+	if (kver != UINT32_MAX)
 		return kver;
 	if (uname(&uts))
 		return kver = 0;
 
-	n = sscanf(uts.release, "%d.%d.%d", &x, &y, &z);
+	/*
+	 * uts.release values come from linux kernel Makefile where
+	 *   VERSION is x
+	 *   PATCHLEVEL is y
+	 *   SUBLEVEL and is z in here
+	 */
+	n = sscanf(uts.release, "%" SCNu8 ".%" SCNu8 ".%" SCNu8, &x, &y, &z);
 	if (n < 1 || n > 3)
 		return kver = 0;
 

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -739,19 +739,19 @@ static void cal_output_header(struct cal_month *month, const struct cal_control 
 
 	if (ctl->header_hint || ctl->header_year) {
 		for (i = month; i; i = i->next) {
-			sprintf(out, _("%s"), ctl->full_month[i->month - 1]);
+			sprintf(out, "%s", ctl->full_month[i->month - 1]);
 			center(out, ctl->week_width - 1, i->next == NULL ? 0 : ctl->gutter_width);
 		}
 		if (!ctl->header_year) {
 			my_putstring("\n");
 			for (i = month; i; i = i->next) {
-				sprintf(out, _("%04d"), i->year);
+				sprintf(out, "%04d", i->year);
 				center(out, ctl->week_width - 1, i->next == NULL ? 0 : ctl->gutter_width);
 			}
 		}
 	} else {
 		for (i = month; i; i = i->next) {
-			sprintf(out, _("%s %04d"), ctl->full_month[i->month - 1], i->year);
+			sprintf(out, "%s %04d", ctl->full_month[i->month - 1], i->year);
 			center(out, ctl->week_width - 1, i->next == NULL ? 0 : ctl->gutter_width);
 		}
 	}

--- a/misc-utils/namei.c
+++ b/misc-utils/namei.c
@@ -281,7 +281,7 @@ print_namei(struct namei *nm, char *path)
 				blanks += 1;
 			blanks += nm->level * 2;
 			printf("%*s ", blanks, "");
-			printf(_("%s - %s\n"), nm->name, strerror(nm->noent));
+			printf("%s - %s\n", nm->name, strerror(nm->noent));
 			return -1;
 		}
 

--- a/sys-utils/mount.c
+++ b/sys-utils/mount.c
@@ -304,7 +304,7 @@ static int mk_exit_code(struct libmnt_context *cxt, int rc)
 			spec = mnt_context_get_source(cxt);
 		if (!spec)
 			spec = "???";
-		warnx(_("%s: %s."), spec, buf);
+		warnx("%s: %s.", spec, buf);
 	}
 
 	if (rc == MNT_EX_SUCCESS && mnt_context_get_status(cxt) == 1) {

--- a/sys-utils/mountpoint.c
+++ b/sys-utils/mountpoint.c
@@ -76,8 +76,7 @@ static int dir_to_device(struct mountpoint_control *ctl)
 		if (stat(buf, &pst) !=0)
 			return -1;
 
-		if ((ctl->st.st_dev != pst.st_dev) ||
-		    (ctl->st.st_dev == pst.st_dev && ctl->st.st_ino == pst.st_ino)) {
+		if (ctl->st.st_dev != pst.st_dev || ctl->st.st_ino == pst.st_ino) {
 			ctl->dev = ctl->st.st_dev;
 			return 0;
 		}

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -158,7 +158,7 @@ static int mk_exit_code(struct libmnt_context *cxt, int rc)
 			spec = mnt_context_get_source(cxt);
 		if (!spec)
 			spec = "???";
-		warnx(_("%s: %s."), spec, buf);
+		warnx("%s: %s.", spec, buf);
 	}
 	return rc;
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -82,7 +82,7 @@ while [ -n "$1" ]; do
 		;;
 	--parallel=*)
 		paraller_jobs="${1##--parallel=}"
-		if ! [ "$paraller_jobs" -ge 0 2>/dev/null ]; then
+		if ! [ "$paraller_jobs" -ge 0 ] 2>/dev/null; then
 			echo "invalid argument '$paraller_jobs' for --parallel="
 			exit 1
 		fi

--- a/text-utils/rev.c
+++ b/text-utils/rev.c
@@ -64,8 +64,6 @@
 #include "c.h"
 #include "closestream.h"
 
-static wchar_t *buf;
-
 static void sig_handler(int signo __attribute__ ((__unused__)))
 {
 	_exit(EXIT_SUCCESS);
@@ -100,7 +98,8 @@ static void reverse_str(wchar_t *str, size_t n)
 
 int main(int argc, char *argv[])
 {
-	char *filename = "stdin";
+	char const *filename = "stdin";
+	wchar_t *buf;
 	size_t len, bufsiz = BUFSIZ;
 	FILE *fp = stdin;
 	int ch, rval = EXIT_SUCCESS;


### PR DESCRIPTION
The following changes since commit 03d190ad9e34c19ee11340293dbeca3ec49c0e50:

  lsns: remove unnecessary include (2018-05-17 12:42:16 +0200)

are available in the Git repository at:

  git://github.com/kerolasa/util-linux.git 2018wk19

for you to fetch changes up to 4482a7ae65d3607f424ce7b87680f7e075489cb0:

  mountpoint: simplify test condition [cppcheck] (2018-05-17 22:08:48 +0100)

Sami Kerola (9):
      tests: move stderr redirection out from test expression
      rev: move a global variable to local scope
      bash-completion: add swapon specifiers to completion
      nls: remove translation strings
      lib/mbsalign: fix return value integer overflow in mbsalign_with_padding()
      include/pt-mbr.h: fix integer overflow
      include/pt-mbr.h: be explicit about data type sizes
      include/linux_version: be careful with data type sizes
      mountpoint: simplify test condition [cppcheck]