### PR TITLE
lscpu: prefer memcpy() to manual pointer arithmetic

### DIFF
--- a/sys-utils/lscpu-dmi.c
+++ b/sys-utils/lscpu-dmi.c
@@ -80,7 +80,7 @@ static void to_dmi_header(struct dmi_header *h, uint8_t *data)
 {
 	h->type = data[0];
 	h->length = data[1];
-	h->handle = WORD(data + 2);
+	memcpy(&h->handle, data + 2, sizeof(h->handle));
 	h->data = data;
 }
 


### PR DESCRIPTION
With pointer arithmetic clang address sanitizer gives following error this
change addresses.  Notice the following happens only when running as root.

sys-utils/lscpu-dmi.c:83:14: runtime error: load of misaligned address
0x55a1d62f3d1d for type 'const uint16_t' (aka 'const unsigned short'), which
requires 2 byte alignment

Signed-off-by: Sami Kerola <kerolasa@iki.fi>