### PR TITLE
changes to table handling

### DIFF
--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -560,7 +560,14 @@ extern int mnt_table_append_trailing_comment(struct libmnt_table *tb, const char
 extern int mnt_table_set_cache(struct libmnt_table *tb, struct libmnt_cache *mpc);
 extern struct libmnt_cache *mnt_table_get_cache(struct libmnt_table *tb);
 extern int mnt_table_add_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
+extern int mnt_table_add_fs_after(struct libmnt_table *tb, struct libmnt_fs *fs, struct libmnt_fs *new);
+extern int mnt_table_add_fs_before(struct libmnt_table *tb, struct libmnt_fs *fs, struct libmnt_fs *new);
 extern int mnt_table_remove_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
+extern int mnt_table_move_fs(struct libmnt_table *src, struct libmnt_table *dst, struct libmnt_fs *fs);
+extern int mnt_table_move_fs_before(struct libmnt_table *src, struct libmnt_table *dst,
+				struct libmnt_fs *pos, struct libmnt_fs *fs);
+extern int mnt_table_move_fs_after(struct libmnt_table *src, struct libmnt_table *dst,
+				struct libmnt_fs *pos, struct libmnt_fs *fs);
 extern int mnt_table_first_fs(struct libmnt_table *tb, struct libmnt_fs **fs);
 extern int mnt_table_last_fs(struct libmnt_table *tb, struct libmnt_fs **fs);
 extern int mnt_table_next_fs(struct libmnt_table *tb, struct libmnt_iter *itr,
@@ -597,6 +604,8 @@ extern struct libmnt_fs *mnt_table_find_pair(struct libmnt_table *tb,
 				const char *target, int direction);
 extern struct libmnt_fs *mnt_table_find_devno(struct libmnt_table *tb,
 				dev_t devno, int direction);
+
+extern int mnt_table_find_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
 
 extern int mnt_table_find_next_fs(struct libmnt_table *tb,
 			struct libmnt_iter *itr,

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -560,8 +560,8 @@ extern int mnt_table_append_trailing_comment(struct libmnt_table *tb, const char
 extern int mnt_table_set_cache(struct libmnt_table *tb, struct libmnt_cache *mpc);
 extern struct libmnt_cache *mnt_table_get_cache(struct libmnt_table *tb);
 extern int mnt_table_add_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
-extern int mnt_table_add_fs_after(struct libmnt_table *tb, struct libmnt_fs *fs, struct libmnt_fs *new);
-extern int mnt_table_add_fs_before(struct libmnt_table *tb, struct libmnt_fs *fs, struct libmnt_fs *new);
+extern int mnt_table_add_fs_after(struct libmnt_table *tb, struct libmnt_fs *pos, struct libmnt_fs *fs);
+extern int mnt_table_add_fs_before(struct libmnt_table *tb, struct libmnt_fs *pos, struct libmnt_fs *fs);
 extern int mnt_table_remove_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
 extern int mnt_table_move_fs(struct libmnt_table *src, struct libmnt_table *dst, struct libmnt_fs *fs);
 extern int mnt_table_move_fs_before(struct libmnt_table *src, struct libmnt_table *dst,

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -402,18 +402,22 @@ struct libmnt_cache *mnt_table_get_cache(struct libmnt_table *tb)
  *
  * Checks if @fs is part of table @tb.
  *
- * Returns: negative number in case of error, 1 if @fs is part of @tb, otherwise 0.
+ * Returns: index of @fs in table, 0 if not found or negative number in case of error.
  */
 int mnt_table_find_fs(struct libmnt_table *tb, struct libmnt_fs *fs)
 {
 	struct list_head *p;
+	int i;
 
 	if (!tb || !fs)
 		return -EINVAL;
 
+	i = 0;
 	list_for_each(p, &tb->ents) {
+		++i;
+
 		if (list_entry(p, struct libmnt_fs, ents) == fs)
-			return 1;
+			return i;
 	}
 
 	return 0;


### PR DESCRIPTION
Added 'mnt_table_find_fs()' to check if an entry is part of a table.
Added 'mnt_table_move_fs()' to move an entry from one table to the end of another.
Added 'mnt_table_add_fs_after()' to add an entry after a specific entry.
Added 'mnt_table_add_fs_before()' to add an entry before a specific entry.
Added 'mnt_table_move_fs_after()' to move an entry from one table to another after a specific entry.
Added 'mnt_table_move_fs_before()' to move an entry from one table to another before a specific entry.
Added validation to 'mnt_table_add_fs()' and 'mnt_table_remove_fs()' that the entry to remove is part of the table, otherwise the entry counter is changed for the given table but the entry is remove/added from/to another table.
These are the changes that I have made for one of my projects. Maybe some of these are useful for others. If that is not the case, simply close.