### PR TITLE
fstrim.c: Remove comment about vfat not supporting fstrim

### DIFF
--- a/sys-utils/fstrim.c
+++ b/sys-utils/fstrim.c
@@ -303,7 +303,7 @@ static int fstrim_all(struct fstrim_control *ctl)
 		/*
 		 * We're able to detect that the device supports discard, but
 		 * things also depend on filesystem or device mapping, for
-		 * example vfat or LUKS (by default) does not support FSTRIM.
+		 * example LUKS (by default) does not support FSTRIM.
 		 *
 		 * This is reason why we ignore EOPNOTSUPP and ENOTTY errors
 		 * from discard ioctl.


### PR DESCRIPTION
Commit f663b5b38f ("fat: add FITRIM ioctl for FAT file system") in
linux kernel added support for using fstrim with vfat filesystem.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>