### PR TITLE
fix script hanging when child is killed

### DIFF
--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -478,7 +478,7 @@ static void handle_signal(struct script_control *ctl, int fd)
 	switch (info.ssi_signo) {
 	case SIGCHLD:
 		DBG(SIGNAL, ul_debug(" get signal SIGCHLD"));
-		if (info.ssi_code == CLD_EXITED) {
+		if (info.ssi_code == CLD_EXITED || info.ssi_code == CLD_KILLED) {
 			wait_for_child(ctl, 0);
 			ctl->poll_timeout = 10;
 		} else if (info.ssi_status == SIGSTOP && ctl->child) {

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -478,7 +478,11 @@ static void handle_signal(struct script_control *ctl, int fd)
 	switch (info.ssi_signo) {
 	case SIGCHLD:
 		DBG(SIGNAL, ul_debug(" get signal SIGCHLD"));
-		if (info.ssi_code == CLD_EXITED || info.ssi_code == CLD_KILLED) {
+		int child_exited =
+			info.ssi_code == CLD_EXITED ||
+			info.ssi_code == CLD_KILLED ||
+			info.ssi_code == CLD_DUMPED;
+		if (child_exited) {
 			wait_for_child(ctl, 0);
 			ctl->poll_timeout = 10;
 		} else if (info.ssi_status == SIGSTOP && ctl->child) {


### PR DESCRIPTION
Script would exit as expected when the child process just exits normally, but when it was killed (and SIGCHLD's ssi_code was CLD_KILLED instead of CLD_EXITED), script would just hang indefinitely.

This PR fixes https://github.com/karelzak/util-linux/issues/686.