### PR TITLE
libmount/src/tab.c: check table membership before adding entry

### DIFF
--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -410,6 +410,9 @@ int mnt_table_add_fs(struct libmnt_table *tb, struct libmnt_fs *fs)
 {
 	if (!tb || !fs)
 		return -EINVAL;
+	
+	if (!list_empty(&fs->ents))
+		return -EBUSY;
 
 	mnt_ref_fs(fs);
 	list_add_tail(&fs->ents, &tb->ents);


### PR DESCRIPTION
Added validation to function 'mnt_table_add_fs()' to check that added struct libmnt_fs
is not already a member of another table, otherwise accessing the entries of the first
table over an iterator would result in an infinite loop and so freeing the first table results
in memory corruption error. 