### PR TITLE
mesg: do not print 'ttyname failed' message unless --verbose requested

### DIFF
--- a/term-utils/mesg.c
+++ b/term-utils/mesg.c
@@ -121,6 +121,11 @@ int main(int argc, char *argv[])
 	argc -= optind;
 	argv += optind;
 
+	if (isatty(STDERR_FILENO)) {
+		if (verbose)
+			warnx(_("no tty"));
+		exit(MESG_EXIT_FAILURE);
+	}
 	if ((tty = ttyname(STDERR_FILENO)) == NULL)
 		err(MESG_EXIT_FAILURE, _("ttyname failed"));
 	if ((fd = open(tty, O_RDONLY)) < 0)


### PR DESCRIPTION
Lots of people are confused why mesg(1) is priting this message.  Usual
cause seems to be an uninteractive shell trying to turn running 'mesg n'
from a /root/.profile where command invocation is by default on debian based
systems.  This might be rare case when failing silently is better.

Reference: https://www.google.com/search?q=mesg+ttyname+failed
Review: https://marc.info/?l=util-linux-ng&m=153319988631233&w=2
Signed-off-by: Sami Kerola <kerolasa@iki.fi>