### PR TITLE
fix a bug where switch_root would erroneously try to parse initargs

### DIFF
--- a/sys-utils/switch_root.c
+++ b/sys-utils/switch_root.c
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
 
 	atexit(close_stdout);
 
-	while ((c = getopt_long(argc, argv, "Vh", longopts, NULL)) != -1)
+	while ((c = getopt_long(argc, argv, "+Vh", longopts, NULL)) != -1)
 		switch (c) {
 		case 'V':
 			printf(UTIL_LINUX_VERSION);


### PR DESCRIPTION
before this change, switch_root would try to parse all arguments, including `initargs`, using getopt, which would lead to an 'unrecognized option' error when trying to pass a flag to the init program