### PR TITLE
Fix documentation

### DIFF
--- a/disk-utils/mkswap.8
+++ b/disk-utils/mkswap.8
@@ -104,7 +104,7 @@ The maximum useful size of a swap area depends on the architecture and
 the kernel version.
 
 The maximum number of the pages that is possible to address by swap area header
-is 4294967295 (UINT_MAX).  The remaining space on the swap device is ignored.
+is UINT_MAX.  The remaining space on the swap device is ignored.
 
 Presently, Linux allows 32 swap areas.
 The areas in use can be seen in the file


### PR DESCRIPTION
The number 4294967295 corresponds to UINT_MAX on 32b systems. However, we live in 64b world yet and the corresponding number is much larger. I think it is better to remove the value.