### PR TITLE
Fix off by one when checking "/dev/mapper/" path

### DIFF
--- a/libblkid/src/devname.c
+++ b/libblkid/src/devname.c
@@ -258,7 +258,7 @@ set_pri:
 	if (dev) {
 		if (pri)
 			dev->bid_pri = pri;
-		else if (!strncmp(dev->bid_name, "/dev/mapper/", 11)) {
+		else if (!strncmp(dev->bid_name, "/dev/mapper/", 12)) {
 			dev->bid_pri = BLKID_PRI_DM;
 			if (is_dm_leaf(ptname))
 				dev->bid_pri += 5;


### PR DESCRIPTION
This PR fixes an off by one in `strncmp(dev->bid_name, "/dev/mapper/", 11)` check. The `"/dev/mapper/"` string literal has a length of 12 and without this fix paths like `"/dev/mapperSOMETHING"` would also be accepted.