### PR TITLE
bash-completion: Match non-canonical device names or files

### DIFF
--- a/bash-completion/addpart
+++ b/bash-completion/addpart
@@ -6,6 +6,7 @@ _addpart_module()
 	case $COMP_CWORD in
 		1)
 			OPTS="--help --version $(lsblk -pnro name)"
+			compopt -o bashdefault -o default
 			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
 			;;
 		2)

--- a/bash-completion/blkdiscard
+++ b/bash-completion/blkdiscard
@@ -29,6 +29,7 @@ _blkdiscard_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/blkid
+++ b/bash-completion/blkid
@@ -93,6 +93,7 @@ _blkid_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/blkzone
+++ b/bash-completion/blkzone
@@ -46,6 +46,7 @@ _blkzone_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/blockdev
+++ b/bash-completion/blockdev
@@ -38,6 +38,7 @@ _blockdev_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
 	return 0
 }

--- a/bash-completion/cfdisk
+++ b/bash-completion/cfdisk
@@ -23,6 +23,7 @@ _cfdisk_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/delpart
+++ b/bash-completion/delpart
@@ -12,6 +12,7 @@ _delpart_module()
 	case $COMP_CWORD in
 		1)
 			OPTS="--help --version $(lsblk -pnro name)"
+			compopt -o bashdefault -o default
 			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
 			;;
 		2)

--- a/bash-completion/eject
+++ b/bash-completion/eject
@@ -58,6 +58,7 @@ _eject_module()
 			IFS=$OLD_IFS
 		fi
 	done)"
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$DEVS" $cur) )
 	return 0
 }

--- a/bash-completion/fdisk
+++ b/bash-completion/fdisk
@@ -91,6 +91,7 @@ _fdisk_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/fsck
+++ b/bash-completion/fsck
@@ -32,6 +32,7 @@ _fsck_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/fsck
+++ b/bash-completion/fsck
@@ -32,8 +32,7 @@ _fsck_module()
 			return 0
 			;;
 	esac
-	COMPREPLY=( $(compgen -W "$(find -L /dev/ -path /dev/fd -prune \
-		-o -type b -print 2>/dev/null)" -- $cur) )
+	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }
 complete -F _fsck_module fsck

--- a/bash-completion/fsck.cramfs
+++ b/bash-completion/fsck.cramfs
@@ -25,6 +25,7 @@ _fsck.cramfs_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/fsck.cramfs
+++ b/bash-completion/fsck.cramfs
@@ -25,9 +25,7 @@ _fsck.cramfs_module()
 			return 0
 			;;
 	esac
-	local IFS=$'\n'
-	compopt -o filenames
-	COMPREPLY=( $(compgen -f -- $cur) )
+	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }
 complete -F _fsck.cramfs_module fsck.cramfs

--- a/bash-completion/fsck.minix
+++ b/bash-completion/fsck.minix
@@ -10,6 +10,7 @@ _fsck.minix_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/lsblk
+++ b/bash-completion/lsblk
@@ -85,6 +85,7 @@ _lsblk_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$($1 -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/mkfs
+++ b/bash-completion/mkfs
@@ -21,6 +21,7 @@ _mkfs_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/mkfs
+++ b/bash-completion/mkfs
@@ -21,7 +21,7 @@ _mkfs_module()
 			return 0
 			;;
 	esac
-	COMPREPLY=( $(compgen -W "$(lsblk -pnro name) /path/to/file" -- $cur) )
+	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }
 complete -F _mkfs_module mkfs

--- a/bash-completion/mkfs.bfs
+++ b/bash-completion/mkfs.bfs
@@ -24,6 +24,7 @@ _mkfs.bfs_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/mkfs.bfs
+++ b/bash-completion/mkfs.bfs
@@ -24,7 +24,7 @@ _mkfs.bfs_module()
 			return 0
 			;;
 	esac
-	COMPREPLY=( $(compgen -W "$(lsblk -pnro name) /path/to/file" -- $cur) )
+	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }
 complete -F _mkfs.bfs_module mkfs.bfs

--- a/bash-completion/mkfs.cramfs
+++ b/bash-completion/mkfs.cramfs
@@ -36,6 +36,7 @@ _mkfs.cramfs_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/mkfs.cramfs
+++ b/bash-completion/mkfs.cramfs
@@ -36,9 +36,7 @@ _mkfs.cramfs_module()
 			return 0
 			;;
 	esac
-	local IFS=$'\n'
-	compopt -o filenames
-	COMPREPLY=( $(compgen -f -- $cur) )
+	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }
 complete -F _mkfs.cramfs_module mkfs.cramfs

--- a/bash-completion/mkfs.minix
+++ b/bash-completion/mkfs.minix
@@ -26,6 +26,7 @@ _mkfs.minix_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/mkswap
+++ b/bash-completion/mkswap
@@ -32,9 +32,7 @@ _mkswap_module()
 			return 0
 			;;
 	esac
-	local IFS=$'\n'
-	compopt -o filenames
-	COMPREPLY=( $(compgen -f -- $cur) )
+	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }
 complete -F _mkswap_module mkswap

--- a/bash-completion/mkswap
+++ b/bash-completion/mkswap
@@ -32,6 +32,7 @@ _mkswap_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/partx
+++ b/bash-completion/partx
@@ -59,6 +59,7 @@ _partx_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/resizepart
+++ b/bash-completion/resizepart
@@ -12,6 +12,7 @@ _resizepart_module()
 	case $COMP_CWORD in
 		1)
 			OPTS="--help --version $(lsblk -pnro name)"
+			compopt -o bashdefault -o default
 			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
 			;;
 		2)

--- a/bash-completion/sfdisk
+++ b/bash-completion/sfdisk
@@ -6,6 +6,7 @@ _sfdisk_module()
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 	case $prev in
 		'-d'|'--dump'|'-J'|'--json'|'-l'|'--list'|'-F'|'--list-free'|'-r'|'--reorder'|'-s'|'--show-size'|'-V'|'--verify'|'-A'|'--activate'|'--delete')
+			compopt -o bashdefault -o default
 			COMPREPLY=( $(compgen -W "$(lsblk -dpnro name)" -- $cur) )
 			return 0
 			;;
@@ -90,6 +91,7 @@ _sfdisk_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }

--- a/bash-completion/wipefs
+++ b/bash-completion/wipefs
@@ -54,6 +54,7 @@ _wipefs_module()
 			return 0
 			;;
 	esac
+	compopt -o bashdefault -o default
 	COMPREPLY=( $(compgen -W "$(lsblk -pnro name)" -- $cur) )
 	return 0
 }


### PR DESCRIPTION
This pull request is intended to address #842 as outlined in https://github.com/karelzak/util-linux/issues/842#issuecomment-523450243.

It makes one change to the requested behavior:  If it is unable to complete any of the canonical device names, it falls back to the default Bash matching for all files immediately, rather than special-casing `/dev/disk`.  The reason is that completing all links under `/dev/disk` immediately causes scrolling/paging or a "Display all X possibilities? (y or n)" prompt depending on how many disks are connected, which makes the Bash default of completing one level at a time seem preferable.  The default completion lists `by-id  by-label  by-partlabel  by-partuuid  by-path  by-uuid` when completing `/dev/disk/` then all symlinks in the directory when completing `/dev/disk/by-id/` et al.

This pull request has one drawback worth considering specifically:  It completes all files for commands which only operate on block devices.  After a bit of work implementing generic block device + symlink completion, I realized that a proper implementation would require un-escaping the last partial argument, searching, then escaping the results, ideally handling tilde and variable expansion/completion, as done by [_get_comp_words_by_ref] and [_filedir] in the [bash-completion project], which is non-trivial.  I felt the risks of poorly implemented completion, or the current under-completion, were worse than over-completion.  However, this was done as a separate commit so that if you disagree it is easy to remove and leave the current behavior as-is (or add a commit to special-case `/dev/disk/`).  Let me know what you think.

Thanks for considering,
Kevin

Fixes: #842

[_filedir]: https://github.com/scop/bash-completion/blob/2.9/bash_completion#L552
[_get_comp_words_by_ref]: https://github.com/scop/bash-completion/blob/2.9/bash_completion#L365
[bash-completion project]: https://github.com/scop/bash-completion