### PR TITLE
lsns: add time namespace support

### DIFF
--- a/sys-utils/lsns.8
+++ b/sys-utils/lsns.8
@@ -61,8 +61,8 @@ Use the raw output format.
 .TP
 .BR \-t , " \-\-type " \fItype\fP
 Display the specified \fItype\fP of namespaces only.  The supported types are
-\fBmnt\fP, \fBnet\fP, \fBipc\fP, \fBuser\fP, \fBpid\fP, \fButs\fP and
-\fBcgroup\fP.  This option may be given more than once.
+\fBmnt\fP, \fBnet\fP, \fBipc\fP, \fBuser\fP, \fBpid\fP, \fButs\fP,
+\fBcgroup\fP and \fBtime\fP.  This option may be given more than once.
 .TP
 .BR \-u , " \-\-notruncate"
 Do not truncate text in columns.

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -119,7 +119,8 @@ enum {
 	LSNS_ID_UTS,
 	LSNS_ID_IPC,
 	LSNS_ID_USER,
-	LSNS_ID_CGROUP
+	LSNS_ID_CGROUP,
+	LSNS_ID_TIME
 };
 
 static char *ns_names[] = {
@@ -129,7 +130,8 @@ static char *ns_names[] = {
 	[LSNS_ID_UTS] = "uts",
 	[LSNS_ID_IPC] = "ipc",
 	[LSNS_ID_USER] = "user",
-	[LSNS_ID_CGROUP] = "cgroup"
+	[LSNS_ID_CGROUP] = "cgroup",
+	[LSNS_ID_TIME] = "time"
 };
 
 struct lsns_namespace {
@@ -910,7 +912,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -r, --raw              use the raw output format\n"), out);
 	fputs(_(" -u, --notruncate       don't truncate text in columns\n"), out);
 	fputs(_(" -W, --nowrap           don't use multi-line representation\n"), out);
-	fputs(_(" -t, --type <name>      namespace type (mnt, net, ipc, user, pid, uts, cgroup)\n"), out);
+	fputs(_(" -t, --type <name>      namespace type (mnt, net, ipc, user, pid, uts, cgroup, time)\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
 	printf(USAGE_HELP_OPTIONS(24));


### PR DESCRIPTION
``` 
# ./lsns -t time
         NS TYPE  NPROCS   PID USER COMMAND
 4026531834 time     102     1 root /usr/lib/systemd/systemd --switched-root --system --deserialize 29
 4026532246 time       1 54797 root sleep 100
```

Time namespace support in `lsns`. Also see #974 