### PR TITLE
libuuid: add uuid_parse_range()

### DIFF
--- a/libuuid/src/parse.c
+++ b/libuuid/src/parse.c
@@ -41,14 +41,23 @@
 
 int uuid_parse(const char *in, uuid_t uu)
 {
+	size_t len = strlen(in);
+	if (len != 36)
+		return -1;
+
+	return uuid_parse_range(in, in + len, uu);
+}
+
+int uuid_parse_range(const char *in_start, const char *in_end, uuid_t uu)
+{
 	struct uuid	uuid;
 	int 		i;
 	const char	*cp;
 	char		buf[3];
 
-	if (strlen(in) != 36)
+	if ((in_end - in_start) != 36)
 		return -1;
-	for (i=0, cp = in; i <= 36; i++,cp++) {
+	for (i=0, cp = in_start; i <= 36; i++,cp++) {
 		if ((i == 8) || (i == 13) || (i == 18) ||
 		    (i == 23)) {
 			if (*cp == '-')
@@ -62,11 +71,11 @@ int uuid_parse(const char *in, uuid_t uu)
 		if (!isxdigit(*cp))
 			return -1;
 	}
-	uuid.time_low = strtoul(in, NULL, 16);
-	uuid.time_mid = strtoul(in+9, NULL, 16);
-	uuid.time_hi_and_version = strtoul(in+14, NULL, 16);
-	uuid.clock_seq = strtoul(in+19, NULL, 16);
-	cp = in+24;
+	uuid.time_low = strtoul(in_start, NULL, 16);
+	uuid.time_mid = strtoul(in_start+9, NULL, 16);
+	uuid.time_hi_and_version = strtoul(in_start+14, NULL, 16);
+	uuid.clock_seq = strtoul(in_start+19, NULL, 16);
+	cp = in_start+24;
 	buf[2] = 0;
 	for (i=0; i < 6; i++) {
 		buf[0] = *cp++;

--- a/libuuid/src/uuid.h
+++ b/libuuid/src/uuid.h
@@ -100,6 +100,7 @@ extern int uuid_is_null(const uuid_t uu);
 
 /* parse.c */
 extern int uuid_parse(const char *in, uuid_t uu);
+extern int uuid_parse_range(const char *in_start, const char *in_end, uuid_t uu);
 
 /* unparse.c */
 extern void uuid_unparse(const uuid_t uu, char *out);


### PR DESCRIPTION
We have a use case to construct a uuid from subset of a string. Currently, we have to create a temporary NULL-terminated buffer, copy the uuid, and call `uuid_parse()`:
```c++
uuid::uuid(std::string_view s)
{
	if(s.size() != string_length)
		throw std::runtime_error("malformed uuid");

	uuid_string_type buf;
	strncpy(buf, s.data(), std::min(s.size(), string_length));
	buf[string_length] = '\0';

	if(uuid_parse(buf, m_uuid) < 0)
		throw std::runtime_error("malformed uuid");
}
```

This patch adds `uuid_parse_range()` which takes a pointer "range". This allows us to simplify the above down to:
```c++
uuid::uuid(std::string_view s)
{
	if(uuid_parse_range(s.begin(), s.end(), m_uuid) < 0)
		throw std::runtime_error("malformed uuid");
}
```

I send this to the mailing list previously, but received no response.