### PR TITLE
Minor update of mount.8

### DIFF
--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -937,7 +937,7 @@ output for extN filesystems).
 The following options apply to any filesystem that is being
 mounted (but not every filesystem actually honors them \(en e.g.\&, the
 .B sync
-option today has an effect only for ext2, ext3, ext4, fat, vfat and ufs):
+option today has an effect only for ext2, ext3, ext4, fat, vfat, ufs and xfs):
 
 .TP
 .B async


### PR DESCRIPTION
Unfortunate use of 'e.g.', somebody noticed it is not actual and reported a bug.