### PR TITLE
Correct HiSilicon 0xD01 CPU part name

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -171,7 +171,7 @@ static const struct id_part intel_part[] = {
 };
 
 static const struct id_part hisi_part[] = {
-    { 0xd01, "tsv110" },
+    { 0xd01, "Kunpeng-920" },
     { -1, "unknown" },
 };
 


### PR DESCRIPTION
The official name for HiSilicon aarch64 0xD01 cpupart model is Kunpeng-920
rather than tsv110, this patch corrects it.

Signed-off-by: Zheng Zhenyu <zheng.zhenyu@outlook.com>