### PR TITLE
2018wk51 three warning fixes

### DIFF
--- a/libblkid/src/superblocks/ntfs.c
+++ b/libblkid/src/superblocks/ntfs.c
@@ -75,10 +75,8 @@ struct file_attribute {
 /* Windows 10 Creators edition has extended the cluster size limit to 2MB */
 #define NTFS_MAX_CLUSTER_SIZE	(2 * 1024 * 1024)
 
-enum {
-	MFT_RECORD_ATTR_VOLUME_NAME		= 0x60,
-	MFT_RECORD_ATTR_END			= 0xffffffff
-};
+static const uint32_t MFT_RECORD_ATTR_VOLUME_NAME = 0x60;
+static const uint32_t MFT_RECORD_ATTR_END = 0xffffffff;
 
 static int probe_ntfs(blkid_probe pr, const struct blkid_idmag *mag)
 {

--- a/libsmartcols/src/grouping.c
+++ b/libsmartcols/src/grouping.c
@@ -156,7 +156,7 @@ static inline const char *group_state_to_string(int state)
 	assert((size_t) state < ARRAY_SIZE(grpstates));
 
 	return grpstates[state];
-};
+}
 
 static void grpset_debug(struct libscols_table *tb, struct libscols_line *ln)
 {

--- a/sys-utils/chmem.c
+++ b/sys-utils/chmem.c
@@ -354,7 +354,7 @@ static void __attribute__((__noreturn__)) usage(void)
 
 int main(int argc, char **argv)
 {
-	struct chmem_desc _desc = { }, *desc = &_desc;
+	struct chmem_desc _desc = { 0 }, *desc = &_desc;
 	int cmd = CMD_NONE, zone_id = -1;
 	char *zone = NULL;
 	int c, rc;


### PR DESCRIPTION
Only the enum overflow is somewhat interesting. Compiler warning prompted me to find out why the message is given, and that resulted to become informed enum is basically a signed int. So lets play totally safe and pair up definition and what is being compared using same data type.

Meanwhile, merry Christmas Karel I wish many new contributions and many contributions from old ones in year 2019.