### PR TITLE
disk-utils: docs: fix sfdisk(8) man page typo

### DIFF
--- a/disk-utils/sfdisk.8
+++ b/disk-utils/sfdisk.8
@@ -417,7 +417,7 @@ value is
 .I bootable
 is specified as [\fB*\fR|\fB-\fR], with as default not-bootable.  The
 value of this field is irrelevant for Linux - when Linux runs it has
-been booted already - but ir might play a role for certain boot
+been booted already - but it might play a role for certain boot
 loaders and for other operating systems.
 .RE
 


### PR DESCRIPTION
 * `disk-utils/sfdisk.8`: fix typo: "ir" -> "it"