### PR TITLE
lscpu: Adapt MIPS cpuinfo

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -536,6 +536,7 @@ read_basicinfo(struct lscpu_desc *desc, struct lscpu_modifier *mod)
 		else if (lookup(buf, "cpu family", &desc->family)) ;
 		else if (lookup(buf, "model", &desc->model)) ;
 		else if (lookup(buf, "CPU part", &desc->model)) ; /* ARM and aarch64 */
+		else if (lookup(buf, "cpu model", &desc->model)) ; /* mips */
 		else if (lookup(buf, "model name", &desc->modelname)) ;
 		else if (lookup(buf, "stepping", &desc->stepping)) ;
 		else if (lookup(buf, "CPU variant", &desc->stepping)) ; /* aarch64 */
@@ -545,6 +546,7 @@ read_basicinfo(struct lscpu_desc *desc, struct lscpu_modifier *mod)
 		else if (lookup(buf, "flags", &desc->flags)) ;		/* x86 */
 		else if (lookup(buf, "features", &desc->flags)) ;	/* s390 */
 		else if (lookup(buf, "Features", &desc->flags)) ;	/* aarch64 */
+		else if (lookup(buf, "ASEs implemented", &desc->flags)) ;	/* mips */
 		else if (lookup(buf, "type", &desc->flags)) ;		/* sparc64 */
 		else if (lookup(buf, "bogomips", &desc->bogomips)) ;
 		else if (lookup(buf, "BogoMIPS", &desc->bogomips)) ;	/* aarch64 */


### PR DESCRIPTION
MIPS have slightly different layout of cpuinfo.

Btw:
MIPS's cpuinfo looks like this:

```
system type             : Generic Loongson64 System
machine                 : loongson,loongson3-8core-rs780e
processor               : 0
cpu model               : ICT Loongson-3 V0.7  FPU V0.1
BogoMIPS                : 1063.98
wait instruction        : no
microsecond timers      : yes
tlb_entries             : 64
extra interrupt vector  : no
hardware watchpoint     : yes, count: 0, address/irw mask: []
isa                     : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented        : loongson-mmi loongson-cam loongson-ext
shadow register sets    : 1
kscratch registers      : 0
package                 : 0
core                    : 0
VCED exceptions         : not available
VCEI exceptions         : not available
```

I believe that both "isa" and "ASEs implemented" should be a part of "flags" in lscpu.
I need some suggestions on how to implement it.

Thanks.