### PR TITLE
logger: Define SD_JOURNAL_SUPPRESS_LOCATION.

### DIFF
--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -68,6 +68,7 @@
 #include <syslog.h>
 
 #ifdef HAVE_LIBSYSTEMD
+# define SD_JOURNAL_SUPPRESS_LOCATION
 # include <systemd/sd-daemon.h>
 # include <systemd/sd-journal.h>
 #endif


### PR DESCRIPTION
The normal journald functions add the location in the C source code files to
the log messages. This is nice for a big C based project, but logger is used in
scripts so it would be more useful to let users specify the location in the
script by adding the CODE_FUNC, CODE_FILE and CODE_FILE fields to the log
message.

It is already possible to do this, but it will result in two versions of these
fields: one for the location in logger.c and one for the location in the
script.