### PR TITLE
Remove isascii usage

### DIFF
--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -416,7 +416,6 @@ static void do_uncompress(char *path, int outfd, unsigned long offset,
 		curr = next;
 	} while (size);
 }
-#include <utime.h>
 static void change_file_status(char *path, struct cramfs_inode *i)
 {
 	const struct timeval epoch[] = { {0,0}, {0,0} };

--- a/include/carefulputc.h
+++ b/include/carefulputc.h
@@ -10,13 +10,15 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "cctype.h"
+
 static inline int fputc_careful(int c, FILE *fp, const char fail)
 {
 	int ret;
 
 	if (isprint(c) || c == '\a' || c == '\t' || c == '\r' || c == '\n')
 		ret = putc(c, fp);
-	else if (!isascii(c))
+	else if (!c_isascii(c))
 		ret = fprintf(fp, "\\%3o", (unsigned char)c);
 	else {
 		ret = putc(fail, fp);

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -42,6 +42,7 @@
 #include "nls.h"
 #include "pathnames.h"
 #include "c.h"
+#include "cctype.h"
 #include "widechar.h"
 #include "ttyutils.h"
 #include "color-names.h"
@@ -1432,7 +1433,7 @@ static void auto_baud(struct termios *tp)
 	if ((nread = read(STDIN_FILENO, buf, sizeof(buf) - 1)) > 0) {
 		buf[nread] = '\0';
 		for (bp = buf; bp < buf + nread; bp++)
-			if (isascii(*bp) && isdigit(*bp)) {
+			if (c_isascii(*bp) && isdigit(*bp)) {
 				if ((speed = bcode(bp))) {
 					cfsetispeed(tp, speed);
 					cfsetospeed(tp, speed);

--- a/term-utils/wall.c
+++ b/term-utils/wall.c
@@ -68,6 +68,7 @@
 #include "pathnames.h"
 #include "carefulputc.h"
 #include "c.h"
+#include "cctype.h"
 #include "fileutils.h"
 #include "closestream.h"
 
@@ -324,7 +325,7 @@ static void buf_putc_careful(struct buffer *bs, int c)
 	if (isprint(c) || c == '\a' || c == '\t' || c == '\r' || c == '\n') {
 		buf_enlarge(bs, 1);
 		bs->data[bs->used++] = c;
-	} else if (!isascii(c))
+	} else if (!c_isascii(c))
 		buf_printf(bs, "\\%3o", (unsigned char)c);
 	else {
 		char tmp[] = { '^', c ^ 0x40, '\0' };


### PR DESCRIPTION
There is a c_isascii function that can be used.

isascii is deprecated and not available with some libcs like uClibc-ng
where it can be compile time disabled.