### PR TITLE
logger: concatenate multiple lines of MESSAGE into a single field.

### DIFF
--- a/misc-utils/logger.1
+++ b/misc-utils/logger.1
@@ -107,7 +107,10 @@ execution of
 .B journalctl
 will display MESSAGE field.  Use
 .B journalctl \-\-output json-pretty
-to see rest of the fields.
+to see rest of the fields.  To include newlines in MESSAGE, specify
+MESSAGE several times.  This is handled as a special case, other
+fields will be stored as an array in the journal if they appear
+multiple times.
 .TP
 .BR \-\-msgid " \fImsgid
 Sets the RFC5424 MSGID field.  Note that the space character is not permitted


### PR DESCRIPTION
this is deemed a useful special case since journalctl will only show
either the first or last element of the message array if the field
appears multiple times.

this will solve issue 742
