### PR TITLE
Introduce uuid_unparse_f() and allow unparsing without dashes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -762,6 +762,7 @@ CONTRIBUTORS:
       Yu Zhiguo <yuzg@cn.fujitsu.com>
       Zachary Catlin <z@zc.is>
       Zac Medico <zmedico@gentoo.org>
+      Zane van Iperen <zane@zanevaniperen.com>
       Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
       Zdenek Behan <rain@matfyz.cz>
       Zeeshan Ali (Khattak) <zeeshanak@gnome.org>

--- a/libuuid/man/uuid_unparse.3
+++ b/libuuid/man/uuid_unparse.3
@@ -39,6 +39,7 @@ uuid_unparse \- convert a UUID from binary representation to a string
 .BI "void uuid_unparse(uuid_t " uu ", char *" out );
 .BI "void uuid_unparse_upper(uuid_t " uu ", char *" out );
 .BI "void uuid_unparse_lower(uuid_t " uu ", char *" out );
+.BI "void uuid_unparse_formatted(uuid_t " uu ", char *" out ", int " flags );
 .fi
 .SH DESCRIPTION
 The
@@ -60,6 +61,26 @@ hex digits is important then the functions
 and
 .B uuid_unparse_lower
 may be used.
+.PP
+The
+.B uuid_unparse_formatted
+function allows for finer-grained unparsing that what is otherwise available.
+.B uuid_unparse, uuid_unparse_upper,
+and
+.B uuid_unparse_lower
+are each thin wrappers around
+.B uuid_unparse_formatted.
+The flags argument is specified as a bitwise-OR of zero or more of the
+constants listed below.
+.TP
+.BR UUID_UNPARSE_UPPER " (since 2.36)"
+Use upper-case hex digits.
+.TP
+.BR UUID_UNPARSE_COMPACT " (since 2.36)"
+Skip writing the separating dashes.
+.TP
+.BR UUID_UNPARSE_DEFAULT " (since 2.36)"
+The default unparsing flags. Is system-dependent.
 .SH CONFORMING TO
 This library unparses UUIDs compatible with OSF DCE 1.1.
 .SH AUTHORS

--- a/libuuid/src/libuuid.sym
+++ b/libuuid/src/libuuid.sym
@@ -50,6 +50,7 @@ global:
 UUID_2.36 {
 global:
 	uuid_parse_range;
+	uuid_unparse_formatted;
 } UUID_2.31;
 
 

--- a/libuuid/src/unparse.c
+++ b/libuuid/src/unparse.c
@@ -39,36 +39,33 @@
 static char const hexdigits_lower[16] = "0123456789abcdef";
 static char const hexdigits_upper[16] = "0123456789ABCDEF";
 
-static void uuid_fmt(const uuid_t uuid, char *buf, char const fmt[restrict])
+void uuid_unparse_formatted(const uuid_t uu, char *out, int flags)
 {
-	char *p = buf;
+    char const *fmt = flags & UUID_UNPARSE_UPPER ?
+        hexdigits_upper : hexdigits_lower;
 
-	for (int i = 0; i < 16; i++) {
-		if (i == 4 || i == 6 || i == 8 || i == 10) {
-			*p++ = '-';
-		}
-		size_t tmp = uuid[i];
-		*p++ = fmt[tmp >> 4];
-		*p++ = fmt[tmp & 15];
-	}
-	*p = '\0';
+    for (int i = 0; i < 16; i++) {
+        if (i == 4 || i == 6 || i == 8 || i == 10)
+            *out++ = '-';
+
+        size_t tmp = uu[i];
+        *out++ = fmt[tmp >> 4];
+        *out++ = fmt[tmp & 15];
+    }
+    *out = '\0';
 }
 
 void uuid_unparse_lower(const uuid_t uu, char *out)
 {
-	uuid_fmt(uu, out, hexdigits_lower);
+    uuid_unparse_f(uu, out, 0);
 }
 
 void uuid_unparse_upper(const uuid_t uu, char *out)
 {
-	uuid_fmt(uu, out, hexdigits_upper);
+    uuid_unparse_formatted(uu, out, UUID_UNPARSE_UPPER);
 }
 
 void uuid_unparse(const uuid_t uu, char *out)
 {
-#ifdef UUID_UNPARSE_DEFAULT_UPPER
-	uuid_fmt(uu, out, hexdigits_upper);
-#else
-	uuid_fmt(uu, out, hexdigits_lower);
-#endif
+    uuid_unparse_formatted(uu, out, UUID_UNPARSE_DEFAULT);
 }

--- a/libuuid/src/unparse.c
+++ b/libuuid/src/unparse.c
@@ -45,7 +45,8 @@ void uuid_unparse_formatted(const uuid_t uu, char *out, int flags)
         hexdigits_upper : hexdigits_lower;
 
     for (int i = 0; i < 16; i++) {
-        if (i == 4 || i == 6 || i == 8 || i == 10)
+        if (!(flags & UUID_UNPARSE_COMPACT) &&
+            (i == 4 || i == 6 || i == 8 || i == 10))
             *out++ = '-';
 
         size_t tmp = uu[i];

--- a/libuuid/src/uuid.h
+++ b/libuuid/src/uuid.h
@@ -68,6 +68,8 @@ typedef unsigned char uuid_t[16];
 enum {
     /* Use uppercase hex digits */
     UUID_UNPARSE_UPPER   = (1 << 0),
+    /* Don't use dashes */
+    UUID_UNPARSE_COMPACT = (1 << 1),
 #ifdef UUID_UNPARSE_DEFAULT_UPPER
     UUID_UNPARSE_DEFAULT = UUID_UNPARSE_UPPER,
 #else

--- a/libuuid/src/uuid.h
+++ b/libuuid/src/uuid.h
@@ -64,6 +64,17 @@ typedef unsigned char uuid_t[16];
 
 #define UUID_STR_LEN	37
 
+/* Unparsing flags */
+enum {
+    /* Use uppercase hex digits */
+    UUID_UNPARSE_UPPER   = (1 << 0),
+#ifdef UUID_UNPARSE_DEFAULT_UPPER
+    UUID_UNPARSE_DEFAULT = UUID_UNPARSE_UPPER,
+#else
+    UUID_UNPARSE_DEFAULT = 0,
+#endif
+};
+
 /* Allow UUID constants to be defined */
 #ifdef __GNUC__
 #define UUID_DEFINE(name,u0,u1,u2,u3,u4,u5,u6,u7,u8,u9,u10,u11,u12,u13,u14,u15) \
@@ -106,6 +117,7 @@ extern int uuid_parse_range(const char *in_start, const char *in_end, uuid_t uu)
 extern void uuid_unparse(const uuid_t uu, char *out);
 extern void uuid_unparse_lower(const uuid_t uu, char *out);
 extern void uuid_unparse_upper(const uuid_t uu, char *out);
+extern void uuid_unparse_formatted(const uuid_t uu, char *out, int flags);
 
 /* uuid_time.c */
 extern time_t uuid_time(const uuid_t uu, struct timeval *ret_tv);


### PR DESCRIPTION
Not entirely sure if this belongs in `libuuid`, but here it is anyway.