### PR TITLE
tests: add BE:8192 checksum to cramfs/mkfs, fixing the warning

### DIFF
--- a/tests/ts/cramfs/mkfs
+++ b/tests/ts/cramfs/mkfs
@@ -42,6 +42,7 @@ case "${BYTE_ORDER}:${PAGE_SIZE}" in
 	LE:4096) MD5_EXP="a6667acb1cb0685d9eb5b9cd3724766c" ;;
 	LE:65536) MD5_EXP="b60133682603b0118592b55f1dba017c" ;;
 	BE:4096) MD5_EXP="eaf05031dc8ec97c91ba5c773635cc89" ;;
+	BE:8192) MD5_EXP="5859f87b185b1187fca3b2b00c809c03" ;;
 	BE:65536) MD5_EXP="5859f87b185b1187fca3b2b00c809c03" ;;
 	*) echo "warning ${TS_NS}: unknown checksum" \
 	        "for ${BYTE_ORDER}:${PAGE_SIZE}"


### PR DESCRIPTION
Fix cramfs/mkfs test warning on sparc64 / big-endian arch with pagesize 8192 by adding checksum for `BE:8192`

before the patch:
```
tests/ts/cramfs# ./mkfs 
       cramfs: mkfs checksums                 ...warning cramfs/mkfs: unknown checksum for BE:8192
 OK
```

after the patch:
```
tests/ts/cramfs# ./mkfs
       cramfs: mkfs checksums                 ... OK
```