### PR TITLE
Make manpage of su clearer

### DIFF
--- a/login-utils/su.1
+++ b/login-utils/su.1
@@ -16,9 +16,9 @@ defaults to running an interactive shell as
 .IR root .
 When
 .IR user
-is specified, an additional
-.IR argument
-can be supplied, in which case it is passed to the shell.
+is specified, additional
+.IR argument s
+can be supplied, in which case they are passed to the shell.
 .PP
 For backward compatibility,
 .B su

--- a/login-utils/su.1
+++ b/login-utils/su.1
@@ -8,10 +8,17 @@ su \- run a command with substitute user and group ID
 .B su
 allows to run commands with a substitute user and group ID.
 .PP
-When called without arguments,
+When called with no
+.IR user
+specified,
 .B su
 defaults to running an interactive shell as
 .IR root .
+When
+.IR user
+is specified, an additional
+.IR argument
+can be supplied, in which case it is passed to the shell.
 .PP
 For backward compatibility,
 .B su


### PR DESCRIPTION
In the manpage of `su`, the synopsis implies the existence of arguments `user` and `argument`(s). However, how they are handled isn't noted at all.

I made a slight change to `su.1` to make it clearer.