### PR TITLE
lsblk: update man description of -f / --fs for current columns

### DIFF
--- a/misc-utils/lsblk.8
+++ b/misc-utils/lsblk.8
@@ -73,7 +73,7 @@ The filter is applied to the top-level devices only. This may be confusing for
 .TP
 .BR \-f , " \-\-fs"
 Output info about filesystems.  This option is equivalent to
-.BR -o\ NAME,FSTYPE,LABEL,UUID,MOUNTPOINT .
+.BR -o\ NAME,FSTYPE,LABEL,UUID,FSAVAIL,FSUSE%,MOUNTPOINT .
 The authoritative information about filesystems and raids is provided by the
 .BR blkid (8)
 command.


### PR DESCRIPTION
The docs (man page) currently do not list correct columns for the -f/--fs option. This fixes the doc to reflect the source.

(Found in - https://github.com/rhinstaller/anaconda/pull/2172 where --fs was replaced with -o (...) and the columns did not match.)