### PR TITLE
cfdisk: fix compiler warnings, follow-up 7085f1e4 (#636)

### DIFF
--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -1857,7 +1857,7 @@ static int ui_get_size(struct cfdisk *cf,	/* context */
 	ssize_t rc;
 	char *dflt = size_to_human_string(0, *res);
 
-	DBG(UI, ul_debug("get_size (default=%ju)", *res));
+	DBG(UI, ul_debug("get_size (default=%"PRIu64")", *res));
 
 	ui_clean_info();
 
@@ -1886,7 +1886,7 @@ static int ui_get_size(struct cfdisk *cf,	/* context */
 				insec = 1;
 				buf[len - 1] = '\0';
 			}
-			rc = parse_size(buf, &user, &pwr);	/* parse */
+			rc = parse_size(buf, (uintmax_t *)&user, &pwr);	/* parse */
 		}
 
 		if (rc == 0) {


### PR DESCRIPTION
Seen on OSX 10.13, xcode 9.3.
```C
 disk-utils/cfdisk.c:1860:45: error: format specifies type 'uintmax_t' (aka 'unsigned long') but the argument has type 'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
         DBG(UI, ul_debug("get_size (default=%ju)", *res));
                                             ~~~    ^~~~
                                             %llu
 disk-utils/cfdisk.c:267:60: note: expanded from macro 'DBG'
 #define DBG(m, x)       __UL_DBG(cfdisk, CFDISK_DEBUG_, m, x)
                                                           ^
 ./include/debug.h:67:4: note: expanded from macro '__UL_DBG'
                         x; \
                         ^
 disk-utils/cfdisk.c:1889:25: error: incompatible pointer types passing 'uint64_t *' (aka 'unsigned long long *') to parameter of type 'uintmax_t *' (aka 'unsigned long *') [-Werror,-Wincompatible-pointer-types]
                         rc = parse_size(buf, &user, &pwr);      /* parse */
                                              ^~~~~
 ./include/strutils.h:15:51: note: passing argument to parameter 'res' here
 extern int parse_size(const char *str, uintmax_t *res, int *power);
                                                   ^
 2 errors generated.
```
Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>