### PR TITLE
irqtop: trim whilte spaces

### DIFF
--- a/sys-utils/irqtop.c
+++ b/sys-utils/irqtop.c
@@ -324,6 +324,7 @@ static struct irq_stat *get_irqinfo(void)
 			while (isspace(*tmp))
 				tmp++;
 			tmp = remove_repeated_spaces(tmp);
+			rtrim_whitespace((unsigned char *)tmp);
 			curr->name = xstrdup(tmp);
 		} else	/* no irq name string, we have to set '\0' here */
 			curr->name = xstrdup("");


### PR DESCRIPTION
Excess white spaces were easiest to see in json output.

    $ irqtop --once --json
    {
       "interrupts": [
          {"irq":"LOC", "total":7425148, "name":"Local timer interrupts "},
          {"irq":"51", "total":1848384, "name":"IR-PCI-MSI 32768-edge i915 "},
          {"irq":"RES", "total":1176665, "name":"Rescheduling interrupts "},
          ...

Signed-off-by: Sami Kerola <kerolasa@iki.fi>