### PR TITLE
fstrim: run service and timer only if /etc/fstab is present

### DIFF
--- a/sys-utils/fstrim.service.in
+++ b/sys-utils/fstrim.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Discard unused blocks on filesystems from /etc/fstab
 Documentation=man:fstrim(8)
+ConditionPathExists=/etc/fstab
 ConditionVirtualization=!container
 
 [Service]

--- a/sys-utils/fstrim.timer
+++ b/sys-utils/fstrim.timer
@@ -1,6 +1,7 @@
 [Unit]
 Description=Discard unused blocks once a week
 Documentation=man:fstrim
+ConditionPathExists=/etc/fstab
 ConditionVirtualization=!container
 
 [Timer]


### PR DESCRIPTION
The timer and service units run `fstrim --fstab`, which strictly
depends on `/etc/fstab` being present in the OS. This adds relevant
condition statements to the units, in order to skip them and avoid
runtime failures.

Ref: https://github.com/karelzak/util-linux/issues/673#issuecomment-409246816
Ref: https://github.com/coreos/bugs/issues/2591
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/468

Signed-off-by: Luca BRUNO <luca.bruno@coreos.com>