### PR TITLE
mountpoint: add --nofollow option

### DIFF
--- a/bash-completion/mountpoint
+++ b/bash-completion/mountpoint
@@ -11,7 +11,7 @@ _mountpoint_module()
 	esac
 	case $cur in
 		-*)
-			OPTS="--quiet --fs-devno --devno --help --version"
+			OPTS="--quiet --nofollow --fs-devno --devno --help --version"
 			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
 			return 0
 			;;

--- a/sys-utils/mountpoint.1
+++ b/sys-utils/mountpoint.1
@@ -1,4 +1,4 @@
-.TH MOUNTPOINT 1 "July 2014" "util-linux" "User Commands"
+.TH MOUNTPOINT 1 "August 2019" "util-linux" "User Commands"
 .SH NAME
 mountpoint \- see if a directory or file is a mountpoint
 .SH SYNOPSIS
@@ -27,6 +27,11 @@ directory.
 .TP
 .BR \-q , " \-\-quiet"
 Be quiet - don't print anything.
+.TP
+.B "\-\-nofollow"
+Do not follow symbolic link if it the last elemnt of the
+.I directory
+path.
 .TP
 .BR \-x , " \-\-devno"
 Show the major/minor numbers of the given blockdevice on standard output.

--- a/tests/expected/misc/mountpoint
+++ b/tests/expected/misc/mountpoint
@@ -1,0 +1,9 @@
+default
+./symlink-to-root is a mountpoint
+0
+try --nofollow
+./symlink-to-root is not a mountpoint
+1
+mutually exclusive
+mountpoint: --devno and --nofollow are mutually exclusive
+1

--- a/tests/ts/misc/mountpoint
+++ b/tests/ts/misc/mountpoint
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="mountpoint"
+
+. $TS_TOPDIR/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_MOUNTPOINT"
+
+ln -s / ./symlink-to-root
+
+echo "default" >> $TS_OUTPUT 2>&1
+$TS_CMD_MOUNTPOINT ./symlink-to-root >> $TS_OUTPUT 2>&1
+echo $? >> $TS_OUTPUT 2>&1
+
+echo "try --nofollow" >> $TS_OUTPUT 2>&1
+$TS_CMD_MOUNTPOINT --nofollow ./symlink-to-root >> $TS_OUTPUT 2>&1
+echo $? >> $TS_OUTPUT 2>&1
+
+echo "mutually exclusive" >> $TS_OUTPUT 2>&1
+$TS_CMD_MOUNTPOINT --devno --nofollow / >> $TS_OUTPUT 2>&1
+echo $? >> $TS_OUTPUT 2>&1
+
+rm -f ./symlink-to-root
+
+ts_finalize


### PR DESCRIPTION
The no follow option will allow user to distinct mount points from symbolic
links pointing to them.  Arguably this is pretty pedantic option, mounting a
device or bind mount to a directory via symlink does not have or cause any
issues.

Addresses: https://github.com/karelzak/util-linux/issues/832
Signed-off-by: Sami Kerola <kerolasa@iki.fi>