### PR TITLE
use ID_SCSI_SERIAL when available

### DIFF
--- a/misc-utils/lsblk-properties.c
+++ b/misc-utils/lsblk-properties.c
@@ -96,8 +96,12 @@ static struct lsblk_devprop *get_properties_by_udev(struct lsblk_device *ld)
 		if (data)
 			prop->wwn = xstrdup(data);
 
-		if ((data = udev_device_get_property_value(dev, "ID_SERIAL_SHORT")))
+		data = udev_device_get_property_value(dev, "ID_SCSI_SERIAL");
+		if(!data)
+			data = udev_device_get_property_value(dev, "ID_SERIAL_SHORT");
+		if (data)
 			prop->serial = xstrdup(data);
+
 		if ((data = udev_device_get_property_value(dev, "ID_MODEL")))
 			prop->model = xstrdup(data);
 


### PR DESCRIPTION
Would fix https://github.com/karelzak/util-linux/issues/750. 