### PR TITLE
Add support for detecting Ceph BlueStore Block Devices

### DIFF
--- a/libblkid/src/Makemodule.am
+++ b/libblkid/src/Makemodule.am
@@ -49,6 +49,7 @@ libblkid_la_SOURCES = \
 	libblkid/src/superblocks/befs.c \
 	libblkid/src/superblocks/bfs.c \
 	libblkid/src/superblocks/bitlocker.c \
+	libblkid/src/superblocks/bluestore.c \
 	libblkid/src/superblocks/btrfs.c \
 	libblkid/src/superblocks/cramfs.c \
 	libblkid/src/superblocks/ddf_raid.c \

--- a/libblkid/src/superblocks/bluestore.c
+++ b/libblkid/src/superblocks/bluestore.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 by Kenneth Van Alstyne <kvanals@kvanals.org>
+ *
+ * This file may be redistributed under the terms of the
+ * GNU Lesser General Public License.
+ *
+ *
+ * Ceph BlueStore is one of the supported storage
+ * methods for Object Storage Devices (OSDs).  
+ * This is used to detect the backing block devices
+ * used for these types of OSDs in a Ceph Cluster.
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+#include <inttypes.h>
+#include <stddef.h>
+
+#include "bitops.h"
+#include "superblocks.h"
+
+#define BLUESTORE_MAGIC_L		22
+
+struct bluestore_phdr {
+	uint8_t		magic[BLUESTORE_MAGIC_L];
+	uint32_t	version;
+} __attribute__((packed));
+
+static int probe_bluestore(blkid_probe pr, const struct blkid_idmag *mag)
+{
+	struct bluestore_phdr *header;
+
+	header = blkid_probe_get_sb(pr, mag, struct bluestore_phdr);
+	if (header == NULL)
+		return errno ? -errno : 1;
+
+	blkid_probe_sprintf_version(pr, "%u", le32_to_cpu(header->version));
+	return 0;
+}
+
+const struct blkid_idinfo bluestore_idinfo =
+{
+	.name		= "ceph_bluestore",
+	.usage		= BLKID_USAGE_OTHER,
+	.probefunc	= probe_bluestore,
+	.magics		=
+	{
+		{ .magic = "bluestore block device", .len = 22 }
+	}
+};

--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -102,6 +102,7 @@ static const struct blkid_idinfo *idinfos[] =
 	&jmraid_idinfo,
 
 	&bcache_idinfo,
+	&bluestore_idinfo,
 	&drbd_idinfo,
 	&drbdmanage_idinfo,
 	&drbdproxy_datalog_idinfo,

--- a/libblkid/src/superblocks/superblocks.h
+++ b/libblkid/src/superblocks/superblocks.h
@@ -70,6 +70,7 @@ extern const struct blkid_idinfo zfs_idinfo;
 extern const struct blkid_idinfo bfs_idinfo;
 extern const struct blkid_idinfo vmfs_volume_idinfo;
 extern const struct blkid_idinfo vmfs_fs_idinfo;
+extern const struct blkid_idinfo bluestore_idinfo;
 extern const struct blkid_idinfo drbd_idinfo;
 extern const struct blkid_idinfo drbdmanage_idinfo;
 extern const struct blkid_idinfo drbdproxy_datalog_idinfo;


### PR DESCRIPTION
Hey folks, I recently came across a need to detect block devices that back Ceph OSDs running BlueStore (as opposed to FileStore).  I wrote this up in a few minutes and it meets my needs.  Submitting it as a PR in case this interests anyone else.  I can modify as needed if there is interest in this being included upstream.