### PR TITLE
lscpu: fixed part ID for ARM Cortex-M7

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -60,7 +60,7 @@ static const struct id_part arm_part[] = {
     { 0xc21, "Cortex-M1" },
     { 0xc23, "Cortex-M3" },
     { 0xc24, "Cortex-M4" },
-    { 0xc20, "Cortex-M7" },
+    { 0xc27, "Cortex-M7" },
     { 0xc60, "Cortex-M0+" },
     { 0xd01, "Cortex-A32" },
     { 0xd03, "Cortex-A53" },


### PR DESCRIPTION
Looks like a typo in the original commit.  Documentation showing actual ID here: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0646b/CIHCAGHH.html