### PR TITLE
exec_shell: prevent ".: applet not found" error when SHELL env is NULL

### DIFF
--- a/lib/exec_shell.c
+++ b/lib/exec_shell.c
@@ -33,13 +33,14 @@
 void __attribute__((__noreturn__)) exec_shell(void)
 {
 	const char *shell = getenv("SHELL");
-	char *shellc = xstrdup(shell);
+	char *shellc;
 	const char *shell_basename;
 	char *arg0;
 
 	if (!shell)
 		shell = DEFAULT_SHELL;
 
+	shellc = xstrdup(shell);
 	shell_basename = basename(shellc);
 	arg0 = xmalloc(strlen(shell_basename) + 2);
 	arg0[0] = '-';


### PR DESCRIPTION
When SHELL env is not set, it cause `xstrdup(NULL)` be executed, and result in weird error message `
.: applet not found` instead of DEFAULT_SHELL being used.