### PR TITLE
Fix couple compiler warnings

### DIFF
--- a/libsmartcols/src/grouping.c
+++ b/libsmartcols/src/grouping.c
@@ -112,9 +112,9 @@ void scols_groups_fix_members_order(struct libscols_table *tb)
 	scols_reset_iter(&itr, SCOLS_ITER_FORWARD);
 	while (scols_table_next_group(tb, &itr, &gr) == 0) {
 		while (!list_empty(&gr->gr_members)) {
-			struct libscols_line *ln = list_entry(gr->gr_members.next,
+			struct libscols_line *line = list_entry(gr->gr_members.next,
 						struct libscols_line, ln_groups);
-			list_del_init(&ln->ln_groups);
+			list_del_init(&line->ln_groups);
 		}
 	}
 

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -623,7 +623,7 @@ static int valid_pwd(const char *str)
 		return 0;
 
 	/* salt$ */
-	for (; p && *p; p++) {
+	for (; *p; p++) {
 		if (*p == '$') {
 			p++;
 			break;

--- a/misc-utils/lsblk-devtree.c
+++ b/misc-utils/lsblk-devtree.c
@@ -203,7 +203,8 @@ int lsblk_device_is_last_parent(struct lsblk_device *dev, struct lsblk_device *p
 	struct lsblk_devdep *dp = list_last_entry(
 					&dev->parents,
 					struct lsblk_devdep, ls_parents);
-
+	if (!dp)
+		return 0;
 	return dp->parent == parent;
 }
 

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -747,7 +747,7 @@ static char *device_get_data(
 	case COL_OWNER:
 	{
 		struct stat *st = device_get_stat(dev);
-		struct passwd *pw = st ? NULL : getpwuid(st->st_uid);
+		struct passwd *pw = st ? getpwuid(st->st_uid) : NULL;
 		if (pw)
 			str = xstrdup(pw->pw_name);
 		break;
@@ -755,7 +755,7 @@ static char *device_get_data(
 	case COL_GROUP:
 	{
 		struct stat *st = device_get_stat(dev);
-		struct group *gr = st ? NULL : getgrgid(st->st_gid);
+		struct group *gr = st ? getgrgid(st->st_gid) : NULL;
 		if (gr)
 			str = xstrdup(gr->gr_name);
 		break;

--- a/text-utils/hexdump-parse.c
+++ b/text-utils/hexdump-parse.c
@@ -128,8 +128,8 @@ void add_fmt(const char *fmt, struct hexdump *hex)
 		/* If leading digit, repetition count. */
 		if (isdigit(*p)) {
 			savep = p;
-			while (isdigit(*p) && ++p)
-				;
+			while (isdigit(*p))
+				p++;
 			if (!isspace(*p) && *p != '/')
 				badfmt(fmt);
 			/* may overwrite either white space or slash */
@@ -146,8 +146,8 @@ void add_fmt(const char *fmt, struct hexdump *hex)
 		/* byte count */
 		if (isdigit(*p)) {
 			savep = p;
-			while (isdigit(*p) && ++p)
-				;
+			while (isdigit(*p))
+				p++;
 			if (!isspace(*p))
 				badfmt(fmt);
 			tfu->bcnt = atoi(savep);
@@ -261,7 +261,7 @@ void rewrite_rules(struct hexdump_fs *fs, struct hexdump *hex)
 			if (fu->bcnt) {
 				sokay = USEBCNT;
 				/* skip to conversion character */
-				while (++p1 && strchr(spec, *p1))
+				for (p1++; strchr(spec, *p1); p1++)
 					;
 			} else {
 				/* skip any special chars, field width */
@@ -462,6 +462,8 @@ isint:				cs[3] = '\0';
 				fu->reps += (hex->blocksize - fs->bcnt) / fu->bcnt;
 		if (fu->reps > 1 && !list_empty(&fu->prlist)) {
 			pr = list_last_entry(&fu->prlist, struct hexdump_pr, prlist);
+			if (!pr)
+				continue;
 			for (p1 = pr->fmt, p2 = NULL; *p1; ++p1)
 				p2 = isspace(*p1) ? p1 : NULL;
 			if (p2)


### PR DESCRIPTION
Nothing special, just compiler warning fixes. Well, maybe e361253 has some importance. I guess the ternary operator typo could have caused genuine problem.