### PR TITLE
lscpu: move trailing null after removing characters from a string

### DIFF
--- a/include/strutils.h
+++ b/include/strutils.h
@@ -262,6 +262,7 @@ static inline void strrem(char *s, int rem)
 		if (*s != rem)
 			*p++ = *s;
 	}
+	*p = '\0';
 }
 
 extern char *strnappend(const char *s, const char *suffix, size_t b);

--- a/tests/expected/lscpu/lscpu-x86_64-epyc_7451
+++ b/tests/expected/lscpu/lscpu-x86_64-epyc_7451
@@ -33,7 +33,7 @@ Vulnerability L1tf:               Not affected
 Vulnerability Meltdown:           Not affected
 Vulnerability Spec store bypass:  Mitigation; Speculative Store Bypass disabled via prctl and seccomp
 Vulnerability Spectre v1:         Mitigation; __user pointer sanitization
-Vulnerability Spectre v2:         Mitigation; Full AMD retpoline, IBPB conditional, STIBP disabled, RSB fillingng
+Vulnerability Spectre v2:         Mitigation; Full AMD retpoline, IBPB conditional, STIBP disabled, RSB filling
 Flags:                            fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid amd_dcm aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb hw_pstate ssbd ibpb vmmcall fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 xsaves clzero irperf xsaveerptr arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif overflow_recov succor smca
 
 # The following is the parsable format, which can be fed to other


### PR DESCRIPTION
From the test input string ':' characters are removed:

    cat x86_64-epyc_7451/sys/devices/system/cpu/vulnerabilities/spectre_v2
    Mitigation: Full AMD retpoline, IBPB: conditional, STIBP: disabled, RSB filling

Signed-off-by: Sami Kerola <kerolasa@iki.fi>