### PR TITLE
lsblk: Fall back to ID_SERIAL

### DIFF
--- a/misc-utils/lsblk-properties.c
+++ b/misc-utils/lsblk-properties.c
@@ -107,6 +107,8 @@ static struct lsblk_devprop *get_properties_by_udev(struct lsblk_device *ld)
 		data = udev_device_get_property_value(dev, "ID_SCSI_SERIAL");
 		if(!data)
 			data = udev_device_get_property_value(dev, "ID_SERIAL_SHORT");
+		if(!data)
+			data = udev_device_get_property_value(dev, "ID_SERIAL");
 		if (data)
 			prop->serial = xstrdup(data);
 


### PR DESCRIPTION
In some cases ID_SERIAL_SHORT isn't provided by libudev, but ID_SERIAL
is. An example of this are virtio devices. See the output of udevadm
info:
```
P: /devices/pci0000:00/0000:00:06.0/virtio2/block/vdb
N: vdb
S: disk/by-id/virtio-08491434ee711d3420e9
S: disk/by-path/pci-0000:00:06.0
S: disk/by-path/virtio-pci-0000:00:06.0
E: DEVLINKS=/dev/disk/by-id/virtio-08491434ee711d3420e9 /dev/disk/by-path/pci-0000:00:06.0 /dev/disk/by-path/virtio-pci-0000:00:06.0
E: DEVNAME=/dev/vdb
E: DEVPATH=/devices/pci0000:00/0000:00:06.0/virtio2/block/vdb
E: DEVTYPE=disk
E: ID_PATH=pci-0000:00:06.0
E: ID_PATH_TAG=pci-0000_00_06_0
E: ID_SERIAL=08491434ee711d3420e9
E: MAJOR=252
E: MINOR=16
E: SUBSYSTEM=block
E: TAGS=:systemd:
E: USEC_INITIALIZED=1403804
```

In our case we set the serial for our disk so we can identify what block device belongs to what external volume, but lsblk doesn't display it properly.