### PR TITLE
Manual page: fdisk.8: fix typo

### DIFF
--- a/disk-utils/fdisk.8
+++ b/disk-utils/fdisk.8
@@ -149,7 +149,7 @@ before a new partition table is created.  See also
 command.
 
 .TP
-\fB\-W\fR, \fB\-\-wipe-partition\fR \fIwhen\fR
+\fB\-W\fR, \fB\-\-wipe-partitions\fR \fIwhen\fR
 Wipe filesystem, RAID and partition-table signatures from a newly created
 partitions, in order to avoid possible collisions.  The argument \fIwhen\fR can
 be \fBauto\fR, \fBnever\fR or \fBalways\fR.  When this option is not given, the


### PR DESCRIPTION
It seems that "--wipe-partitions" is correct, not "--wipe-partition".

Signed-off-by: Shigeki Morishima <s.morishima@jp.fujitsu.com>