### PR TITLE
Fix typo in the mount (8) man page

### DIFF
--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -547,7 +547,7 @@ is the same as:
 
 .RS
 .nf
-.B mount /dev/sda1 /foox
+.B mount /dev/sda1 /foo
 .B mount \-\-make\-private /foo
 .B mount \-\-make\-unbindable /foo
 .fi


### PR DESCRIPTION
In a section about mounting a directory `/foo`, it uses `/foox` once.  I believe this is a typo.