### PR TITLE
bash-completion/umount: shell charaters escape

### DIFF
--- a/bash-completion/umount
+++ b/bash-completion/umount
@@ -1,3 +1,27 @@
+_umount_points_list()
+{
+	# List of characters to escape shamelessly stolen from "scp" completion
+	local escape_chars='[][(){}<>\",:;^&!$=?`|\\'\'' \t\f\n\r\v]'
+
+	findmnt -lno TARGET | awk '{
+		if ($0 ~ "^"ENVIRON["HOME"]) {
+			homeless = $0
+			sub("^"ENVIRON["HOME"], "~", homeless)
+			gsub("'"$escape_chars"'", "\\\\&", homeless)
+			print homeless " "
+		}
+		if ($0 ~ "^"ENVIRON["PWD"]) {
+			reldir = $0
+			sub("^"ENVIRON["PWD"]"/?", "", reldir)
+			gsub("'"$escape_chars"'", "\\\\&", reldir)
+			print "./" reldir " "
+			print reldir " "
+		}
+		gsub("'"$escape_chars"'", "\\\\&")
+		print $0 " "
+	}'
+}
+
 _umount_module()
 {
 	local cur prev OPTS
@@ -49,27 +73,7 @@ _umount_module()
 			;;
 	esac
 
-	local oldifs=$IFS
-	IFS=$'\n'
-	COMPREPLY=( $( compgen -W "$(findmnt -lno TARGET | gawk \
-		'{
-			if ($0 ~ ENVIRON["HOME"]) {
-				homeless = $0
-				homeless = gensub(ENVIRON["HOME"], "\\\\~", "g", homeless)
-				homeless = gensub(/(\s)/, "\\\\\\1", "g", homeless)
-				print homeless
-			}
-			if ($0 ~ ENVIRON["PWD"]) {
-				reldir = $0
-				reldir = gensub(ENVIRON["PWD"]"/", "", "g", reldir)
-				reldir = gensub(/(\s)/, "\\\\\\1", "g", reldir)
-				print "./" reldir
-				print reldir
-			}
-			gsub(/\s/, "\\\\&")
-			print $0
-		}'
-	)" -- "$cur" ) )
-	IFS=$oldifs
+	local IFS=$'\n'
+	COMPREPLY=( $( compgen -W '$( _umount_points_list )'  -- "$cur" ) )
 }
-complete -F _umount_module umount
+complete -F _umount_module -o nospace umount


### PR DESCRIPTION
Good day,

This patch brings support for automatic dangerous shell characters
escape in umount autocompletion.  Due to the very peculiar way for
bash to handle autocompletion routines, proper escaping of the shell
sequences only worked properly inside a function: _umount_point_list,
which will add to the user's namespace at the next umount attempt of
autocompleting mount point.

It also translates calls of gensub to the portable alternatives sub
and gsub, in order to allow the use of various awk implementations
(mawk, Gnu, Busybox, etc), and as such kind of undoes a recent change
to enforce the use of Gnu awk. The whole story landed into the Debian
BTS initially:

	https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=933934

PS: It's been a few months since the patch is available, sorry for the
    delay; I only got myself a Github account quite recently...

Have a nice day!  :)