### PR TITLE
kill: use pidfd system calls to implement --timeout option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -497,6 +497,8 @@ AC_CHECK_FUNCS([ \
 	nanosleep \
 	ntp_gettime \
 	personality \
+	pidfd_open \
+	pidfd_send_signal \
 	posix_fadvise \
 	prctl \
 	qsort_r \
@@ -538,6 +540,9 @@ UL_CHECK_SYSCALL([setns])
 AS_IF([test "x$ul_cv_syscall_setns" = xno], [
    have_setns_syscall="no"
 ])
+
+UL_CHECK_SYSCALL([pidfd_open])
+UL_CHECK_SYSCALL([pidfd_send_signal])
 
 AC_CHECK_FUNCS([isnan], [],
 	[AC_CHECK_LIB([m], [isnan], [MATH_LIBS="-lm"])]

--- a/include/pidfd-utils.h
+++ b/include/pidfd-utils.h
@@ -1,0 +1,23 @@
+#ifndef UTIL_LINUX_PIDFD_UTILS
+#define UTIL_LINUX_PIDFD_UTILS
+
+#if defined (__linux__)
+# include <sys/types.h>
+# include <sys/syscall.h>
+# ifndef HAVE_PIDFD_OPEN
+static inline int pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
+				    unsigned int flags)
+{
+	return syscall(SYS_pidfd_send_signal, pidfd, sig, info, flags);
+}
+# endif
+# ifndef HAVE_PIDFD_SEND_SIGNAL
+static inline int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(SYS_pidfd_open, pid, flags);
+}
+# endif
+# define UL_HAVE_PIDFD 1
+#endif
+
+#endif

--- a/m4/ul.m4
+++ b/m4/ul.m4
@@ -105,8 +105,8 @@ AC_DEFUN([UL_CHECK_SYSCALL], [
       [syscall=SYS_$1],
       [dnl Our libc failed use, so see if we can get the kernel
       dnl headers to play ball ...
-      _UL_SYSCALL_CHECK_DECL([_NR_$1],
-	[syscall=_NR_$1],
+      _UL_SYSCALL_CHECK_DECL([__NR_$1],
+	[syscall=__NR_$1],
 	[
 	  syscall=no
 	  if test "x$linux_os" = xyes; then

--- a/misc-utils/kill.1
+++ b/misc-utils/kill.1
@@ -1,7 +1,7 @@
 .\" Copyright 1994 Salvatore Valente (svalente@mit.edu)
 .\" Copyright 1992 Rickard E. Faith (faith@cs.unc.edu)
 .\" May be distributed under the GNU General Public License
-.TH KILL 1 "July 2014" "util-linux" "User Commands"
+.TH KILL 1 "November 2019" "util-linux" "User Commands"
 .SH NAME
 kill \- terminate a process
 .SH SYNOPSIS
@@ -11,6 +11,7 @@ kill \- terminate a process
 .RB [ \-q
 .IR value ]
 .RB [ \-a ]
+\fR[\fB\-\-timeout \fImilliseconds signal\fR]
 .RB [ \-\- ]
 .IR pid | name ...
 .br
@@ -120,7 +121,26 @@ then it can obtain this data via the
 field of the
 .I siginfo_t
 structure.
-
+.TP
+\fB\-\-timeout\fR \fImilliseconds signal\fR
+Send a signal defined the usual way to a process.
+.B \-\-timeout
+will make
+.B kill
+to wait for a period defined in
+.I milliseconds
+before sending follow-up
+.I signal
+to process.  When timeout is speficified multiple times to a list of
+timeouts and signals that are sent sequentially.  The
+.B \-\-timeout
+option can be combined with
+.B \-\-queue
+option.
+.IP
+Example.  Send signal that does nothing twice, and terminate cat(1).
+.br
+kill --timeout 1000 0 --timeout 1000 TERM --verbose -s 0 cat
 .SH NOTES
 Although it is possible to specify the TID (thread ID, see
 .BR gettid (2))


### PR DESCRIPTION
It is fairly common case for various system admin script to run kill, wait a
bit and send another signal.  This can be used for example when trying to first
gently ask for a program to terminate before sending a SIGKILL.  Another use
case is nginx that needs multiple signals to perform upgrade.  In short having
a way to send another signal after a bit makes scripting nicer and less racy.

Signed-off-by: Sami Kerola <kerolasa@iki.fi>