### PR TITLE
blkid: open device in nonblock mode.

### DIFF
--- a/libblkid/src/verify.c
+++ b/libblkid/src/verify.c
@@ -126,7 +126,7 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 		}
 	}
 
-	fd = open(dev->bid_name, O_RDONLY|O_CLOEXEC);
+	fd = open(dev->bid_name, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
 	if (fd < 0) {
 		DBG(PROBE, ul_debug("blkid_verify: error %m (%d) while "
 					"opening %s", errno,

--- a/misc-utils/blkid.c
+++ b/misc-utils/blkid.c
@@ -499,7 +499,7 @@ static int lowprobe_device(blkid_probe pr, const char *devname,
 	int rc = 0;
 	static int first = 1;
 
-	fd = open(devname, O_RDONLY|O_CLOEXEC);
+	fd = open(devname, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
 	if (fd < 0) {
 		warn(_("error: %s"), devname);
 		return BLKID_EXIT_NOTFOUND;


### PR DESCRIPTION
When autoclose is set (kernel default but many distributions reverse the
setting) opening a CD-rom device causes the tray to close.

The function of blkid is to report the current state of the device and
not to change it. Hence it should use O_NONBLOCK when opening the
device to avoid closing a CD-rom tray.

blkid is used liberally in scripts so it can potentially interfere with
the user operating the CD-rom hardware.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>