### PR TITLE
tests: fixes eject, libmount, mount (root) tests on SPARC

### DIFF
--- a/tests/ts/eject/umount
+++ b/tests/ts/eject/umount
@@ -35,6 +35,7 @@ function init_partitions {
 
 	ts_log "Create partitions"
 	$TS_CMD_FDISK $dev >> /dev/null 2>&1 <<EOF
+o
 n
 p
 1

--- a/tests/ts/libmount/context
+++ b/tests/ts/libmount/context
@@ -40,6 +40,7 @@ fi
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} &> /dev/null <<EOF
+o
 n
 p
 1

--- a/tests/ts/libmount/context-py
+++ b/tests/ts/libmount/context-py
@@ -49,6 +49,7 @@ fi
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} &> /dev/null <<EOF
+o
 n
 p
 1

--- a/tests/ts/libmount/context-utab
+++ b/tests/ts/libmount/context-utab
@@ -31,6 +31,7 @@ DEVNAME=$(basename $TS_DEVICE)
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} &> /dev/null <<EOF
+o
 n
 p
 1

--- a/tests/ts/libmount/context-utab-py
+++ b/tests/ts/libmount/context-utab-py
@@ -36,6 +36,7 @@ DEVNAME=$(basename $TS_DEVICE)
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} &> /dev/null <<EOF
+o
 n
 p
 1

--- a/tests/ts/mount/fstab-all
+++ b/tests/ts/mount/fstab-all
@@ -22,6 +22,7 @@ ts_scsi_debug_init dev_size_mb=50
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} &> /dev/null <<EOF
+o
 n
 p
 1

--- a/tests/ts/mount/umount-alltargets
+++ b/tests/ts/mount/umount-alltargets
@@ -28,6 +28,7 @@ ts_scsi_debug_init dev_size_mb=50
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} &> /dev/null <<EOF
+o
 n
 p
 1

--- a/tests/ts/mount/umount-recursive
+++ b/tests/ts/mount/umount-recursive
@@ -24,6 +24,7 @@ ts_scsi_debug_init dev_size_mb=50
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} &> /dev/null <<EOF
+o
 n
 p
 1


### PR DESCRIPTION
Since SPARC is using 'sun' partition table by default, make tests not to assume that disk has 'dos' partition table, so write 'dos' partition table on disk, before proceeding any further.

Besides, this change allows next tests to execute, which depend on `scsi_debug` module as well, since `eject/umount` test does not dismount properly scsi debug block device partitions.

```
root@ttip:/1/mator/util-linux/tests# uname -a
Linux ttip 5.6.0-rc5 #29 SMP Mon Mar 9 12:15:59 MSK 2020 sparc64 GNU/Linux
```

Before changes:

```
        eject: umount                         ...
                : by-disk                     ... OK
                : by-disk-mounted             ... OK
                : by-disk-mounted-partition   ...Found a sun partition table in /dev/sda1
Proceed anyway? (y,N)
mount: /1/mator/util-linux/tests/output/eject/umount-by-disk-mounted-partition-mnt1: wrong fs type, bad option, bad superblock on /dev/sda1, missing codepage or helper p
rogram, or other error.
 OK
                : by-partition                ...Found a sun partition table in /dev/sda1
Proceed anyway? (y,N)

 OK
                : by-partition-mounted        ...Found a sun partition table in /dev/sda1
Proceed anyway? (y,N)
mount: /1/mator/util-linux/tests/output/eject/umount-by-partition-mounted-mnt1: wrong fs type, bad option, bad superblock on /dev/sda1, missing codepage or helper program, or other error.
 OK
```
libmount before:
```
     libmount: context                        ... FAILED (libmount/context)
     libmount: context-py                     ... FAILED (libmount/context-py)
     libmount: context (utab)                 ...
                : mount-by-devname            ... FAILED (libmount/context-utab-mount-by-devname)
                : umount-by-devname           ... FAILED (libmount/context-utab-umount-by-devname)
                : mount-uhelper               ... FAILED (libmount/context-utab-mount-uhelper)
                : umount                      ... FAILED (libmount/context-utab-umount)
                : mount-uhelper-subvol        ... FAILED (libmount/context-utab-mount-uhelper-subvol)
                : umount-subvol               ... FAILED (libmount/context-utab-umount-subvol)
           ... FAILED (6 from 6 sub-tests)
     libmount: context-py (utab)              ...
                : mount-by-devname            ... FAILED (libmount/context-utab-py-mount-by-devname)
                : umount-by-devname           ... FAILED (libmount/context-utab-py-umount-by-devname)
                : mount-uhelper               ... FAILED (libmount/context-utab-py-mount-uhelper)
                : umount                      ... FAILED (libmount/context-utab-py-umount)
                : mount-uhelper-subvol        ... FAILED (libmount/context-utab-py-mount-uhelper-subvol)
                : umount-subvol               ... FAILED (libmount/context-utab-py-umount-subvol)
           ... FAILED (6 from 6 sub-tests)
```

after change:

```
root@ttip:/1/mator/util-linux/tests# ./run.sh eject

-------------------- util-linux regression tests --------------------

                    For development purpose only.
                 Don't execute on production system!

       kernel: 5.6.0-rc5

      options: --srcdir=/1/mator/util-linux/tests/.. \
               --builddir=/1/mator/util-linux/tests/..

        eject: umount                         ...
                : by-disk                     ... OK
                : by-disk-mounted             ... OK
                : by-disk-mounted-partition   ... OK
                : by-partition                ... OK
                : by-partition-mounted        ... OK
           ... OK (all 5 sub-tests PASSED)
```
libmount test:
```
root@ttip:/1/mator/util-linux/tests# ./run.sh libmount

-------------------- util-linux regression tests --------------------

                    For development purpose only.
                 Don't execute on production system!

       kernel: 5.6.0-rc5

      options: --srcdir=/1/mator/util-linux/tests/.. \
               --builddir=/1/mator/util-linux/tests/..

     libmount: context                        ...
                : mount-by-devname            ... OK
                : umount-by-devname           ... OK
                : mount-by-label              ... OK
                : umount-by-mountpoint        ... OK
                : mount-by-uuid               ... OK
                : mount-flags                 ... OK
                : mount-loopdev               ... OK
                : x-permanent                 ... OK
                : X-comment                   ... OK
           ... OK (all 9 sub-tests PASSED)
     libmount: context-py                     ...
                : mount-by-devname            ... OK
                : umount-by-devname           ... OK
                : mount-by-label              ... OK
                : umount-by-mountpoint        ... OK
                : mount-by-uuid               ... OK
                : mount-flags                 ... OK
                : mount-loopdev               ... OK
                : x-mount.mkdir               ... OK
           ... OK (all 8 sub-tests PASSED)
    libmount: context (utab)                 ...
                : mount-by-devname            ... OK
                : umount-by-devname           ... OK
                : mount-uhelper               ... OK
                : umount                      ... OK
                : mount-uhelper-subvol        ... OK
                : umount-subvol               ... OK
           ... OK (all 6 sub-tests PASSED)
     libmount: context-py (utab)              ...
                : mount-by-devname            ... OK
                : umount-by-devname           ... OK
                : mount-uhelper               ... OK
                : umount                      ... OK
                : mount-uhelper-subvol        ... OK
                : umount-subvol               ... OK
           ... OK (all 6 sub-tests PASSED)
     libmount: debugging                      ...
                : set-from-code               ... OK
                : set-from-env-str            ... OK
                : set-from-env-int            ... OK
           ... OK (all 3 sub-tests PASSED)
     libmount: lock                           ... SKIPPED (optional)
     libmount: losetup-loop                   ...
                : file                        ... OK
                : file-o-loop                 ... OK
                : dev-loop                    ... OK
                : o-loop-val                  ... OK
                : reuse                       ... OK
                : conflict                    ... OK
                : o-loop-val-initialized      ... OK
                : o-loop-val-conflict         ... OK
           ... OK (all 8 sub-tests PASSED)
     libmount: loop overlay                   ... OK
    libmount: options string                 ...
                : append                      ... OK
                : append-value                ... OK
                : append-empty-value          ... OK
                : prepend                     ... OK
                : prepend-value               ... OK
                : prepend-empty-value         ... OK
                : set-remove                  ... OK
                : set-small                   ... OK
                : set-large                   ... OK
                : set-empty                   ... OK
                : set-new                     ... OK
                : set-new-empty               ... OK
                : set-new-end                 ... OK
                : set-new-end-empty           ... OK
                : get                         ... OK
                : get-value                   ... OK
                : remove                      ... OK
                : remove-quoted               ... OK
                : remove-value                ... OK
                : remove-empty-value          ... OK
                : split                       ... OK
                : flags                       ... OK
                : apply-linux                 ... OK
                : apply-user                  ... OK
                : fix                         ... OK
                : deduplicate                 ... OK
                : deduplicate-empty           ... OK
           ... OK (all 27 sub-tests PASSED)
     libmount: table diffs                    ...
                : mount                       ... OK
                : umount                      ... OK
                : remount                     ... OK
                : move                        ... OK
           ... OK (all 4 sub-tests PASSED)
     libmount: tab files                      ...
                : parse-fstab                 ... OK
                : parse-fstab-full            ... OK
                : parse-mtab                  ... OK
                : parse-fstab-broken          ... OK
                : parse-mountinfo             ... OK
                : parse-mountinfo-nosrc       ... OK
                : parse-swaps                 ... OK
                : copy                        ... OK
                : find-source                 ... OK
                : find-target                 ... OK
                : find-target2                ... OK
                : find-target3                ... OK
                : find-pair                   ... OK
                : find-fs                     ... OK
           ... OK (all 14 sub-tests PASSED)
     libmount: tab files-py                   ...
                : parse-fstab                 ... OK
                : parse-fstab-full            ... OK
                : parse-mtab                  ... OK
                : parse-fstab-broken          ... OK
                : parse-mountinfo             ... OK
                : copy                        ... OK
                : find-source                 ... OK
                : find-target                 ... OK
                : find-target2                ... OK
                : find-target3                ... OK
                : find-pair                   ... OK
           ... OK (all 11 sub-tests PASSED)
     libmount: tags                           ...
                : fstab-label2uuid            ... OK
                : fstab-label2dev             ... OK
                : fstab-uuid                  ... OK
                : fstab-label                 ... OK
                : fstab-dev2label             ... OK
                : fstab-dev                   ... OK
           ... OK (all 6 sub-tests PASSED)
     libmount: tags-py                        ...
                : fstab-label2uuid            ... OK
                : fstab-label2dev             ... OK
                : fstab-uuid                  ... OK
                : fstab-label                 ... OK
                : fstab-dev2label             ... OK
                : fstab-dev                   ... OK
           ... OK (all 6 sub-tests PASSED)
     libmount: tab update                     ...
                : utab-mount                  ... OK
                : utab-move                   ... OK
                : utab-remount                ... OK
                : utab-umount                 ... OK
                : fstab-replace               ... OK
           ... OK (all 5 sub-tests PASSED)
     libmount: tab update-py                  ...
                : fstab-replace               ... OK
           ... OK (all 1 sub-tests PASSED)
     libmount: utils                          ...
                : match-fstype                ... OK
                : match-fstype-neg            ... OK
                : match-fstype-neg2           ... OK
                : match-options               ... OK
                : match-options-list          ... OK
                : match-options-neg           ... OK
                : match-options-neg-list      ... OK
                : match-options-neg-list2     ... OK
                : starts-with                 ... OK
                : ends-with                   ... OK
                : mountpoint                  ... OK
                : mountpoint-subdir           ... OK
                : mountpoint-root             ... OK
                : kernel-cmdline              ... OK
           ... OK (all 14 sub-tests PASSED)

---------------------------------------------------------------------
  All 17 tests PASSED
---------------------------------------------------------------------
```