### PR TITLE
TODO: fix typo

### DIFF
--- a/Documentation/TODO
+++ b/Documentation/TODO
@@ -51,7 +51,7 @@ nsenter(1)
  - read the default UID and GID from the target process.
    http://thread.gmane.org/gmane.linux.utilities.util-linux-ng/9553/focus=9585
 
-hwlock
+hwclock
 ------
  - use /var/lib/hwclock/drift to store hw-clock drift numbers.
  - use /etc/adjtime as read-only for UTC/LOCAL information only


### PR DESCRIPTION
The description is of hwclock whereas the title consists of hwlock. Since the title doesn't match with description, this seems to be a typo