### PR TITLE
tests: fixes fdisk/align-512-* tests

### DIFF
--- a/tests/expected/fdisk/align-512-4K
+++ b/tests/expected/fdisk/align-512-4K
@@ -6,6 +6,11 @@ Be careful before using the write command.
 
 Device does not contain a recognized partition table.
 Created a new <removed>.
+Created a new <removed>.
+Created a new <removed>.
+Created a new <removed>.
+
+Command (m for help): Created a new <removed>.
 
 Command (m for help): Partition type
    p   primary (0 primary, 0 extended, 4 free)

--- a/tests/expected/fdisk/align-512-4K-63
+++ b/tests/expected/fdisk/align-512-4K-63
@@ -6,6 +6,11 @@ Be careful before using the write command.
 
 Device does not contain a recognized partition table.
 Created a new <removed>.
+Created a new <removed>.
+Created a new <removed>.
+Created a new <removed>.
+
+Command (m for help): Created a new <removed>.
 
 Command (m for help): Partition type
    p   primary (0 primary, 0 extended, 4 free)

--- a/tests/expected/fdisk/align-512-512
+++ b/tests/expected/fdisk/align-512-512
@@ -6,6 +6,11 @@ Be careful before using the write command.
 
 Device does not contain a recognized partition table.
 Created a new <removed>.
+Created a new <removed>.
+Created a new <removed>.
+Created a new <removed>.
+
+Command (m for help): Created a new <removed>.
 
 Command (m for help): Partition type
    p   primary (0 primary, 0 extended, 4 free)

--- a/tests/expected/fdisk/align-512-512-topology
+++ b/tests/expected/fdisk/align-512-512-topology
@@ -6,6 +6,11 @@ Be careful before using the write command.
 
 Device does not contain a recognized partition table.
 Created a new <removed>.
+Created a new <removed>.
+Created a new <removed>.
+Created a new <removed>.
+
+Command (m for help): Created a new <removed>.
 
 Command (m for help): Partition type
    p   primary (0 primary, 0 extended, 4 free)

--- a/tests/ts/fdisk/align-512-4K
+++ b/tests/ts/fdisk/align-512-4K
@@ -36,6 +36,7 @@ DEVNAME=$(basename $TS_DEVICE)
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} >> $TS_OUTPUT 2>> $TS_ERRLOG <<EOF
+o
 n
 p
 1

--- a/tests/ts/fdisk/align-512-4K-63
+++ b/tests/ts/fdisk/align-512-4K-63
@@ -36,6 +36,7 @@ DEVNAME=$(basename $TS_DEVICE)
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} >> $TS_OUTPUT 2>> $TS_ERRLOG <<EOF
+o
 n
 p
 1

--- a/tests/ts/fdisk/align-512-512
+++ b/tests/ts/fdisk/align-512-512
@@ -35,6 +35,7 @@ DEVICE=$TS_LODEV
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${DEVICE} >> $TS_OUTPUT 2>> $TS_ERRLOG <<EOF
+o
 n
 p
 1

--- a/tests/ts/fdisk/align-512-512-topology
+++ b/tests/ts/fdisk/align-512-512-topology
@@ -36,6 +36,7 @@ DEVNAME=$(basename $TS_DEVICE)
 
 ts_log "Create partitions"
 $TS_CMD_FDISK ${TS_DEVICE} >> $TS_OUTPUT 2>> $TS_ERRLOG <<EOF
+o
 n
 p
 1


### PR DESCRIPTION
Fixes fdisk/align-512-* tests

Before:
```
# ./run.sh fdisk

-------------------- util-linux regression tests --------------------

                    For development purpose only.
                 Don't execute on production system!

       kernel: 5.6.0-rc7

      options: --srcdir=/1/mator/util-linux/tests/.. \
               --builddir=/1/mator/util-linux/tests/..

        fdisk: align 512/4K                   ... FAILED (fdisk/align-512-4K)
        fdisk: align 512/4K +alignment_offset ... FAILED (fdisk/align-512-4K-63)
        fdisk: align 512/4K +MD               ... KNOWN FAILED (fdisk/align-512-4K-md)
        fdisk: align 512/512                  ... FAILED (fdisk/align-512-512)
        fdisk: align 512/512 +topology        ... FAILED (fdisk/align-512-512-topology)
        fdisk: nested BSD                     ... OK
        fdisk: GPT                            ... OK
        fdisk: gpt-resize                     ... OK
        fdisk: MBR - id                       ... OK
        fdisk: MBR - dos mode                 ... OK
        fdisk: MBR - non-dos mode             ... SKIPPED (unsupported)
        fdisk: MBR - sort                     ... OK
        fdisk: invalid input tests            ... OK
        fdisk: sunlabel tests                 ... OK

---------------------------------------------------------------------
  4 tests of 14 FAILED
---------------------------------------------------------------------```
after:
```
        fdisk: align 512/4K                   ... OK
        fdisk: align 512/4K +alignment_offset ... OK
        fdisk: align 512/4K +MD               ... KNOWN FAILED (fdisk/align-512-4K-md)
        fdisk: align 512/512                  ... OK
        fdisk: align 512/512 +topology        ... OK
```
Thanks.

PS: patch tested with x86_64 debian VM and sparc64 debian LDOM