### PR TITLE
libfdisk: Fix double free of *_chs strings in fdisk_partition

### DIFF
--- a/libfdisk/src/partition.c
+++ b/libfdisk/src/partition.c
@@ -100,6 +100,10 @@ static struct fdisk_partition *__copy_partition(struct fdisk_partition *o)
 		n->fsuuid = strdup(o->fsuuid);
 	if (o->fslabel)
 		n->fslabel = strdup(o->fslabel);
+	if (o->start_chs)
+		n->start_chs = strdup(o->start_chs);
+	if (o->end_chs)
+		n->end_chs = strdup(o->end_chs);
 
 	return n;
 }


### PR DESCRIPTION
__copy_partition doesn't duplicate these strings which leads to
occasional double free.

Signed-off-by: Vojtech Trefny <vtrefny@redhat.com>