### PR TITLE
lib/pty: Ensure waitpid is repeated after EINTR

### DIFF
--- a/lib/pty-session.c
+++ b/lib/pty-session.c
@@ -404,8 +404,9 @@ void ul_pty_wait_for_child(struct ul_pty *pty)
 							pty->callback_data,
 							pty->child, status);
 				ul_pty_set_child(pty, (pid_t) -1);
-			} else
+			} else if (errno != EINTR) {
 				break;
+			}
 		}
 	} else {
 		/* final wait */


### PR DESCRIPTION
The waitpid syscall may return EINTR. In that case, the waitpid call
should be repeated to ensure that children are reaped.

I have seen a case of script not reaping its child. While I have not
been able to verify that this caused the issue, it does seem like a
likely cause for the problem.

Signed-off-by: Benjamin Berg <bberg@redhat.com>