### PR TITLE
Libfdisk script fix segmentation fault

### DIFF
--- a/include/mangle.h
+++ b/include/mangle.h
@@ -14,12 +14,14 @@ extern char *unmangle(const char *s, const char **end);
 
 static inline void unmangle_string(char *s)
 {
-	unmangle_to_buffer(s, s, strlen(s) + 1);
+	if (s)
+		unmangle_to_buffer(s, s, strlen(s) + 1);
 }
 
 static inline void unhexmangle_string(char *s)
 {
-	unhexmangle_to_buffer(s, s, strlen(s) + 1);
+	if (s)
+		unhexmangle_to_buffer(s, s, strlen(s) + 1);
 }
 
 #endif /* UTIL_LINUX_MANGLE_H */

--- a/libfdisk/src/script.c
+++ b/libfdisk/src/script.c
@@ -1059,7 +1059,8 @@ static int parse_line_nameval(struct fdisk_script *dp, char *s)
 		} else if (!strncasecmp(p, "name=", 5)) {
 			p += 5;
 			rc = next_string(&p, &pa->name);
-			unhexmangle_string(pa->name);
+			if (!rc)
+				unhexmangle_string(pa->name);
 
 		} else if (!strncasecmp(p, "type=", 5) ||
 			   !strncasecmp(p, "Id=", 3)) {		/* backward compatibility */


### PR DESCRIPTION
Hello,

This PR fixes a segmentation fault that occurs if the name value is empty (i.e. `name=`).

The first patch fixes the issue in the fdisk library by calling the function `unhexmangle_string()` if the call to function `next_string()` succeeds.

The second patch makes the function `unhexmangle_string()` more robust by testing the nullity of the string argument before calling `strlen()` that crashes if the string pointer is `NULL`.

Here is how to produce the bug:

```
$ fallocate --length 1G disk.img
$ cat <<EOF | sfdisk disk.img
label: gpt
type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B uuid=8052084B-E1EF-4A16-A959-803D4E6C4427 name=
EOF
label: gpt
type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B uuid=8052084B-E1EF-4A16-A959-803D4E6C4427 name=
EOF
Checking that no-one is using this disk right now ... OK

Disk disk.img: 1 GiB, 1073741824 bytes, 2097152 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes

>>> Script header accepted.
Segmentation fault (core dumped)
```

Here is what valgrind reports:

```
==149389== 1 errors in context 1 of 1:
==149389== Invalid read of size 1
==149389==    at 0x483CC82: strlen (vg_replace_strmem.c:461)
==149389==    by 0x4868ED2: unhexmangle_string (mangle.h:22)
==149389==    by 0x4868ED2: parse_line_nameval (script.c:1062)
==149389==    by 0x4868ED2: fdisk_script_read_buffer (script.c:1254)
==149389==    by 0x4868ED2: fdisk_script_read_line (script.c:1336)
==149389==    by 0x4868ED2: fdisk_script_read_line (script.c:1298)
==149389==    by 0x1139EE: command_fdisk (sfdisk.c:1867)
==149389==    by 0x10F7E6: main (sfdisk.c:2369)
==149389==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==149389== 
```

Regards,
Gaël