### PR TITLE
blkzone: fix whole device detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1730,6 +1730,7 @@ AM_CONDITIONAL([BUILD_BLKDISCARD], [test "x$build_blkdiscard" = xyes])
 
 UL_BUILD_INIT([blkzone], [check])
 UL_REQUIRES_LINUX([blkzone])
+UL_REQUIRES_BUILD([blkzone], [libblkid])
 UL_REQUIRES_HAVE([blkzone], [linux_blkzoned_h], [linux/blkzoned.h header])
 AM_CONDITIONAL([BUILD_BLKZONE], [test "x$build_blkzone" = xyes])
 

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -145,7 +145,8 @@ if BUILD_BLKZONE
 sbin_PROGRAMS += blkzone
 dist_man_MANS += sys-utils/blkzone.8
 blkzone_SOURCES = sys-utils/blkzone.c
-blkzone_LDADD = $(LDADD) libcommon.la
+blkzone_LDADD = $(LDADD) libblkid.la libcommon.la
+blkzone_CFLAGS = $(AMFLAGS) -I$(ul_libblkid_incdir)
 endif
 
 if BUILD_LDATTACH


### PR DESCRIPTION
The current detection code for chunk size assumes that the
underlying device is a device that uses the minor device id
as the partition id, and that the whole device has minor id 0.
This is not true for example null_blk and nvme device drivers.

Therefore, use blkid's blkid_probe_get_wholedisk_devno() to
resolve the whole device minor id appropriately.

Signed-off-by: Matias Bjørling <matias.bjorling@wdc.com>
Tested-by: Damien Le Moal <Damien.lemoal@wdc.com>