### PR TITLE
su: set SETGID bit

### DIFF
--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -239,7 +239,7 @@ if MAKEINSTALL_DO_CHOWN
 	chown root:root $(DESTDIR)$(bindir)/su
 endif
 if MAKEINSTALL_DO_SETUID
-	chmod 4755 $(DESTDIR)$(bindir)/su
+	chmod 6755 $(DESTDIR)$(bindir)/su
 endif
 endif
 if BUILD_VIPW


### PR DESCRIPTION
Without the bit set only the effective group ID is changed but not
the real group id. (If the shell is bash, the effective group id
gets reset to the unchanged real group ID, and no startup file is
read. See "Invoked with unequal effective and real UID/GIDs" under
"6.2 Bash Startup Files" of the bash manual.)

```
[tom@localhost ~]$ chmod 4755 /usr/bin/su
[tom@localhost ~]$ su -c 'id -u; id -u -r; id -g; id -g -r' -s /bin/zsh
Password: 

0
0
0
1000
[tom@localhost ~]$ su meh -c 'id -u; id -u -r; id -g; id -g -r' -s /bin/zsh
Password: 

1001
1001
1001
1000
[tom@localhost ~]$ su -c 'id -u; id -u -r; id -g; id -g -r' -s /bin/bash
Password: 

0
0
1000
1000
[tom@localhost ~]$ su meh -c 'id -u; id -u -r; id -g; id -g -r' -s /bin/bash
Password: 

1001
1001
1000
1000
```
```
[tom@localhost ~]$ chmod 6755 /usr/bin/su
[tom@localhost ~]$ su -c 'id -u; id -u -r; id -g; id -g -r' -s /bin/zsh
Password: 

0
0
0
0
[tom@localhost ~]$ su meh -c 'id -u; id -u -r; id -g; id -g -r' -s /bin/zsh
Password: 

1001
1001
1001
1001
[tom@localhost ~]$ su -c 'id -u; id -u -r; id -g; id -g -r' -s /bin/bash
Password: 

0
0
0
0
[tom@localhost ~]$ su meh -c 'id -u; id -u -r; id -g; id -g -r' -s /bin/bash
Password: 

1001
1001
1001
1001
[tom@localhost ~]$
```
(Ref: https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files)