### PR TITLE
tests: run oids test only when uuidgen tool was built

### DIFF
--- a/tests/ts/uuid/oids
+++ b/tests/ts/uuid/oids
@@ -20,12 +20,14 @@ ts_init "$*"
 
 : . > $TS_OUTPUT
 
-uuidgen --md5 --namespace @dns --name "www.widgets.com" >> $TS_OUTPUT
+ts_check_test_command "$TS_CMD_UUIDGEN"
 
-uuidgen --md5 --namespace @dns --name "www.example.com" >> $TS_OUTPUT
+$TS_CMD_UUIDGEN --md5 --namespace @dns --name "www.widgets.com" >> $TS_OUTPUT
 
-uuidgen --sha1 --namespace @dns --name "www.example.com" >> $TS_OUTPUT
+$TS_CMD_UUIDGEN --md5 --namespace @dns --name "www.example.com" >> $TS_OUTPUT
 
-uuidgen --sha1 --namespace @oid --hex --name "525400fc0f5e" >> $TS_OUTPUT
+$TS_CMD_UUIDGEN --sha1 --namespace @dns --name "www.example.com" >> $TS_OUTPUT
+
+$TS_CMD_UUIDGEN --sha1 --namespace @oid --hex --name "525400fc0f5e" >> $TS_OUTPUT
 
 ts_finalize


### PR DESCRIPTION
oids test did not check if uuidgen was available.

oids test was also calling uuidgen from PATH which could result
in wrong results if uuidgen from a previous util-linux installation
was used.

With this commit we will check if uuidgen was built and make sure
that we only call the uuidgen binary we just built. If uuidgen is
not available we will skip this test.