### PR TITLE
reference counting and iterator changes

### DIFF
--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -575,6 +575,8 @@ extern int mnt_table_next_child_fs(struct libmnt_table *tb, struct libmnt_iter *
 extern int mnt_table_get_root_fs(struct libmnt_table *tb, struct libmnt_fs **root);
 extern int mnt_table_set_iter(struct libmnt_table *tb, struct libmnt_iter *itr,
 			      struct libmnt_fs *fs);
+extern int mnt_table_set_iter_safe(struct libmnt_table *tb, struct libmnt_iter *itr,
+			      struct libmnt_fs *fs);
 
 enum {
 	MNT_UNIQ_FORWARD  = (1 << 1),	/* default is backward */

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -730,7 +730,7 @@ int mnt_table_next_fs(struct libmnt_table *tb, struct libmnt_iter *itr, struct l
 
 	if (!itr->head)
 		MNT_ITER_INIT(itr, &tb->ents);
-	else if (*fs == list_entry(iter->p, struct libmnt_fs, ents))
+	else if (*fs == list_entry(itr->p, struct libmnt_fs, ents))
 		mnt_unref_fs(*fs);
 
 	if (itr->p != itr->head) {
@@ -942,7 +942,7 @@ int mnt_table_set_iter_safe(struct libmnt_table *tb, struct libmnt_iter *itr, st
 		return -EINVAL;
 
 	if (list_empty(&fs->ents) || 
-		list_empty(&tb->ents) || list_table_find_fs(tb, fs) < 1)
+		list_empty(&tb->ents) || mnt_table_find_fs(tb, fs) < 1)
 		return -ENOENT;
 
 	MNT_ITER_INIT(itr, &tb->ents);


### PR DESCRIPTION
Added reference counting to functions mnt_table_{first,next,last}_fs(). If you don't want this behavior because you want the programmer to take care of reference handling in this case then just ignore my suggestion. I have come across this after using table entries that I have retrieved through above functions and freeing the respective tables without incrementing the reference counter of the entries.

Added function mnt_table_set_iter_safe() that checks if an entry is member of the respective table otherwise the later use of the iterator would cause problems. Of course, you can add the checks to the
original function without the need of a new function.