### PR TITLE
fstrim.service: set I/O scheduling class to 'idle'

### DIFF
--- a/sys-utils/fstrim.service.in
+++ b/sys-utils/fstrim.service.in
@@ -5,6 +5,7 @@ Documentation=man:fstrim(8)
 [Service]
 Type=oneshot
 ExecStart=@sbindir@/fstrim --fstab --verbose
+IOSchedulingClass=idle
 ProtectSystem=strict
 ProtectHome=yes
 PrivateDevices=no


### PR DESCRIPTION
It's a background maintenance job - so, I think, it should have the
lowest priority.

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>