### PR TITLE
Bash completion updates

### DIFF
--- a/bash-completion/blkid
+++ b/bash-completion/blkid
@@ -85,6 +85,7 @@ _blkid_module()
 				--offset
 				--usages
 				--match-types
+				--no-part-details
 				--help
 				--version
 			"

--- a/bash-completion/hardlink
+++ b/bash-completion/hardlink
@@ -1,0 +1,36 @@
+_hardlink_module()
+{
+	local cur prev OPTS
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	case $prev in
+		'-x'|'--exclude')
+			COMPREPLY=( $(compgen -W "regex" -- $cur) )
+			return 0
+			;;
+		'-H'|'--help'|'-V'|'--version')
+			return 0
+			;;
+	esac
+	case $cur in
+		-*)
+		OPTS="
+			--content
+			--dry-run
+			--verbose
+			--force
+			--exclude
+			--version
+			--help
+		"
+			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
+			return 0
+			;;
+	esac
+	local IFS=$'\n'
+	compopt -o filenames
+	COMPREPLY=( $(compgen -d -- $cur) )
+	return 0
+}
+complete -F _hardlink_module hardlink

--- a/bash-completion/lsblk
+++ b/bash-completion/lsblk
@@ -31,7 +31,7 @@ _lsblk_module()
 			COMPREPLY=( $(compgen -P "$prefix" -W "${MAJOR:-""}" -S ',' -- $realcur) )
 			return 0
 			;;
-		'-o'|'--output')
+		'-o'|'--output'|'-M'|'--dedup')
 			local prefix realcur LSBLK_COLS
 			realcur="${cur##*,}"
 			prefix="${cur%$realcur}"
@@ -66,6 +66,8 @@ _lsblk_module()
 				--json
 				--ascii
 				--list
+				--dedup
+				--merge
 				--perms
 				--noheadings
 				--output

--- a/bash-completion/lscpu
+++ b/bash-completion/lscpu
@@ -30,6 +30,8 @@ _lscpu_module()
 		-*)
 			OPTS_ALL="--all
 				--online
+				--bytes
+				--caches
 				--offline
 				--json
 				--extended=


### PR DESCRIPTION
Usual check what has changed in usage() in between previous release and latest commit resulting updates to to bash completions. That said manuals had all the options found in these commits.