### PR TITLE
lib/loopdev.c: Inline loopcxt_has_device

### DIFF
--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -128,7 +128,7 @@ int loopcxt_set_device(struct loopdev_cxt *lc, const char *device)
 	return 0;
 }
 
-int loopcxt_has_device(struct loopdev_cxt *lc)
+inline int loopcxt_has_device(struct loopdev_cxt *lc)
 {
 	return lc && *lc->device;
 }


### PR DESCRIPTION
loopcxt_has_device is a one liner, so adding inline statement does not
hurt.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>