### PR TITLE
Four time related fixes

### DIFF
--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -42,7 +42,6 @@
 #include <errno.h>
 #include <string.h>
 #include <getopt.h>
-#include <utime.h>
 #include <fcntl.h>
 
 /* We don't use our include/crc32.h, but crc32 from zlib!
@@ -52,6 +51,7 @@
  */
 #include <zlib.h>
 
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
@@ -419,7 +419,7 @@ static void do_uncompress(char *path, int outfd, unsigned long offset,
 
 static void change_file_status(char *path, struct cramfs_inode *i)
 {
-	struct utimbuf epoch = { 0, 0 };
+	const struct timeval epoch = { 0, 0 };
 
 	if (euid == 0) {
 		if (lchown(path, i->uid, i->gid) < 0)
@@ -431,8 +431,8 @@ static void change_file_status(char *path, struct cramfs_inode *i)
 	}
 	if (S_ISLNK(i->mode))
 		return;
-	if (utime(path, &epoch) < 0)
-		err(FSCK_EX_ERROR, _("utime failed: %s"), path);
+	if (utimes(path, &epoch) < 0)
+		err(FSCK_EX_ERROR, _("utimes failed: %s"), path);
 }
 
 static void do_directory(char *path, struct cramfs_inode *i)

--- a/include/monotonic.h
+++ b/include/monotonic.h
@@ -1,6 +1,12 @@
 #ifndef UTIL_LINUX_MONOTONIC_H
 #define UTIL_LINUX_MONOTONIC_H
 
+# ifdef CLOCK_MONOTONIC_RAW
+#  define UL_CLOCK_MONOTONIC	CLOCK_MONOTONIC_RAW
+# else
+#  define UL_CLOCK_MONOTONIC	CLOCK_MONOTONIC
+# endif
+
 #include <sys/time.h>
 
 extern int get_boot_time(struct timeval *boot_time);

--- a/include/timeutils.h
+++ b/include/timeutils.h
@@ -82,9 +82,6 @@ int strtime_iso(const time_t *t, int flags, char *buf, size_t bufsz);
 
 #define UL_SHORTTIME_THISYEAR_HHMM (1 << 1)
 
-int time_is_today(const time_t *t, struct timeval *now);
-int time_is_thisyear(const time_t *t, struct timeval *now);
-
 int strtime_short(const time_t *t, struct timeval *now, int flags, char *buf, size_t bufsz);
 
 #ifndef HAVE_TIMEGM

--- a/lib/monotonic.c
+++ b/lib/monotonic.c
@@ -52,12 +52,8 @@ int gettime_monotonic(struct timeval *tv)
 	int ret;
 	struct timespec ts;
 
-# ifdef CLOCK_MONOTONIC_RAW
 	/* Linux specific, can't slew */
-	if (!(ret = clock_gettime(CLOCK_MONOTONIC_RAW, &ts))) {
-# else
-	if (!(ret = clock_gettime(CLOCK_MONOTONIC, &ts))) {
-# endif
+	if (!(ret = clock_gettime(UL_CLOCK_MONOTONIC, &ts))) {
 		tv->tv_sec = ts.tv_sec;
 		tv->tv_usec = ts.tv_nsec / 1000;
 	}

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -454,7 +454,9 @@ hwclock_SOURCES = \
 	sys-utils/hwclock.h \
 	sys-utils/hwclock-cmos.c
 if LINUX
-hwclock_SOURCES += sys-utils/hwclock-rtc.c
+hwclock_SOURCES += \
+	sys-utils/hwclock-rtc.c \
+	lib/monotonic.c
 endif
 hwclock_LDADD = $(LDADD) libcommon.la -lm
 if HAVE_AUDIT

--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -12,6 +12,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "monotonic.h"
 #include "nls.h"
 
 #include "hwclock.h"
@@ -223,12 +224,12 @@ static int busywait_for_rtc_clock_tick(const struct hwclock_control *ctl,
 	 * something weird happens, we have a time limit (1.5s) on this loop
 	 * to reduce the impact of this failure.
 	 */
-	gettimeofday(&begin, NULL);
+	gettime_monotonic(&begin);
 	do {
 		rc = do_rtc_read_ioctl(rtc_fd, &nowtime);
 		if (rc || start_time.tm_sec != nowtime.tm_sec)
 			break;
-		gettimeofday(&now, NULL);
+		gettime_monotonic(&now);
 		if (time_diff(now, begin) > 1.5) {
 			warnx(_("Timed out waiting for time change."));
 			return 1;


### PR DESCRIPTION
This started as check if there is suspicious use of gettimeofday() function. In lib one was found from timeutils, and use in hwclock felt a bit wrong at spot that needs monotonic time difference measurement. But to make the monotonic time to work nice way I realized it would be good to have project local define to avoid calling CLOCK_MONOTONIC_RAW if it does not exist.  Last commit is vaguely related to time stuff, it replaces obsolete function call with one does the same thing and isn't obsolete yet.