### PR TITLE
travis: run distcheck rather than dist when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ compiler:
 env:
   - MAKE_CHECK="nonroot"
   - MAKE_CHECK="root"
-  - MAKE_CHECK="dist"
+  - MAKE_CHECK="distcheck"
 
 matrix:
   include:


### PR DESCRIPTION
The distcheck will perform out of tree build.  These tend to break when new
files are added and forgot to include in any of the Makefile.am target lists.

Signed-off-by: Sami Kerola <kerolasa@iki.fi>