### PR TITLE
nsenter: add support for the time namespace

### DIFF
--- a/sys-utils/nsenter.1
+++ b/sys-utils/nsenter.1
@@ -92,6 +92,13 @@ and the discussion of the
 flag in
 .BR clone (2).
 .TP
+.B time namespace
+The process can have a distinct view of
+.B CLOCK_MONOTONIC
+and/or
+.B CLOCK_BOOTTIME
+which can be changed using \fI/proc/self/timens_offsets\fP.
+.TP
 See \fBclone\fP(2) for the exact semantics of the flags.
 .SH OPTIONS
 Various of the options below that relate to namespaces take an optional
@@ -143,6 +150,9 @@ the user namespace
 .TP
 /proc/\fIpid\fR/ns/cgroup
 the cgroup namespace
+.TP
+/proc/\fIpid\fR/ns/time
+the time namespace
 .TP
 /proc/\fIpid\fR/root
 the root directory
@@ -208,6 +218,14 @@ the target process.
 If
 .I file
 is specified, enter the cgroup namespace specified by
+.IR file .
+.TP
+\fB\-T\fR, \fB\-\-time\fR[=\fIfile\fR]
+Enter the time namespace.  If no file is specified, enter the time namespace of
+the target process.
+If
+.I file
+is specified, enter the time namespace specified by
 .IR file .
 .TP
 \fB\-G\fR, \fB\-\-setgid\fR \fIgid\fR

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -62,6 +62,7 @@ static struct namespace_file {
 	{ .nstype = CLONE_NEWNET,   .name = "ns/net",  .fd = -1 },
 	{ .nstype = CLONE_NEWPID,   .name = "ns/pid",  .fd = -1 },
 	{ .nstype = CLONE_NEWNS,    .name = "ns/mnt",  .fd = -1 },
+	{ .nstype = CLONE_NEWTIME,  .name = "ns/time", .fd = -1 },
 	{ .nstype = 0, .name = NULL, .fd = -1 }
 };
 
@@ -86,6 +87,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -p, --pid[=<file>]     enter pid namespace\n"), out);
 	fputs(_(" -C, --cgroup[=<file>]  enter cgroup namespace\n"), out);
 	fputs(_(" -U, --user[=<file>]    enter user namespace\n"), out);
+	fputs(_(" -T, --time[=<file>]    enter time namespace\n"), out);
 	fputs(_(" -S, --setuid <uid>     set uid in entered namespace\n"), out);
 	fputs(_(" -G, --setgid <gid>     set gid in entered namespace\n"), out);
 	fputs(_("     --preserve-credentials do not touch uids or gids\n"), out);
@@ -219,6 +221,7 @@ int main(int argc, char *argv[])
 		{ "pid", optional_argument, NULL, 'p' },
 		{ "user", optional_argument, NULL, 'U' },
 		{ "cgroup", optional_argument, NULL, 'C' },
+		{ "time", optional_argument, NULL, 'T' },
 		{ "setuid", required_argument, NULL, 'S' },
 		{ "setgid", required_argument, NULL, 'G' },
 		{ "root", optional_argument, NULL, 'r' },
@@ -248,7 +251,7 @@ int main(int argc, char *argv[])
 	close_stdout_atexit();
 
 	while ((c =
-		getopt_long(argc, argv, "+ahVt:m::u::i::n::p::C::U::S:G:r::w::FZ",
+		getopt_long(argc, argv, "+ahVt:m::u::i::n::p::C::U::T::S:G:r::w::FZ",
 			    longopts, NULL)) != -1) {
 		switch (c) {
 		case 'a':
@@ -299,6 +302,12 @@ int main(int argc, char *argv[])
 				open_namespace_fd(CLONE_NEWUSER, optarg);
 			else
 				namespaces |= CLONE_NEWUSER;
+			break;
+		case 'T':
+			if (optarg)
+				open_namespace_fd(CLONE_NEWTIME, optarg);
+			else
+				namespaces |= CLONE_NEWTIME;
 			break;
 		case 'S':
 			uid = strtoul_or_err(optarg, _("failed to parse uid"));


### PR DESCRIPTION
Just as with unshare and lsns this adds time namespace support to
nsenter.

In contrast to unshare nsenter does not have the options '--boottime'
and '--monotonic' as that offset can only be set as long as there have
no processes being started in the corresponding time namespace.