### PR TITLE
fallocate: add missing semicolon

### DIFF
--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
 			posix = 1;
 			break;
 #else
-			errx(EXIT_FAILURE, _("posix_fallocate support is not compiled"))
+			errx(EXIT_FAILURE, _("posix_fallocate support is not compiled"));
 #endif
 		case 'v':
 			verbose++;


### PR DESCRIPTION
This broke compilation when `HAVE_POSIX_FALLOCATE` was undefined. The typo dates to the original `posix_fallocate` support added in commit 833f9a7aae713278eec5f85266597482f18c7370.