### PR TITLE
agetty: fix output of escaped characters

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -2755,7 +2755,7 @@ static void output_special_char(struct issue *ie,
 		break;
 	}
 	default:
-		putchar(c);
+		putc(c, ie->output);
 		break;
 	}
 }


### PR DESCRIPTION
Signed-off-by: Christian Hesse <mail@eworm.de>