### PR TITLE
Removing overhead from table handling functions 

### DIFF
--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -563,9 +563,14 @@ extern int mnt_table_add_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
 extern int mnt_table_find_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
 extern int mnt_table_insert_fs(struct libmnt_table *tb, int before,
 				struct libmnt_fs *pos, struct libmnt_fs *fs);
+extern int mnt_table_insert_fs_safe(struct libmnt_table *tb, int before,
+				struct libmnt_fs *pos, struct libmnt_fs *fs);
 extern int mnt_table_move_fs(struct libmnt_table *src, struct libmnt_table *dst,
                       int before, struct libmnt_fs *pos, struct libmnt_fs *fs);
+extern int mnt_table_move_fs_safe(struct libmnt_table *src, struct libmnt_table *dst,
+                      int before, struct libmnt_fs *pos, struct libmnt_fs *fs);
 extern int mnt_table_remove_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
+extern int mnt_table_remove_fs_safe(struct libmnt_table *tb, struct libmnt_fs *fs);
 extern int mnt_table_first_fs(struct libmnt_table *tb, struct libmnt_fs **fs);
 extern int mnt_table_last_fs(struct libmnt_table *tb, struct libmnt_fs **fs);
 extern int mnt_table_next_fs(struct libmnt_table *tb, struct libmnt_iter *itr,


### PR DESCRIPTION
Added mnt_table_move_safe()
Added mnt_table_insert_safe()
Added mnt_table_remove_safe()
The functions are checking for table memberships of the respective entries if you are not sure about it. So you can use the "unsafe" versions if you know that erverything is alright and avoid the overhead of checking the memberships
I don't know if this is an appropriate alternative but this avoids looping over the table over and over again, although you know that every entry belongs to the right table before calling the function.