### PR TITLE
adding table handling functionality

### DIFF
--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -406,7 +406,7 @@ struct libmnt_cache *mnt_table_get_cache(struct libmnt_table *tb)
  */
 int mnt_table_contains_fs(struct libmnt_table *tb, struct libmnt_fs *fs)
 {
-	struct list_head *ent;
+	struct libmnt_fs *ent;
 
 	if (!tb || !fs)
 		return -EINVAL;

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -438,9 +438,11 @@ int mnt_table_add_fs(struct libmnt_table *tb, struct libmnt_fs *fs)
 	if (!list_empty(&fs->ents))
 		return -EBUSY;
 
-	mnt_ref_fs(fs);
-	list_add_tail(&fs->ents, &tb->ents);
-	tb->nents++;
+	if (!mnt_table_contains_fs(tb, fs)) {
+		mnt_ref_fs(fs);
+		list_add_tail(&fs->ents, &tb->ents);
+		tb->nents++;
+	}
 
 	DBG(TAB, ul_debugobj(tb, "add entry: %s %s",
 			mnt_fs_get_source(fs), mnt_fs_get_target(fs)));

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -492,11 +492,16 @@ int mnt_table_move_fs(struct libmnt_table *src, struct libmnt_table *dst, struct
 	if (!src || !dst || !fs)
 		return -EINVAL;
 
-	if (!mnt_table_contains_fs(src, fs))
-		return -ENOENT;
+	if (!mnt_table_contains_fs(src, fs)) {
+		if (!list_empty(&fs->ents))
+			return -ENOENT;
 
-	src->nents--;
-	list_move_tail(&fs->ents, &dst->ents);
+		list_add_tail(&fs->ents, &dst->ents);
+	} else {
+		src->nents--;
+		list_move_tail(&fs->ents, &dst->ents);
+	}
+	
 	dst->nents++;	
 
 	return 0;


### PR DESCRIPTION
Added the function 'mnt_table_contains_fs()' to check if an entry is part of a specific table.
Added the function 'mnt_table_move_fs()' to move an entry from one table to  another.
Added a validation to functions 'mnt_table_remove_fs()'  and 'mnt_table_add_fs()' if an entry is part of the table. If it is not part of it, the variable 'nents' would contain a wrong value.
These are enhancements I need for one of my own projects and I thought that some could be useful for others. If this is not the case, ignore it.