### PR TITLE
fstrim shouldn't run inside a container

### DIFF
--- a/sys-utils/fstrim.service.in
+++ b/sys-utils/fstrim.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Discard unused blocks on filesystems from /etc/fstab
 Documentation=man:fstrim(8)
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/sys-utils/fstrim.timer
+++ b/sys-utils/fstrim.timer
@@ -1,6 +1,7 @@
 [Unit]
 Description=Discard unused blocks once a week
 Documentation=man:fstrim
+ConditionVirtualization=!container
 
 [Timer]
 OnCalendar=weekly


### PR DESCRIPTION
Container type implies the following products:
openvz	OpenVZ/Virtuozzo
lxc	Linux container implementation by LXC
lxc-libvirt	Linux container implementation by libvirt
systemd-nspawn	systemd's minimal container implementation, see systemd-nspawn(1)
docker	Docker container manager
podman	Podman container manager
rkt	rkt app container runtime
wsl	Windows Subsystem for Linux

References:
https://www.freedesktop.org/software/systemd/man/systemd.unit.html
https://www.freedesktop.org/software/systemd/man/systemd-detect-virt.html#

Fix: #840

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>