### PR TITLE
lscpu: Add aarch32 detection on aarch64

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -33,6 +33,7 @@
 #include <stdarg.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/personality.h>
 
 #if (defined(__x86_64__) || defined(__i386__))
 # if !defined( __SANITIZE_ADDRESS__)
@@ -331,6 +332,19 @@ init_mode(struct lscpu_modifier *mod)
 #if defined(__i386__) || defined(__x86_64__) || \
     defined(__s390x__) || defined(__s390__) || defined(__sparc_v9__)
 	m |= MODE_32BIT;
+#endif
+
+#if defined(__aarch64__)
+	{
+		/* personality() is the most reliable way (since 4.7)
+		 * to determine aarch32 support */
+		int pers = personality(PER_LINUX32);
+		if (pers != -1) {
+			personality(pers);
+			m |= MODE_32BIT;
+		}
+		m |= MODE_64BIT;
+	}
 #endif
 	return m;
 }


### PR DESCRIPTION
aarch32 support is an optional feature of ARMv8. As CPUs
which don't support aarch32 become more common, lets make
sure that lscpu can tell a user quickly if they are on a
machine that only supports 64-bit.

Signed-off-by: Jeremy Linton <lintonrjeremy@gmail.com>