### PR TITLE
libblkid: Add very basic APFS recognition

### DIFF
--- a/libblkid/src/Makemodule.am
+++ b/libblkid/src/Makemodule.am
@@ -44,6 +44,7 @@ libblkid_la_SOURCES = \
 	libblkid/src/partitions/unixware.c \
 	\
 	libblkid/src/superblocks/adaptec_raid.c \
+	libblkid/src/superblocks/apfs.c \
 	libblkid/src/superblocks/bcache.c \
 	libblkid/src/superblocks/befs.c \
 	libblkid/src/superblocks/bfs.c \

--- a/libblkid/src/superblocks/apfs.c
+++ b/libblkid/src/superblocks/apfs.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 Harry Mallon <hjmallon@gmail.com>
+ *
+ * This file may be redistributed under the terms of the
+ * GNU Lesser General Public License.
+ */
+
+#include "superblocks.h"
+
+const struct blkid_idinfo apfs_idinfo =
+{
+	.name		= "apfs",
+	.usage		= BLKID_USAGE_FILESYSTEM,
+	.magics		=
+	{
+		{ .magic = "NXSB", .len = 4, .sboff = 32 },
+		{ NULL }
+	}
+};

--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -163,7 +163,8 @@ static const struct blkid_idinfo *idinfos[] =
 	&nilfs2_idinfo,
 	&exfat_idinfo,
 	&f2fs_idinfo,
-	&mpool_idinfo
+	&mpool_idinfo,
+	&apfs_idinfo
 };
 
 /*

--- a/libblkid/src/superblocks/superblocks.h
+++ b/libblkid/src/superblocks/superblocks.h
@@ -82,6 +82,7 @@ extern const struct blkid_idinfo mpool_idinfo;
 extern const struct blkid_idinfo vdo_idinfo;
 extern const struct blkid_idinfo stratis_idinfo;
 extern const struct blkid_idinfo bitlocker_idinfo;
+extern const struct blkid_idinfo apfs_idinfo;
 
 /*
  * superblock functions


### PR DESCRIPTION
Does not support anything to do with APFS volumes or similar. Just reports when it sees an APFS container on a disk.