### PR TITLE
Use sched_setscheduler system call directly in chrt

### DIFF
--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -347,7 +347,10 @@ static int set_sched_one_by_setscheduler(struct chrt_ctl *ctl, pid_t pid)
 	if (ctl->reset_on_fork)
 		policy |= SCHED_RESET_ON_FORK;
 # endif
-	return sched_setscheduler(pid, policy, &sp);
+	/* musl libc returns ENOSYS for its sched_setscheduler library function,
+	   because the sched_setscheduler Linux kernel system call does not conform
+	   to Posix; so we use the system call directly */
+	return syscall(SYS_sched_setscheduler, pid, policy, &sp);
 }
 
 


### PR DESCRIPTION
musl libc does not support the sched_setscheduler library function because the underlying Linux system call does not confirm to Posix; this patch makes chrt use the system call directly so it works in a musl libc environment