### PR TITLE
tests: skip nonroot on setarch

### DIFF
--- a/tests/ts/misc/setarch
+++ b/tests/ts/misc/setarch
@@ -20,6 +20,8 @@ ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SETARCH"
 
+ts_skip_nonroot
+
 ARCH=$(uname -m)
 
 ts_init_subtest options


### PR DESCRIPTION
Debian Salsa CI recently begins to run CI tests without root privileges, and it [failed](https://salsa.debian.org/vicamo-guest/util-linux/-/jobs/91953) with:
```
================= O/E diff ===================
--- /tmp/building/package/tests/output/misc/setarch-options	2018-12-13 07:25:41.000000000 +0000
+++ /tmp/building/package/tests/expected/misc/setarch-options	2018-12-07 10:04:12.000000000 +0000
@@ -9,7 +9,6 @@
 Execute command `uname'.
 uname -a unchanged
 ###### almost all options
-setarch: failed to set personality to x86_64: Operation not permitted
 Switching on ADDR_NO_RANDOMIZE.
 Switching on FDPIC_FUNCPTRS.
 Switching on MMAP_PAGE_ZERO.
@@ -20,3 +19,5 @@
 Switching on WHOLE_SECONDS.
 Switching on STICKY_TIMEOUTS.
 Switching on ADDR_LIMIT_3GB.
+Execute command `echo'.
+success
==============================================
```

This change skips setarch tests when no root privileges.