### PR TITLE
Typo in configuration help

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1435,7 +1435,7 @@ AS_IF([test "x$have_futimens" = xyes -a "x$have_inotify_init1" = xyes ], [
 
 
 AC_ARG_ENABLE([plymouth_support],
-  AS_HELP_STRING([--disable-plymouth_support], [don not care about plymouth in sylogin(8) and agetty(8)]),
+  AS_HELP_STRING([--disable-plymouth_support], [do not care about plymouth in sylogin(8) and agetty(8)]),
   [], [enable_plymouth_support=check]
 )
 UL_BUILD_INIT([plymouth_support])


### PR DESCRIPTION
Released version 2.33.1 has the same typo in a ./configure file, but I don't find it in this tree, so I will just assume it is generated from the configure.ac file.