### PR TITLE
po/update-potfiles: fallback to `find` when `git ls-files` doesn't work

### DIFF
--- a/po/update-potfiles
+++ b/po/update-potfiles
@@ -15,10 +15,12 @@ fi
 # find all git-tracked files
 source_files=$(git ls-files . 2>/dev/null)
 if [ $? -ne 0 ] || [ -z "$source_files" ]; then
-	echo "$0: warning: update-potfiles requires git" >&2
 	# we still go through the rest of this script to provide at least an empty
 	# list or remove non-existing (deleted) files
 	source_files=$(cat po/POTFILES.in 2>/dev/null)
+fi
+if [ $? -ne 0 ] || [ -z "$source_files" ]; then
+	source_files=$(find . -type f -printf "%P\\n" 2>/dev/null)
 fi
 
 # apply include/exclude patterns


### PR DESCRIPTION
It allows to run po/update-potfiles not only in tarballs and git repositories, but in git snapshots as well.