### PR TITLE
unshare: use '-T' for time namespace instead of '-t'

### DIFF
--- a/sys-utils/unshare.1
+++ b/sys-utils/unshare.1
@@ -141,7 +141,7 @@ namespace is created by a bind mount.
 Unshare the cgroup namespace. If \fIfile\fP is specified then persistent namespace is created
 by bind mount.
 .TP
-.BR \-t , " \-\-time"[=\fIfile\fP]
+.BR \-T , " \-\-time"[=\fIfile\fP]
 Unshare the time namespace. If \fIfile\fP is specified then a persistent
 namespace is created by a bind mount. The \fB\-\-monotonic\fP and
 \fB\-\-boottime\fP options can be used to specify the corresponding

--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -285,7 +285,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -p, --pid[=<file>]        unshare pid namespace\n"), out);
 	fputs(_(" -U, --user[=<file>]       unshare user namespace\n"), out);
 	fputs(_(" -C, --cgroup[=<file>]     unshare cgroup namespace\n"), out);
-	fputs(_(" -t, --time[=<file>]       unshare time namespace\n"), out);
+	fputs(_(" -T, --time[=<file>]       unshare time namespace\n"), out);
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_(" -f, --fork                fork before launching <program>\n"), out);
 	fputs(_(" -r, --map-root-user       map current user to root (implies --user)\n"), out);
@@ -335,7 +335,7 @@ int main(int argc, char *argv[])
 		{ "pid",           optional_argument, NULL, 'p'             },
 		{ "user",          optional_argument, NULL, 'U'             },
 		{ "cgroup",        optional_argument, NULL, 'C'             },
-		{ "time",          optional_argument, NULL, 't'             },
+		{ "time",          optional_argument, NULL, 'T'             },
 
 		{ "fork",          no_argument,       NULL, 'f'             },
 		{ "kill-child",    optional_argument, NULL, OPT_KILLCHILD   },
@@ -379,7 +379,7 @@ int main(int argc, char *argv[])
 	textdomain(PACKAGE);
 	close_stdout_atexit();
 
-	while ((c = getopt_long(argc, argv, "+fhVmuinpCtUrR:w:S:G:c", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "+fhVmuinpCTUrR:w:S:G:c", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'f':
 			forkit = 1;
@@ -419,7 +419,7 @@ int main(int argc, char *argv[])
 			if (optarg)
 				set_ns_target(CLONE_NEWCGROUP, optarg);
 			break;
-		case 't':
+		case 'T':
 			unshare_flags |= CLONE_NEWTIME;
 			if (optarg)
 				set_ns_target(CLONE_NEWTIME, optarg);


### PR DESCRIPTION
While working on getting time namespace support into 'nsenter' it was
not possible to use '-t' to enter a time namespace as '-t' is the short
option for '--target'. Fortunately '-T' is still available in 'nsenter'
and 'unshare' and therefore let's change 'unshare' to use the same flag
for the time namespace as 'nsenter'.

See #974 