### PR TITLE
fstrim: add --quiet option to suppress error messages

### DIFF
--- a/sys-utils/fstrim.8
+++ b/sys-utils/fstrim.8
@@ -1,4 +1,4 @@
-.TH FSTRIM 8 "July 2014" "util-linux" "System Administration"
+.TH FSTRIM 8 "May 2019" "util-linux" "System Administration"
 .SH NAME
 fstrim \- discard unused blocks on a mounted filesystem
 .SH SYNOPSIS
@@ -99,6 +99,14 @@ LVM setup, etc.  These reductions would not be reflected in fstrim_range.len
 (the
 .B --length
 option).
+.TP
+.B \-\-quiet
+Suppress error messages.  This option is meant to be used in systemd service
+file to hide warnings that are result of known problems, such as NTFS driver
+reporting
+.I Bad file descriptor
+when device is mounted read-only, or lack of file system support for ioctl
+FITRIM call.
 .TP
 .BR \-V , " \-\-version"
 Display version information and exit.

--- a/sys-utils/fstrim.service.in
+++ b/sys-utils/fstrim.service.in
@@ -4,7 +4,7 @@ Documentation=man:fstrim(8)
 
 [Service]
 Type=oneshot
-ExecStart=@sbindir@/fstrim --fstab --verbose
+ExecStart=@sbindir@/fstrim --fstab --verbose --quiet
 ProtectSystem=strict
 ProtectHome=yes
 PrivateDevices=no


### PR DESCRIPTION
When fstrim interacts with NTFS it result can be error reporting bad file
descriptor.  That seems to be a bug in NTFS.  While waiting driver to get on
top of the issue and be commonly available lets add to fstrim option to make
it be more silent about errno 9 aka EBADF, Bad file descriptor.

Reported-by: https://github.com/moviuro
Proposed-by: Dave Reisner <dreisner@archlinux.org>
Reference: https://bugs.archlinux.org/task/62288
Addresses: https://github.com/karelzak/util-linux/issues/789
Signed-off-by: Sami Kerola <kerolasa@iki.fi>