### PR TITLE
tests: fixes blkid/md-raidX-whole on Sparc

### DIFF
--- a/tests/expected/blkid/md-raid0-whole
+++ b/tests/expected/blkid/md-raid0-whole
@@ -6,8 +6,6 @@ Welcome to fdisk <removed>.
 Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command.
 
-Device does not contain a recognized partition table.
-Created a new <removed>.
 
 Command (m for help): Partition type
    p   primary (0 primary, 0 extended, 4 free)

--- a/tests/expected/blkid/md-raid1-whole
+++ b/tests/expected/blkid/md-raid1-whole
@@ -6,8 +6,6 @@ Welcome to fdisk <removed>.
 Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command.
 
-Device does not contain a recognized partition table.
-Created a new <removed>.
 
 Command (m for help): Partition type
    p   primary (0 primary, 0 extended, 4 free)

--- a/tests/ts/blkid/md-raid0-whole
+++ b/tests/ts/blkid/md-raid0-whole
@@ -48,6 +48,13 @@ ts_log "Create RAID device"
 mdadm -q --create ${MD_DEVICE} --metadata=0.90 --chunk=64 --level=0 \
 	    --raid-devices=2 ${DEVICE1} ${DEVICE2} >> $TS_OUTPUT 2>> $TS_ERRLOG
 
+# create dos partition table
+$TS_CMD_FDISK ${MD_DEVICE} &>/dev/null <<EOF
+o
+w
+q
+EOF
+
 ts_log "Create partitions on RAID device"
 $TS_CMD_FDISK ${MD_DEVICE} >> $TS_OUTPUT 2>> $TS_ERRLOG <<EOF
 n

--- a/tests/ts/blkid/md-raid1-whole
+++ b/tests/ts/blkid/md-raid1-whole
@@ -51,6 +51,13 @@ mdadm -q --create ${MD_DEVICE} --metadata=0.90 --chunk=64 --level=1 \
 	    --raid-devices=2 ${DEVICE1} ${DEVICE2} >> $TS_OUTPUT 2>> $TS_ERRLOG
 udevadm settle
 
+# create dos partition table
+$TS_CMD_FDISK ${MD_DEVICE} &>/dev/null <<EOF
+o
+w
+q
+EOF
+
 ts_log "Create partitions on RAID device"
 $TS_CMD_FDISK ${MD_DEVICE} >> $TS_OUTPUT 2>> $TS_ERRLOG <<EOF
 n


### PR DESCRIPTION
Since sparc is using 'sun' partition table by default, make test not to assume that disk has 'dos' partition table, write/init 'dos' partition table on disk, before processing any further.

Signed-off-by: Anatoly Pugachev <matorola@gmail.com>


before:

```
util-linux/tests# ./run.sh blkid
...
           ... OK (all 7 sub-tests PASSED)
        blkid: mbr-wholedisk                  ... SKIPPED (cannot remove scsi_debug module (rmmod))
        blkid: MD raid0 (whole-disks)         ... FAILED (blkid/md-raid0-whole)
        blkid: MD raid1 (last partition)      ... SKIPPED (cannot remove scsi_debug module (rmmod))
        blkid: MD raid1 (whole-disks)         ... FAILED (blkid/md-raid1-whole)

---------------------------------------------------------------------
  2 tests of 8 FAILED
---------------------------------------------------------------------
```

after patch:
```
           ... OK (all 7 sub-tests PASSED)
        blkid: mbr-wholedisk                  ... SKIPPED (cannot remove scsi_debug module (rmmod))
        blkid: MD raid0 (whole-disks)         ... OK
        blkid: MD raid1 (last partition)      ... SKIPPED (cannot remove scsi_debug module (rmmod))
        blkid: MD raid1 (whole-disks)         ... OK

---------------------------------------------------------------------
  All 8 tests PASSED
---------------------------------------------------------------------
```
