### PR TITLE
2019wk33 debian bug fixes and manual references

### DIFF
--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -2635,7 +2635,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Display or manipulate a disk partition table.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	fputs(_(" -L, --color[=<when>]     colorize output (auto, always or never)\n"), out);
+	fprintf(out,
+	      _(" -L, --color[=<when>]     colorize output (%s, %s or %s)\n"), "auto", "always", "never");
 	fprintf(out,
 	        "                            %s\n", USAGE_COLORS_DEFAULT);
 	fputs(_(" -z, --zero               start with zeroed partition table\n"), out);

--- a/disk-utils/fdisk.8
+++ b/disk-utils/fdisk.8
@@ -94,7 +94,7 @@ specified in the format \fI+list\fP (e.g. \fB-o +UUID\fP).
 \fB\-s\fR, \fB\-\-getsz\fR
 Print the size in 512-byte sectors of each given block device.  This option is DEPRECATED
 in favour of
-.BR blockdev (1).
+.BR blockdev (8).
 .TP
 \fB\-t\fR, \fB\-\-type\fR \fItype\fR
 Enable support only for disklabels of the specified \fItype\fP, and disable

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -825,7 +825,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -b, --sector-size <size>      physical and logical sector size\n"), out);
 	fputs(_(" -B, --protect-boot            don't erase bootbits when creating a new label\n"), out);
 	fputs(_(" -c, --compatibility[=<mode>]  mode is 'dos' or 'nondos' (default)\n"), out);
-	fputs(_(" -L, --color[=<when>]          colorize output (auto, always or never)\n"), out);
+	fprintf(out,
+	      _(" -L, --color[=<when>]          colorize output (%s, %s or %s)\n"), "auto", "always", "never");
 	fprintf(out,
 	        "                                 %s\n", USAGE_COLORS_DEFAULT);
 	fputs(_(" -l, --list                    display partitions and exit\n"), out);
@@ -834,8 +835,10 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -u, --units[=<unit>]          display units: 'cylinders' or 'sectors' (default)\n"), out);
 	fputs(_(" -s, --getsz                   display device size in 512-byte sectors [DEPRECATED]\n"), out);
 	fputs(_("     --bytes                   print SIZE in bytes rather than in human readable format\n"), out);
-	fputs(_(" -w, --wipe <mode>             wipe signatures (auto, always or never)\n"), out);
-	fputs(_(" -W, --wipe-partitions <mode>  wipe signatures from new partitions (auto, always or never)\n"), out);
+	fprintf(out,
+	      _(" -w, --wipe <mode>             wipe signatures (%s, %s or %s)\n"), "auto", "always", "never");
+	fprintf(out,
+	      _(" -W, --wipe-partitions <mode>  wipe signatures from new partitions (%s, %s or %s)\n"), "auto", "always", "never");
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_(" -C, --cylinders <number>      specify the number of cylinders\n"), out);

--- a/disk-utils/fsck.8
+++ b/disk-utils/fsck.8
@@ -397,7 +397,7 @@ or
 .BR fsck.ext3 (8)
 or
 .BR e2fsck (8),
-.BR cramfsck (8),
+.BR fsck.cramfs (8),
 .BR fsck.jfs (8),
 .BR fsck.nfs (8),
 .BR fsck.minix (8),

--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -124,24 +124,24 @@ struct entry {
 
 static void __attribute__((__noreturn__)) usage(void)
 {
-	printf(
-		_("usage: %s [-h] [-v] [-b blksize] [-e edition] [-N endian] [-i file] "
-		  "[-n name] dirname outfile\n"
-		  " -v         be verbose\n"
-		  " -E         make all warnings errors "
-		    "(non-zero exit status)\n"
-		  " -b blksize use this blocksize, must equal page size\n"
-		  " -e edition set edition number (part of fsid)\n"
-		  " -N endian  set cramfs endianness (big|little|host), default host\n"
-		  " -i file    insert a file image into the filesystem\n"
-		  " -n name    set name of cramfs filesystem\n"
-		  " -p         pad by %d bytes for boot code\n"
-		  " -s         sort directory entries (old option, ignored)\n"
-		  " -z         make explicit holes\n"
-		  " dirname    root of the filesystem to be compressed\n"
-		  " outfile    output file\n"),
-		program_invocation_short_name, PAD_SIZE);
-
+	fputs(USAGE_HEADER, stdout);
+	printf(_(" %s [-h] [-v] [-b blksize] [-e edition] [-N endian] [-i file] [-n name] dirname outfile\n"),
+		program_invocation_short_name);
+	fputs(USAGE_SEPARATOR, stdout);
+	puts(_("Make compressed ROM file system."));
+	fputs(USAGE_OPTIONS, stdout);
+	puts(_(  " -v             be verbose"));
+	puts(_(  " -E             make all warnings errors (non-zero exit status)"));
+	puts(_(  " -b blksize     use this blocksize, must equal page size"));
+	puts(_(  " -e edition     set edition number (part of fsid)"));
+	printf(_(" -N endian      set cramfs endianness (%s|%s|%s), default %s\n"), "big", "little", "host", "host");
+	puts(_(  " -i file        insert a file image into the filesystem"));
+	puts(_(  " -n name        set name of cramfs filesystem"));
+	printf(_(" -p             pad by %d bytes for boot code\n"), PAD_SIZE);
+	puts(_(  " -s             sort directory entries (old option, ignored)"));
+	puts(_(  " -z             make explicit holes"));
+	puts(_(  " dirname        root of the filesystem to be compressed"));
+	puts(_(  " outfile        output file"));
 	fputs(USAGE_SEPARATOR, stdout);
 	printf(USAGE_HELP_OPTIONS(16));
 	printf(USAGE_MAN_TAIL("mkfs.cramfs(8)"));

--- a/disk-utils/sfdisk.8
+++ b/disk-utils/sfdisk.8
@@ -157,7 +157,7 @@ Renumber the partitions, ordering them by their start offset.
 .BR \-s , " \-\-show\-size " [ \fIdevice ...]
 List the sizes of all or the specified devices in units of 1024 byte size.
 This command is DEPRECATED in favour of
-.BR blockdev (1).
+.BR blockdev (8).
 .TP
 .BR \-T , " \-\-list\-types"
 Print all supported types for the current disk label or the label specified by

--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -1877,7 +1877,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --bytes               print SIZE in bytes rather than in human readable format\n"), out);
 	fputs(_("     --move-data[=<typescript>] move partition data after relocation (requires -N)\n"), out);
 	fputs(_(" -f, --force               disable all consistency checking\n"), out);
-	fputs(_("     --color[=<when>]      colorize output (auto, always or never)\n"), out);
+	fprintf(out,
+	      _("     --color[=<when>]      colorize output (%s, %s or %s)\n"), "auto", "always", "never");
 	fprintf(out,
 	        "                             %s\n", USAGE_COLORS_DEFAULT);
 	fputs(_(" -N, --partno <num>        specify partition number\n"), out);
@@ -1887,8 +1888,10 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -O, --backup-file <path>  override default backup file name\n"), out);
 	fputs(_(" -o, --output <list>       output columns\n"), out);
 	fputs(_(" -q, --quiet               suppress extra info messages\n"), out);
-	fputs(_(" -w, --wipe <mode>         wipe signatures (auto, always or never)\n"), out);
-	fputs(_(" -W, --wipe-partitions <mode>  wipe signatures from new partitions (auto, always or never)\n"), out);
+	fprintf(out,
+	      _(" -w, --wipe <mode>         wipe signatures (%s, %s or %s)\n"), "auto", "always", "never");
+	fprintf(out,
+	      _(" -W, --wipe-partitions <mode>  wipe signatures from new partitions (%s, %s or %s)\n"), "auto", "always", "never");
 	fputs(_(" -X, --label <name>        specify label type (dos, gpt, ...)\n"), out);
 	fputs(_(" -Y, --label-nested <name> specify nested label type (dos, bsd)\n"), out);
 	fputs(USAGE_SEPARATOR, out);

--- a/login-utils/su.1
+++ b/login-utils/su.1
@@ -282,7 +282,7 @@ session  required  pam_lastlog.so nowtmp
 .BR login.defs (5),
 .BR shells (5),
 .BR pam (8),
-.BR runuser (8)
+.BR runuser (1)
 .SH HISTORY
 This \fBsu\fR command was
 derived from coreutils' \fBsu\fR, which was based on an implementation by

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -1133,7 +1133,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -y, --year            show the whole year\n"), out);
 	fputs(_(" -Y, --twelve          show the next twelve months\n"), out);
 	fputs(_(" -w, --week[=<num>]    show US or ISO-8601 week numbers\n"), out);
-	fputs(_("     --color[=<when>]  colorize messages (auto, always or never)\n"), out);
+	fprintf(out,
+	      _("     --color[=<when>]  colorize messages (%s, %s or %s)\n"), "auto", "always", "never");
 	fprintf(out,
 	        "                         %s\n", USAGE_COLORS_DEFAULT);
 

--- a/misc-utils/fincore.1
+++ b/misc-utils/fincore.1
@@ -54,7 +54,7 @@ Masatake YAMATO
 .SH "SEE ALSO"
 .BR mincore (2),
 .BR getpagesize (2),
-.BR getconf (1)
+.BR getconf (1p)
 .SH AVAILABILITY
 The fincore command is part of the util-linux package and is available from
 .UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/

--- a/misc-utils/mcookie.1
+++ b/misc-utils/mcookie.1
@@ -59,7 +59,7 @@ It is assumed that none of the randomness sources will block.
 .I /dev/random
 .SH "SEE ALSO"
 .BR md5sum (1),
-.BR X (1),
+.BR X (7),
 .BR xauth (1),
 .BR rand (3)
 .SH AVAILABILITY

--- a/sys-utils/adjtime_config.5
+++ b/sys-utils/adjtime_config.5
@@ -20,7 +20,7 @@ The Hardware Clock is usually not very accurate.  However, much of its inaccurac
 or loses the same amount of time every day.  This is called systematic drift.  The util hwclock keeps the file /etc/adjtime,
 that keeps some historical information.
 For more details see "\fBThe Adjust Function\fR" and  "\fBThe Adjtime File\fR" sections from
-.BR hwckock (8)
+.BR hwclock (8)
 man page.
 .PP
 

--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -277,7 +277,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -f, --facility <list>       restrict output to defined facilities\n"), out);
 	fputs(_(" -H, --human                 human readable output\n"), out);
 	fputs(_(" -k, --kernel                display kernel messages\n"), out);
-	fputs(_(" -L, --color[=<when>]        colorize messages (auto, always or never)\n"), out);
+	fprintf(out,
+	      _(" -L, --color[=<when>]        colorize messages (%s, %s or %s)\n"), "auto", "always", "never");
 	fprintf(out,
 	        "                               %s\n", USAGE_COLORS_DEFAULT);
 	fputs(_(" -l, --level <list>          restrict output to defined levels\n"), out);

--- a/sys-utils/fstab.5
+++ b/sys-utils/fstab.5
@@ -73,7 +73,7 @@ remote filesystem to be mounted.
 .LP
 For ordinary mounts, it will hold (a link to) a block special
 device node (as created by
-.BR mknod (8))
+.BR mknod (2))
 for the device to be mounted, like `/dev/cdrom' or `/dev/sdb7'.
 For NFS mounts, this field is <host>:<dir>, e.g., `knuth.aeb.nl:/'.
 For filesystems with no storage, any string can be used, and will show up in

--- a/sys-utils/hwclock.8.in
+++ b/sys-utils/hwclock.8.in
@@ -810,7 +810,7 @@ and a precision timepiece, and then calculate the correction manually.
 .PP
 After setting the tick and frequency values, continue to test and refine the
 adjustments until the System Clock keeps good time.  See
-.BR \%adjtimex (8)
+.BR \%adjtimex (2)
 for more information and the example demonstrating manual drift
 calculations.
 .PP
@@ -983,7 +983,7 @@ may try for Hardware Clock access:
 .BR adjtimex (8),
 .BR gettimeofday (2),
 .BR settimeofday (2),
-.BR crontab (1),
+.BR crontab (1p),
 .BR tzset (3)
 .
 .SH AUTHORS

--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -2032,7 +2032,7 @@ utility which can be obtained from
 .TP
 .B user_xattr
 Enable Extended User Attributes.  See the
-.BR attr (5)
+.BR attr (1)
 manual page.
 .TP
 .B acl

--- a/sys-utils/prlimit.1
+++ b/sys-utils/prlimit.1
@@ -104,7 +104,7 @@ processes to unlimited.
 Set both the soft and hard CPU time limit to ten seconds and run 'sort'.
 
 .SH "SEE ALSO"
-.BR ulimit (1),
+.BR ulimit (1p),
 .BR prlimit (2)
 
 .SH NOTES

--- a/sys-utils/renice.1
+++ b/sys-utils/renice.1
@@ -89,7 +89,7 @@ own.  Furthermore, an unprivileged user can only
 the ``nice value'' (i.e., choose a lower priority)
 and such changes are irreversible unless (since Linux 2.6.12)
 the user has a suitable ``nice'' resource limit (see
-.BR ulimit (1)
+.BR ulimit (1p)
 and
 .BR getrlimit (2)).
 

--- a/sys-utils/setarch.8
+++ b/sys-utils/setarch.8
@@ -95,14 +95,14 @@ manual page.  Turns on STICKY_TIMEOUTS.
 .TP
 \fB\-X\fR, \fB\-\-read\-implies\-exec\fR
 If this is set then
-.BR mmap (3)
+.BR mmap (3p)
 PROT_READ will also add the PROT_EXEC bit - as expected by legacy x86
 binaries.  Notice that the ELF loader will automatically set this bit when
 it encounters a legacy binary.  Turns on READ_IMPLIES_EXEC.
 .TP
 \fB\-Z\fR, \fB\-\-mmap\-page\-zero\fR
 SVr4 bug emulation that will set
-.BR mmap (3)
+.BR mmap (3p)
 page zero as read-only.  Use when
 .I program
 depends on this behavior, and the source code is not available to be fixed.

--- a/sys-utils/swapon.8
+++ b/sys-utils/swapon.8
@@ -110,7 +110,7 @@ may also be used to skip non-existing device.
 .BR \-f , " \-\-fixpgsz"
 Reinitialize (exec mkswap) the swap space if its page size does not
 match that of the current running kernel.
-.BR mkswap (2)
+.BR mkswap (8)
 initializes the whole device and does not check for bad blocks.
 .TP
 .BR \-h , " \-\-help"

--- a/term-utils/script.1
+++ b/term-utils/script.1
@@ -116,7 +116,7 @@ Display help text and exit.
 The script ends when the forked shell exits (a
 .I control-D
 for the Bourne shell
-.RB ( sh (1)),
+.RB ( sh (1p)),
 and
 .IR exit ,
 .I logout

--- a/term-utils/setterm.1
+++ b/term-utils/setterm.1
@@ -232,7 +232,7 @@ its power-on state.
 Reset terminal size by assessing maximum row and column.  This is useful
 when actual geometry and kernel terminal driver are not in sync.  Most
 notable use case is with serial consoles, that do not use
-.BR ioctl (3)
+.BR ioctl (3p)
 but just byte streams and breaks.
 .TP
 \fB\-\-reverse\fP [\fBon\fP|\fBoff\fP]

--- a/text-utils/colrm.1
+++ b/text-utils/colrm.1
@@ -60,7 +60,7 @@ Display version information and exit.
 \fB\-h\fR, \fB\-\-help\fR
 Display help text and exit.
 .SH SEE ALSO
-.BR awk (1),
+.BR awk (1p),
 .BR column (1),
 .BR expand (1),
 .BR paste (1)

--- a/text-utils/line.1
+++ b/text-utils/line.1
@@ -11,7 +11,7 @@ copies one line (up to a newline) from standard input to standard output.
 It always prints at least a newline and returns an exit status of 1
 on EOF or read error.
 .SH "SEE ALSO"
-.BR read (1)
+.BR read (1p)
 .SH AVAILABILITY
 The line command is part of the util-linux package and is available from
 https://www.kernel.org/pub/linux/utils/util-linux/.

--- a/text-utils/pg.1
+++ b/text-utils/pg.1
@@ -220,7 +220,7 @@ Determines the terminal type.
 .SH "SEE ALSO"
 .BR cat (1),
 .BR more (1),
-.BR sh (1),
+.BR sh (1p),
 .BR terminfo (5),
 .BR locale (7),
 .BR regex (7),

--- a/text-utils/ul.1
+++ b/text-utils/ul.1
@@ -89,13 +89,13 @@ is set at login time, either by the default terminal type specified in
 or as set during the login process by the user in their
 .B login
 file (see
-.BR setenv (1)).
+.BR setenv (3)).
 .SH SEE ALSO
 .BR colcrt (1),
 .BR login (1),
 .BR man (1),
 .BR nroff (1),
-.BR setenv (1),
+.BR setenv (3),
 .BR terminfo (5)
 .SH BUGS
 .B nroff


### PR DESCRIPTION
I found couple easy to fix debian bugs to fix that first two commits address. The bug 929677 aka runuser reference fix made me wonder if there are more broken man page references, so I grep through  util-linux and found couple.

As mentioned in commit message the process to find broken references is not reproducible. A grep + what ever happens to be installed on a developer laptop + cross reference by googling for man pages that aren't installed is pretty hard scripting exercise. If someone wants to automate that: good luck. My thinking is that these references do not need constant monitoring, sweeping through them manually very occasionally is good enough.