### PR TITLE
unshare: fix --map-current-user short option (-c)

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -349,7 +349,7 @@ int main(int argc, char *argv[])
 	textdomain(PACKAGE);
 	close_stdout_atexit();
 
-	while ((c = getopt_long(argc, argv, "+fhVmuinpCUrR:w:S:G:", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "+fhVmuinpCUrR:w:S:G:c", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'f':
 			forkit = 1;


### PR DESCRIPTION
'c' was missing from the optstring, causing the error:

    $ unshare --user -c
    unshare: invalid option -- 'c'
    Try 'unshare --help' for more information.

Fixes: 4175f29e62 ("unshare: add --map-current-user option")