### PR TITLE
Signal to flush output from `script`

### DIFF
--- a/term-utils/script.1
+++ b/term-utils/script.1
@@ -162,6 +162,12 @@ You should also avoid use of script in command pipes, as
 .B script
 can read more input than you would expect.
 .PP
+.SH SIGNALS
+Upon receiving
+.BR SIGUSR1,
+.B script
+immediately flushes the output file.
+.PP
 .SH ENVIRONMENT
 The following environment variable is utilized by
 .BR script :

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -500,12 +500,11 @@ static void handle_signal(struct script_control *ctl, int fd)
 			ioctl(ctl->slave, TIOCSWINSZ, (char *)&ctl->win);
 		}
 		break;
-  case SIGUSR1:
-    /* on receiving SIGUSR1 we fflush the output file */
+	case SIGUSR1:
+	  /* on receiving SIGUSR1 we fflush the output file */
+	  fflush(ctl->typescriptfp);
 
-		fflush(ctl->typescriptfp);
-
-    return;
+	  return;
 	case SIGTERM:
 		/* fallthrough */
 	case SIGINT:

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -867,7 +867,7 @@ int main(int argc, char **argv)
 	sigaddset(&ctl.sigset, SIGTERM);
 	sigaddset(&ctl.sigset, SIGINT);
 	sigaddset(&ctl.sigset, SIGQUIT);
-  sigaddset(&ctl.sigset, SIGUSR1);
+	sigaddset(&ctl.sigset, SIGUSR1);
 
 	/* block signals used for signalfd() to prevent the signals being
 	 * handled according to their default dispositions */

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -500,6 +500,12 @@ static void handle_signal(struct script_control *ctl, int fd)
 			ioctl(ctl->slave, TIOCSWINSZ, (char *)&ctl->win);
 		}
 		break;
+  case SIGUSR1:
+    /* on receiving SIGUSR1 we fflush the output file */
+
+		fflush(ctl->typescriptfp);
+
+    return;
 	case SIGTERM:
 		/* fallthrough */
 	case SIGINT:
@@ -862,6 +868,7 @@ int main(int argc, char **argv)
 	sigaddset(&ctl.sigset, SIGTERM);
 	sigaddset(&ctl.sigset, SIGINT);
 	sigaddset(&ctl.sigset, SIGQUIT);
+  sigaddset(&ctl.sigset, SIGUSR1);
 
 	/* block signals used for signalfd() to prevent the signals being
 	 * handled according to their default dispositions */


### PR DESCRIPTION
I've long been using `script` as a basis of storing REPL transcriptions, but since I occasionally need to be able to view the transcription without closing the REPL mid-session, have always used a modified version that responds to SIGUSR1 by a one-time flush of the output file (using `-f` to flush on every write causes too much of a performance impact if the REPL involves pretty prints of 'large' objects).

It occurred to me while making the changes again today, that this change might be of use to other people since it doesn't appear to have any negative consequences (other than using SIGUSR1 which is otherwise unused - although SIGTTOU or SIGTRAP *may* be more idiomatic)