### PR TITLE
include/c: check returns_nonnull function attribute with __GNUC_PREREQ

### DIFF
--- a/include/c.h
+++ b/include/c.h
@@ -80,7 +80,7 @@
 # endif
 #endif
 
-#if (__GNUC__ >= 5) || ((__GNUC__ >= 4) && (__GNUC_MINOR__ >= 9))
+#if __GNUC_PREREQ (4, 9)
 # define __ul_returns_nonnull __attribute__((returns_nonnull))
 #else
 # define __ul_returns_nonnull


### PR DESCRIPTION
Karel pointed out previous commit could have been better in github feedback,
so lets use the version check macro instead of compare versions directly.

Previous-commit: f1b327f8d5c8de7bf7fae99e85765d0954a25bac
Reference: https://github.com/karelzak/util-linux/pull/704#issuecomment-432605211
Signed-off-by: Sami Kerola <kerolasa@iki.fi>