### PR TITLE
hexdump: fix hang when trying to skip 0x8000000 bytes

### DIFF
--- a/text-utils/hexdump-display.c
+++ b/text-utils/hexdump-display.c
@@ -447,6 +447,10 @@ doskip(const char *fname, int statok, struct hexdump *hex)
 			return;
 		}
 	}
+	/* When buffering is set, glibc fseek() first calls lseek(), and then it calls
+	   read() to read the whole range it just skipped. Which can be quite a lot e.g.
+	   if a user tries to skip half a terabyte of data on block device. */
+	setbuf(stdin, 0);
 	/* sbuf may be undefined here - do not test it */
 	if (fseek(stdin, hex->skip, SEEK_SET))
 	        err(EXIT_FAILURE, "%s", fname);


### PR DESCRIPTION
When glibc fseek() is called with SEEK_SET argument, it does two things, in
this order:

1. Calls lseek() with SEEK_SET
2. Calls read() over the whole range it just skipped

This means that if you call e.g. `hexdump -s 0x8000000 /dev/sda1`,
hexdump gonna hang because fseek() calls goes reading half a terabyte of
data.

Fix this by disabling buffering for files.

See also: https://sourceware.org/ml/libc-help/2020-01/msg00047.html