### PR TITLE
column: Address fill-order confusion in documentation

### DIFF
--- a/text-utils/column.1
+++ b/text-utils/column.1
@@ -31,7 +31,7 @@
 .\"
 .\"     @(#)column.1	8.1 (Berkeley) 6/6/93
 .\"
-.TH COLUMN 1 "January 2017" "util-linux" "User Commands"
+.TH COLUMN 1 "February 2019" "util-linux" "User Commands"
 .SH NAME
 column \- columnate lists
 .SH SYNOPSIS
@@ -168,6 +168,15 @@ New output (since util-linux 2.23):
 a  b  c
 1     3
 .EE
+.PP
+Historical versions of this tool indicated that "rows are filled before
+columns" by default, and that the
+.B \-x
+option reverses this. This wording did not reflect the actual behavior, and it
+has since been corrected (see above). Other implementations of
+.B column
+may continue to use the older documentation, but the behavior should be
+identical in any case.
 .SH "SEE ALSO"
 .BR colrm (1),
 .BR ls (1),


### PR DESCRIPTION
Hopefully this isn't too nit-picky:

Historical versions of `column` have described the default fill order as rows-then-columns and the `-x` order as columns-then-rows. This was misleading at best, and the util-linux implementation was updated to clarify the actual behaviour in 3e094e5fe2 (March 2017).

However, the other implementations (used by *BSD, macOS, Debian, &al.) continue to use the previous wording, and a user comparing them could easily get the false impression that util-linux `column` has exactly the opposite fill behaviour from BSD `column`.

To address this, a note is added to the man page explaining the change and clarifying that, despite what the BSD documentation says, the two implementations behave identically in this regard.