### PR TITLE
libsmartcols: fix memory leak in scols_print_table_to_string()

### DIFF
--- a/libsmartcols/src/print-api.c
+++ b/libsmartcols/src/print-api.c
@@ -194,6 +194,7 @@ int scols_print_table_to_string(struct libscols_table *tb, char **data)
 	scols_table_set_stream(tb, stream);
 	rc = do_print_table(tb, NULL);
 	fclose(stream);
+	free(*data);
 	scols_table_set_stream(tb, old_stream);
 
 	return rc;


### PR DESCRIPTION
As mentioned in open_memstream(3) manual page 'After closing the stream, the
caller should free(3) this buffer.'  The issue was found while checking if
upcoming irqtop is leaking memory.

Reference: http://man7.org/linux/man-pages/man3/open_memstream.3.html
Signed-off-by: Sami Kerola <kerolasa@iki.fi>