### PR TITLE
su: More descriptive error message on malformed user entry

### DIFF
--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -1446,7 +1446,9 @@ int su_main(int argc, char **argv, int mode)
 	    || !su->pwd->pw_passwd
 	    || !su->pwd->pw_name || !*su->pwd->pw_name
 	    || !su->pwd->pw_dir  || !*su->pwd->pw_dir)
-		errx(EXIT_FAILURE, _("user %s does not exist"), su->new_user);
+		errx(EXIT_FAILURE,
+		     _("user %s does not exist or the user entry does not "
+		       "contain all the required fields"), su->new_user);
 
 	su->new_user = su->pwd->pw_name;
 	su->old_user = xgetlogin();


### PR DESCRIPTION
With users coming from LDAP, it is often the case that the entry in LDAP
does not contain one or more attributes required by su or, because of
misconfigured access control rights, the attribute might not be readable
by the LDAP client. In that case, su just tells the user that the user
does not exist.

It might be more user-friendly to tell the user to check the user entry
for all required fields.