### PR TITLE
various: fix more lgtm scan warnings

### DIFF
--- a/lib/mbsalign.c
+++ b/lib/mbsalign.c
@@ -349,9 +349,6 @@ wc_truncate (wchar_t *wc, size_t width)
   return cells;
 }
 
-/* FIXME: move this function to gnulib as it's missing on:
-   OpenBSD 3.8, IRIX 5.3, Solaris 2.5.1, mingw, BeOS  */
-
 static int
 rpl_wcswidth (const wchar_t *s, size_t n)
 {
@@ -413,8 +410,6 @@ done:
 static char*
 mbs_align_pad (char *dest, const char* dest_end, size_t n_spaces, int padchar)
 {
-  /* FIXME: Should we pad with "figure space" (\u2007)
-     if non ascii data present?  */
   for (/* nothing */; n_spaces && (dest < dest_end); n_spaces--)
     *dest++ = padchar;
   *dest = '\0';

--- a/libblkid/src/read.c
+++ b/libblkid/src/read.c
@@ -277,26 +277,6 @@ static int parse_token(char **name, char **value, char **cp)
 }
 
 /*
- * Extract a tag of the form <NAME>value</NAME> from the line.
- */
-/*
-static int parse_xml(char **name, char **value, char **cp)
-{
-	char *end;
-
-	if (!name || !value || !cp)
-		return -BLKID_ERR_PARAM;
-
-	*name = strip_line(*cp);
-
-	if ((*name)[0] != '<' || (*name)[1] == '/')
-		return 0;
-
-	FIXME: finish this.
-}
-*/
-
-/*
  * Extract a tag from the line.
  *
  * Return 1 if a valid tag was found.
@@ -312,8 +292,7 @@ static int parse_tag(blkid_cache cache, blkid_dev dev, char **cp)
 	if (!cache || !dev)
 		return -BLKID_ERR_PARAM;
 
-	if ((ret = parse_token(&name, &value, cp)) <= 0 /* &&
-	    (ret = parse_xml(&name, &value, cp)) <= 0 */)
+	if ((ret = parse_token(&name, &value, cp)) <= 0)
 		return ret;
 
 	DBG(READ, ul_debug("tag: %s=\"%s\"", name, value));

--- a/libsmartcols/src/calculate.c
+++ b/libsmartcols/src/calculate.c
@@ -362,7 +362,7 @@ int __scols_calculate(struct libscols_table *tb, struct libscols_buffer *buf)
 				continue;
 
 			/* nothing to truncate */
-			if (cl->width == 0 || width == 0)
+			if (cl->width == 0)
 				continue;
 
 			trunc_flag = scols_column_is_trunc(cl)

--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -775,13 +775,13 @@ static void syslog_rfc5424_header(struct logger_ctl *const ctl)
 
 	if (ctl->rfc5424_time) {
 		struct timeval tv;
-		struct tm *tm;
+		struct tm tm;
 
 		logger_gettimeofday(&tv, NULL);
-		if ((tm = localtime(&tv.tv_sec)) != NULL) {
+		if (localtime_r(&tv.tv_sec, &tm) != NULL) {
 			char fmt[64];
 			const size_t i = strftime(fmt, sizeof(fmt),
-						  "%Y-%m-%dT%H:%M:%S.%%06u%z ", tm);
+						  "%Y-%m-%dT%H:%M:%S.%%06u%z ", &tm);
 			/* patch TZ info to comply with RFC3339 (we left SP at end) */
 			fmt[i - 1] = fmt[i - 2];
 			fmt[i - 2] = fmt[i - 3];

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -199,9 +199,10 @@ static int get_basetimes(struct rtcwake_control *ctl, int fd)
 		printf("\tdelta   = %ld\n", ctl->sys_time - ctl->rtc_time);
 		printf("\ttzone   = %ld\n", timezone);
 		printf("\ttzname  = %s\n", tzname[daylight]);
-		gmtime_r(&ctl->rtc_time, &tm);
+		gmtime_r(&ctl->sys_time, &tm);
 		printf("\tsystime = %ld, (UTC) %s",
-				(long) ctl->sys_time, asctime_r(gmtime(&ctl->sys_time), s));
+				(long) ctl->sys_time, asctime_r(&tm, s));
+		gmtime_r(&ctl->rtc_time, &tm);
 		printf("\trtctime = %ld, (UTC) %s",
 				(long) ctl->rtc_time, asctime_r(&tm, s));
 	}

--- a/tests/expected/fdisk/bsd_0_64.BE
+++ b/tests/expected/fdisk/bsd_0_64.BE
@@ -204,10 +204,10 @@ Be careful before using the write command.
 Command (m for help): Entering nested BSD disklabel.
 
 Command (m for help): 
- 0  unused           5  4.1BSD           9  4.4LFS           d  boot           
- 1  swap             6  Eighth Edition   a  unknown          e  ADOS           
- 2  Version 6        7  4.2BSD           b  HPFS             f  HFS            
- 3  Version 7        8  MS-DOS           c  ISO-9660        10  AdvFS          
- 4  System V       
+00 unused           05 4.1BSD           09 4.4LFS           0d boot           
+01 swap             06 Eighth Edition   0a unknown          0e ADOS           
+02 Version 6        07 4.2BSD           0b HPFS             0f HFS            
+03 Version 7        08 MS-DOS           0c ISO-9660         10 AdvFS          
+04 System V       
 
 Command (m for help): 

--- a/tests/expected/fdisk/bsd_0_64.LE
+++ b/tests/expected/fdisk/bsd_0_64.LE
@@ -204,10 +204,10 @@ Be careful before using the write command.
 Command (m for help): Entering nested BSD disklabel.
 
 Command (m for help): 
- 0  unused           5  4.1BSD           9  4.4LFS           d  boot           
- 1  swap             6  Eighth Edition   a  unknown          e  ADOS           
- 2  Version 6        7  4.2BSD           b  HPFS             f  HFS            
- 3  Version 7        8  MS-DOS           c  ISO-9660        10  AdvFS          
- 4  System V       
+00 unused           05 4.1BSD           09 4.4LFS           0d boot           
+01 swap             06 Eighth Edition   0a unknown          0e ADOS           
+02 Version 6        07 4.2BSD           0b HPFS             0f HFS            
+03 Version 7        08 MS-DOS           0c ISO-9660         10 AdvFS          
+04 System V       
 
 Command (m for help): 

--- a/tests/expected/fdisk/bsd_0_64_alpha.LE
+++ b/tests/expected/fdisk/bsd_0_64_alpha.LE
@@ -208,10 +208,10 @@ Be careful before using the write command.
 Command (m for help): Entering nested BSD disklabel.
 
 Command (m for help): 
- 0  unused           5  4.1BSD           9  4.4LFS           d  boot           
- 1  swap             6  Eighth Edition   a  unknown          e  ADOS           
- 2  Version 6        7  4.2BSD           b  HPFS             f  HFS            
- 3  Version 7        8  ext2             c  ISO-9660        10  AdvFS          
- 4  System V       
+00 unused           05 4.1BSD           09 4.4LFS           0d boot           
+01 swap             06 Eighth Edition   0a unknown          0e ADOS           
+02 Version 6        07 4.2BSD           0b HPFS             0f HFS            
+03 Version 7        08 MS-DOS           0c ISO-9660         10 AdvFS          
+04 System V       
 
 Command (m for help): 

--- a/tests/expected/fdisk/bsd_1_0.BE
+++ b/tests/expected/fdisk/bsd_1_0.BE
@@ -204,10 +204,10 @@ Be careful before using the write command.
 Command (m for help): Entering nested BSD disklabel.
 
 Command (m for help): 
- 0  unused           5  4.1BSD           9  4.4LFS           d  boot           
- 1  swap             6  Eighth Edition   a  unknown          e  ADOS           
- 2  Version 6        7  4.2BSD           b  HPFS             f  HFS            
- 3  Version 7        8  MS-DOS           c  ISO-9660        10  AdvFS          
- 4  System V       
+00 unused           05 4.1BSD           09 4.4LFS           0d boot           
+01 swap             06 Eighth Edition   0a unknown          0e ADOS           
+02 Version 6        07 4.2BSD           0b HPFS             0f HFS            
+03 Version 7        08 MS-DOS           0c ISO-9660         10 AdvFS          
+04 System V       
 
 Command (m for help): 

--- a/tests/expected/fdisk/bsd_1_0.LE
+++ b/tests/expected/fdisk/bsd_1_0.LE
@@ -204,10 +204,10 @@ Be careful before using the write command.
 Command (m for help): Entering nested BSD disklabel.
 
 Command (m for help): 
- 0  unused           5  4.1BSD           9  4.4LFS           d  boot           
- 1  swap             6  Eighth Edition   a  unknown          e  ADOS           
- 2  Version 6        7  4.2BSD           b  HPFS             f  HFS            
- 3  Version 7        8  MS-DOS           c  ISO-9660        10  AdvFS          
- 4  System V       
+00 unused           05 4.1BSD           09 4.4LFS           0d boot           
+01 swap             06 Eighth Edition   0a unknown          0e ADOS           
+02 Version 6        07 4.2BSD           0b HPFS             0f HFS            
+03 Version 7        08 MS-DOS           0c ISO-9660         10 AdvFS          
+04 System V       
 
 Command (m for help): 


### PR DESCRIPTION
The logger and rtwake time function changes continue the same fixes as
previous commit - use thread safe functions.  The libsmartcols condition
removal is possible because width must be greater than tb->termwidth that is
size_t and cannot be smaller than zero.  And remove couple FIXME's that are
old and unlikely ever to get fixed.

Reference: 3160589d86470ce7d20c81090fb7f211b3822053
Signed-off-by: Sami Kerola <kerolasa@iki.fi>