### PR TITLE
libmount: table handling more efficient

### DIFF
--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -446,6 +446,23 @@ int mnt_fs_streq_srcpath(struct libmnt_fs *fs, const char *path)
 }
 
 /**
+ * mnt_fs_get_table:
+ * @fs: table entry
+ * @tb: table that contains @fs
+ *
+ * Returns: 0 or negative number on error (if @fs or @tb is NULL).
+ */
+int mnt_fs_get_table(struct libmnt_fs *fs, struct libmnt_table **tb)
+{
+	if (!fs || !tb)
+		return -EINVAL;
+
+	*tb = fs->tab;
+
+	return 0;
+}
+
+/**
  * mnt_fs_streq_target:
  * @fs: fs
  * @path: mount point

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -439,6 +439,7 @@ extern int mnt_fs_set_userdata(struct libmnt_fs *fs, void *data);
 extern const char *mnt_fs_get_source(struct libmnt_fs *fs);
 extern int mnt_fs_set_source(struct libmnt_fs *fs, const char *source);
 extern const char *mnt_fs_get_srcpath(struct libmnt_fs *fs);
+extern int mnt_fs_get_table(struct libmnt_fs *fs, struct libmnt_table **tb);
 
 extern int mnt_fs_get_tag(struct libmnt_fs *fs, const char **name,
 			  const char **value);

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -170,6 +170,7 @@ struct libmnt_iter {
  */
 struct libmnt_fs {
 	struct list_head ents;
+	struct libmnt_table *tab;
 
 	int		refcount;	/* reference counter */
 	int		id;		/* mountinfo[1]: ID */

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -467,6 +467,7 @@ static int __table_insert_fs(
 	else
 		list_add_tail(&fs->ents, head);
 
+	fs->tab = tb;
 	tb->nents++;
 
 	DBG(TAB, ul_debugobj(tb, "insert entry: %s %s",
@@ -561,6 +562,7 @@ int mnt_table_remove_fs(struct libmnt_table *tb, struct libmnt_fs *fs)
 	list_del_init(&fs->ents);
 
 	mnt_unref_fs(fs);
+	fs->tab = NULL;
 	tb->nents--;
 	return 0;
 }

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -443,11 +443,12 @@ int mnt_table_add_fs(struct libmnt_table *tb, struct libmnt_fs *fs)
 	if (!tb || !fs)
 		return -EINVAL;
 
-	if (!list_empty(&fs->ents))
+	if (fs->tab)
 		return -EBUSY;
 
 	mnt_ref_fs(fs);
 	list_add_tail(&fs->ents, &tb->ents);
+	fs->tab = tb;
 	tb->nents++;
 
 	DBG(TAB, ul_debugobj(tb, "add entry: %s %s",
@@ -497,10 +498,10 @@ int mnt_table_insert_fs(struct libmnt_table *tb, int before,
 	if (!tb || !fs)
 		return -EINVAL;
 
-	if (!list_empty(&fs->ents))
+	if (fs->tab)
 		return -EBUSY;
 
-	if (pos && mnt_table_find_fs(tb, pos) < 1)
+	if (pos && pos->tab != tb)
 		return -ENOENT;
 
 	mnt_ref_fs(fs);
@@ -529,10 +530,7 @@ int mnt_table_move_fs(struct libmnt_table *src, struct libmnt_table *dst,
 	if (!src || !dst || !fs)
 		return -EINVAL;
 
-	if (mnt_table_find_fs(src, fs) < 1)
-		return -ENOENT;
-
-	if (pos && mnt_table_find_fs(dst, pos) < 1)
+	if (fs->tab != src || (pos && pos->tab != dst))
 		return -ENOENT;
 
 	/* remove from source */
@@ -557,7 +555,7 @@ int mnt_table_move_fs(struct libmnt_table *src, struct libmnt_table *dst,
  */
 int mnt_table_remove_fs(struct libmnt_table *tb, struct libmnt_fs *fs)
 {
-	if (!tb || !fs || mnt_table_find_fs(tb, fs) < 1)
+	if (!tb || !fs || fs->tab != tb)
 		return -EINVAL;
 
 	list_del_init(&fs->ents);
@@ -912,6 +910,9 @@ int mnt_table_set_iter(struct libmnt_table *tb, struct libmnt_iter *itr, struct 
 {
 	if (!tb || !itr || !fs)
 		return -EINVAL;
+
+	if (fs->tab != tb)
+		return -ENOENT;
 
 	MNT_ITER_INIT(itr, &tb->ents);
 	itr->p = &fs->ents;


### PR DESCRIPTION
Signed-off-by: Tim Hildering <hilderingt@posteo.net>
	changed:       libmount/src/fs.c
	changed:       libmount/src/libmount.h.in
	changed:       libmount/src/mountP.h
	changed:       libmount/src/tab.c

Added member 'struct libmnt_table *tab' to libmnt_fs structure.
Added 'mnt_fs_get_table()'.
Removed overhead from 'mnt_table_{insert,move,remove}_fs().
Added check to 'mnt_table_set_iter()' that entry is member of table.

You are right that creating a "safe" function for each "unsafe" function is not very efficient. So maybe this is a better solution.