### PR TITLE
Correct ChangeLog URL to history log.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,3 @@
 See version control history.
 
-http://git.kernel.org/?p=utils/util-linux/util-linux.git;a=log
+https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/log


### PR DESCRIPTION
Debian is using this to make URL with tagged release, and with the old
URL it does return an empty page.

New URL is taken from visiting old URL after redirects from browser.

```
$ apt info util-linux | grep -i version
Version: 2.35.1-2

$ zcat /usr/share/doc/util-linux/changelog.gz
See version control history.

http://git.kernel.org/?p=utils/util-linux/util-linux.git;a=log;h=2.35.1
````
^^ empty page

PS: next step is to correct debian package (but probably maintainers will make it work themself, if not, going to post debian patch as well)
