### PR TITLE
Fix documentation in libblkid header

### DIFF
--- a/libblkid/src/blkid.h.in
+++ b/libblkid/src/blkid.h.in
@@ -137,8 +137,10 @@ typedef struct blkid_struct_dev_iterate *blkid_dev_iterate;
 # endif
 #endif
 
-/* cache.c */
+/* init.c */
 extern void blkid_init_debug(int mask);
+
+/* cache.c */
 extern void blkid_put_cache(blkid_cache cache);
 extern int blkid_get_cache(blkid_cache *cache, const char *filename);
 extern void blkid_gc_cache(blkid_cache cache);


### PR DESCRIPTION
I'm currently writing some language bindings for libblkid and it took me a little bit to find the source of `blkid_init_debug` so I wanted to submit this for anyone doing something similar at a later point.