### PR TITLE
mount.8: clarify (no)suid behavior on file capabilities

### DIFF
--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -1164,12 +1164,12 @@ or
 Do not use the lazytime feature.
 .TP
 .B suid
-Allow set-user-ID or set-group-ID bits to take
-effect.
+Honor set-user-ID and set-group-ID bits or file capabilities when
+executing programs from this filesystem.
 .TP
 .B nosuid
-Do not allow set-user-ID or set-group-ID bits to take
-effect.
+Do not honor set-user-ID and set-group-ID bits or file capabilities when
+executing programs from this filesystem.
 .TP
 .B silent
 Turn on the silent flag.


### PR DESCRIPTION
Clarify that the nosuid option also affects file capabilities and that
it only limits execution of programs. (setgid on directories still
inherit the group regardless of the nosuid option.) The new text is
taken from the mount(2) manual page from the man-pages project.

Addresses: https://github.com/karelzak/util-linux/issues/482
Signed-off-by: Peter Wu <peter@lekensteyn.nl>