### PR TITLE
unshare: add --map-current-user option

### DIFF
--- a/sys-utils/unshare.1
+++ b/sys-utils/unshare.1
@@ -159,7 +159,12 @@ conveniently gain capabilities needed to manage various aspects of the newly cre
 namespaces (such as configuring interfaces in the network namespace or mounting filesystems in
 the mount namespace) even when run unprivileged.  As a mere convenience feature, it does not support
 more sophisticated use cases, such as mapping multiple ranges of UIDs and GIDs.
-This option implies \fB--setgroups=deny\fR.
+This option implies \fB--setgroups=deny\fR and \fB--user\fR.
+.TP
+.BR \-c , " \-\-map\-current\-user"
+Run the program only after the current effective user and group IDs have been mapped to
+the same UID and GID in the newly created user namespace. This option implies
+\fB--setgroups=deny\fR and \fB--user\fR.
 .TP
 .BR "\-\-propagation private" | shared | slave | unchanged
 Recursively set the mount propagation flag in the new mount namespace.  The default


### PR DESCRIPTION
Add the --map-current-user option to unshare. This option maps the
current effective UID and GID in the new user namespace so that the
inner and outer credentials match.

Signed-off-by: James Peach <jpeach@apache.org>