### PR TITLE
2019wk27 mostly warning fixes

### DIFF
--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -62,8 +62,7 @@ static inline char __attribute__((warn_unused_result)) __ul_returns_nonnull
 {
         char *ret;
 
-        if (!str)
-                return NULL;
+        assert(str);
 
         ret = strdup(str);
 
@@ -77,8 +76,7 @@ xstrndup(const char *str, size_t size)
 {
         char *ret;
 
-        if (!str)
-                return NULL;
+        assert(str);
 
         ret = strndup(str, size);
 

--- a/lib/ttyutils.c
+++ b/lib/ttyutils.c
@@ -47,16 +47,16 @@ int get_terminal_dimension(int *cols, int *lines)
 		l = t_win.ts_lines;
 	}
 #endif
-
-	if (cols && c <= 0)
-		c = get_env_int("COLUMNS");
-	if (lines && l <= 0)
-		l = get_env_int("LINES");
-
-	if (cols)
+	if (cols) {
+		if (c <= 0)
+			c = get_env_int("COLUMNS");
 		*cols = c;
-	if (lines)
+	}
+	if (lines) {
+		if (l <= 0)
+			l = get_env_int("LINES");
 		*lines = l;
+	}
 	return 0;
 }
 

--- a/libblkid/src/save.c
+++ b/libblkid/src/save.c
@@ -213,7 +213,7 @@ int main(int argc, char **argv)
 	int ret;
 
 	blkid_init_debug(BLKID_DEBUG_ALL);
-	if (argc > 2) {
+	if (argc != 2) {
 		fprintf(stderr, "Usage: %s [filename]\n"
 			"Test loading/saving a cache (filename)\n", argv[0]);
 		exit(1);

--- a/libblkid/src/superblocks/drbd.c
+++ b/libblkid/src/superblocks/drbd.c
@@ -109,7 +109,7 @@ struct meta_data_on_disk_9 {
 	struct peer_dev_md_on_disk_9 peers[DRBD_PEERS_MAX];
 	uint64_t history_uuids[HISTORY_UUIDS];
 
-	char padding[0] __attribute__((aligned(4096)));
+	uint8_t padding[2704];
 } __attribute__((packed));
 
 

--- a/libblkid/src/superblocks/zfs.c
+++ b/libblkid/src/superblocks/zfs.c
@@ -58,7 +58,7 @@ struct nvuint64 {
 	uint32_t	nvu_type;
 	uint32_t	nvu_elem;
 	uint64_t	nvu_value;
-};
+} __attribute__((packed));
 
 struct nvlist {
 	uint32_t	nvl_unknown[3];

--- a/libfdisk/src/context.c
+++ b/libfdisk/src/context.c
@@ -675,7 +675,7 @@ int fdisk_assign_device(struct fdisk_context *cxt,
 
 	fd = open(fname, (readonly ? O_RDONLY : O_RDWR ) | O_CLOEXEC);
 	if (fd < 0) {
-		int rc = -errno;
+		rc = -errno;
 		DBG(CXT, ul_debugobj(cxt, "failed to assign device [rc=%d]", rc));
 		return rc;
 	}

--- a/libmount/src/optstr.c
+++ b/libmount/src/optstr.c
@@ -351,7 +351,9 @@ int mnt_optstr_deduplicate_option(char **optstr, const char *name)
 			end = ol.end;
 			opt = end && *end ? end + 1 : NULL;
 		}
-	} while (rc == 0 && opt && *opt);
+		if (opt == NULL)
+			break;
+	} while (rc == 0 && *opt);
 
 	return rc < 0 ? rc : begin ? 0 : 1;
 }

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -774,8 +774,14 @@ static char *device_get_data(
 		str = get_vfs_attribute(dev, id);
 		break;
 	case COL_TARGET:
-		str = xstrdup(lsblk_device_get_mountpoint(dev));
+	{
+		char *s = lsblk_device_get_mountpoint(dev);
+		if (s)
+			str = xstrdup(s);
+		else
+			str = NULL;
 		break;
+	}
 	case COL_LABEL:
 		prop = lsblk_device_get_properties(dev);
 		if (prop && prop->label)


### PR DESCRIPTION
Apart the ttyutils code streamlining these changes are warning and error fixes. The last one of the changes that takes care of ASAN error might actually be somewhat important, as zfs bit operations may have resulted to incorrect computation.

Adding asset() to xstrdup() and xstrndup() might be a bit controversial. I see it did not cause test system to fail, but as we know tests do not cover all code lines. Threat is of course that assert starts to break stuff and we only know after release. So I understand if this commit should be changed to warn if there is buggy code path, but not crash.