### PR TITLE
Fix -n to -b in German help message

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -11358,7 +11358,7 @@ msgstr "Regel-Optionen:\n"
 
 #: schedutils/chrt.c:146
 msgid " -b, --batch          set policy to SCHED_BATCH\n"
-msgstr " -n, --batch          Richtlinie auf SCHED_BATCH setzen\n"
+msgstr " -b, --batch          Richtlinie auf SCHED_BATCH setzen\n"
 
 #: schedutils/chrt.c:147
 msgid " -d, --deadline       set policy to SCHED_DEADLINE\n"


### PR DESCRIPTION
I just reported the Mistake to Mario, which did the translation, via email. This is the PR to fix the (now) obvious mistake.