### PR TITLE
Add built in fallbacks for motd file

### DIFF
--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -43,7 +43,7 @@
 #ifndef _PATH_MAILDIR
 # define _PATH_MAILDIR		"/var/spool/mail"
 #endif
-#define	_PATH_MOTDFILE		"/etc/motd"
+#define	_PATH_MOTDFILE		"/usr/share/misc/motd:/run/motd:/etc/motd"
 #ifndef _PATH_NOLOGIN
 # define _PATH_NOLOGIN		"/etc/nologin"
 #endif


### PR DESCRIPTION
Use several locations for built in default for motd to allow for
e.g. run time generated motd without having to modify config files.
login.c already splits by colon.

/usr/share/misc/motd
  - chould be shipped by distributions
/run/motd
  - potentially run time created file with dynamic information
/etc/motd
  - for the admin fill with local information

Signed-off-by: Ludwig Nussel <ludwig.nussel@suse.de>