### PR TITLE
configure.ac: Include <stdlib.h> in wchar_t test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -756,6 +756,7 @@ UL_REQUIRES_COMPILE([widechar], [[
   #include <wchar.h>
   #include <wctype.h>
   #include <stdio.h>
+  #include <stdlib.h>
   ]], [[
     wchar_t wc;
     wint_t w;


### PR DESCRIPTION
Without #include <stdlib.h>, this configure check fails for strict
C99/C11 compilers which do not support implicit function declarations
(which are a C90 feature removed from C99).