### PR TITLE
irqtop: bash-completion, option exclusion, and man pages

### DIFF
--- a/bash-completion/Makemodule.am
+++ b/bash-completion/Makemodule.am
@@ -60,6 +60,9 @@ endif
 if BUILD_LSIPC
 dist_bashcompletion_DATA += bash-completion/lsipc
 endif
+if BUILD_LSIRQ
+dist_bashcompletion_DATA += bash-completion/lsirq
+endif
 if BUILD_LSNS
 dist_bashcompletion_DATA += bash-completion/lsns
 endif

--- a/bash-completion/lsirq
+++ b/bash-completion/lsirq
@@ -1,23 +1,15 @@
-_irqtop_module()
+_lsirq_module()
 {
 	local cur prev OPTS
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 	case $prev in
-		'-d'|'--delay')
-			COMPREPLY=( $(compgen -W "secs" -- $cur) )
-			return 0
-			;;
-		'-s'|'--sort')
-			COMPREPLY=( $(compgen -W "irq total delta name" -- $cur) )
-			return 0
-			;;
 		'-o'|'--output')
 			local prefix realcur OUTPUT
 			realcur="${cur##*,}"
 			prefix="${cur%$realcur}"
-			for WORD in "IRQ TOTAL DELTA NAME"; do
+			for WORD in "IRQ TOTAL NAME"; do
 				if ! [[ $prefix == *"$WORD"* ]]; then
 					OUTPUT="$WORD ${OUTPUT:-""}"
 				fi
@@ -26,16 +18,21 @@ _irqtop_module()
 			COMPREPLY=( $(compgen -P "$prefix" -W "$OUTPUT" -S ',' -- $realcur) )
 			return 0
 			;;
+		'-s'|'--sort')
+			COMPREPLY=( $(compgen -W "irq total name" -- $cur) )
+			return 0
+			;;
 		'-h'|'--help'|'-V'|'--version')
 			return 0
 			;;
 	esac
-	OPTS="	--delay
-		--sort
+	OPTS="	--json
+		--pairs
 		--output
+		--sort
 		--help
 		--version"
 	COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
 	return 0
 }
-complete -F _irqtop_module irqtop
+complete -F _lsirq_module lsirq

--- a/sys-utils/irqtop.1
+++ b/sys-utils/irqtop.1
@@ -9,14 +9,18 @@ Display kernel interrupt counter information in
 .BR top (1)
 style view.
 .PP
-The default output is subject to change. So  whenever possible,
-you should avoid using default outputs in your scripts.  Always
-explicitly define expected columns by using \fB\-\-output\fR.
+The default output is subject to change.  So whenever possible, you should
+avoid using default outputs in your scripts.  Always explicitly define
+expected columns by using
+.BR \-\-output .
 .SH OPTIONS
 .TP
 .BR \-o , " \-\-output " \fIlist\fP
-Specify which output columns to print.  Use \fB\-\-help\fR to get a list of all supported columns.
-The default list of columns may be extended if list is specified in the format +list.
+Specify which output columns to print.  Use
+.B \-\-help
+to get a list of all supported columns.  The default list of columns may be
+extended if list is specified in the format
+.IR +list .
 .TP
 .BR \-d , " \-\-delay " \fIseconds\fP
 Update interrupt output every
@@ -24,15 +28,18 @@ Update interrupt output every
 intervals.
 .TP
 .BR \-s , " \-\-sort " \fIcolumn\fP
-Specify sort criteria by column name.  See \fB\-\-help\fR output to get column
-names.  The sort criteria may be changes in interactive mode.
+Specify sort criteria by column name.  See
+.B \-\-help
+output to get column names.  The sort criteria may be changes in interactive
+mode.
 .TP
 .BR \-V ", " \-\-version
 Display version information and exit.
 .TP
 .BR \-h ,\  \-\-help
 Display help text and exit.
-.SH COMMAND IN INTERACTIE MODE
+.SH INTERACTIVE MODE KEY COMMANDS
+.PD 0
 .TP
 .B i
 sort by short irq name or number field
@@ -48,6 +55,7 @@ sort by long descriptive name field
 .TP
 .B q Q
 stop updates and exit program
+.PD 1
 .SH AUTHORS
 .MT pizhenwei@\:bytedance.com
 Zhenwei Pi
@@ -57,7 +65,7 @@ Zhenwei Pi
 Sami Kerola
 .ME
 .br
-.MT kzak@\:redhat.com 
+.MT kzak@\:redhat.com
 Karel Zak
 .ME
 .SH AVAILABILITY

--- a/sys-utils/lsirq.1
+++ b/sys-utils/lsirq.1
@@ -7,21 +7,26 @@ lsirq \- utility to display kernel interrupt information
 .SH DESCRIPTION
 Display kernel interrupt counter information.
 .PP
-The default output is subject to change. So  whenever possible,
-you should avoid using default outputs in your scripts.  Always
-explicitly define expected columns by using \fB\-\-output\fR.
+The default output is subject to change.  So whenever possible, you should
+avoid using default outputs in your scripts.  Always explicitly define
+expected columns by using
+.BR \-\-output .
 .SH OPTIONS
 .TP
 .BR \-n , " \-\-noheadings
 Don't print headings.
 .TP
 .BR \-o , " \-\-output " \fIlist\fP
-Specify which output columns to print.  Use \fB\-\-help\fR to get a list of all supported columns.
-The default list of columns may be extended if list is specified in the format +list.
+Specify which output columns to print.  Use
+.B \-\-help
+to get a list of all supported columns.  The default list of columns may be
+extended if list is specified in the format
+.IR +list .
 .TP
 .BR \-s , " \-\-sort " \fIcolumn\fP
-Specify sort criteria by column name.  See \fB\-\-help\fR output to get column
-names.
+Specify sort criteria by column name.  See
+.B \-\-help
+output to get column names.
 .TP
 .BR \-J , " \-\-json
 Use JSON output format.
@@ -44,7 +49,7 @@ Zhenwei Pi
 Sami Kerola
 .ME
 .br
-.MT kzak@\:redhat.com 
+.MT kzak@\:redhat.com
 Karel Zak
 .ME
 .SH AVAILABILITY

--- a/sys-utils/lsirq.c
+++ b/sys-utils/lsirq.c
@@ -32,6 +32,7 @@
 #include <libsmartcols.h>
 
 #include "closestream.h"
+#include "optutils.h"
 #include "strutils.h"
 #include "xalloc.h"
 
@@ -91,10 +92,17 @@ int main(int argc, char **argv)
 	};
 	int c;
 	const char *outarg = NULL;
+	static const ul_excl_t excl[] = {	/* rows and cols in ASCII order */
+		{'J', 'P'},
+		{0}
+	};
+	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
 
 	setlocale(LC_ALL, "");
 
 	while ((c = getopt_long(argc, argv, "no:s:hJPV", longopts, NULL)) != -1) {
+		err_exclusive_options(c, longopts, excl, excl_st);
+
 		switch (c) {
 		case 'J':
 			out.json = 1;


### PR DESCRIPTION
This pull will add bash-completion to lsirq, set --pairs and --json exclusive in lsirq, and makes very pedantic man page amendments. I believe after these changes both irqtop and lsirq are ready to be merged to upstream master.