### PR TITLE
[tests] don't use `nproc --all` for getting cpu number

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,7 +32,7 @@ function num_cpus()
 	local num
 
 	# coreutils
-	if num=$(nproc --all 2>/dev/null); then
+	if num=$(nproc 2>/dev/null); then
 		:
 	# BSD, OSX
 	elif num=$(sysctl -n hw.ncpu 2>/dev/null); then


### PR DESCRIPTION
Don't use `nproc --all` for getting cpu number. For example below, sparc64 is reporting 128 as a total, but only 32 is online. So, use only online cpus for tests parallel run.

```
$ nproc
32

$ nproc --all
128

$ lscpu
Architecture:        sparc64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Big Endian
CPU(s):              32
On-line CPU(s) list: 0-31
Thread(s) per core:  8
Core(s) per socket:  4
Socket(s):           1
Model name:          UltraSparc T5 (Niagara5)
Flags:               sun4v
```
Signed-off-by: Anatoly Pugachev <matorola@gmail.com>