### PR TITLE
col: fix output when first line does not have newline character

### DIFF
--- a/tests/expected/col/newlines
+++ b/tests/expected/col/newlines
@@ -1,0 +1,11 @@
+zero length file
+one line no nl
+1
+one line with nl
+1
+second line no nl
+1
+2
+second line with nl
+1
+2

--- a/tests/ts/col/newlines
+++ b/tests/ts/col/newlines
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2020 Sami Kerola <kerolasa@iki.fi>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="newline handling"
+
+. $TS_TOPDIR/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_COL"
+
+ts_log "zero length file"
+printf "" | $TS_CMD_COL >> $TS_OUTPUT 2>> $TS_ERRLOG
+
+ts_log "one line no nl"
+printf "1" | $TS_CMD_COL >> $TS_OUTPUT 2>> $TS_ERRLOG
+
+ts_log "one line with nl"
+printf "1\n" | $TS_CMD_COL >> $TS_OUTPUT 2>> $TS_ERRLOG
+
+ts_log "second line no nl"
+printf "1\n2" | $TS_CMD_COL >> $TS_OUTPUT 2>> $TS_ERRLOG
+
+ts_log "second line with nl"
+printf "1\n2\n" | $TS_CMD_COL >> $TS_OUTPUT 2>> $TS_ERRLOG
+
+ts_finalize

--- a/text-utils/col.c
+++ b/text-utils/col.c
@@ -396,7 +396,7 @@ int main(int argc, char **argv)
 	/* goto the last line that had a character on it */
 	for (; l->l_next; l = l->l_next)
 		this_line++;
-	if (max_line == 0)
+	if (max_line == 0 && cur_col == 0)
 		return EXIT_SUCCESS;	/* no lines, so just exit */
 	flush_lines(this_line - nflushd_lines + extra_lines + 1);
 


### PR DESCRIPTION
Commit I made while back and has been part of util-linux v2.30 to v2.35 made
col(1) not to output anything when first line did not have newline character.

    printf "gone from output" | col

This commit fixes the issue.  Admittedly the col source code is unnecessarily
hard to work with.  It could be a good idea to refactor the col(1) as low
priority task, Assuming refactoring is done the first commit to get that done
should add tests that exhaust all possible input handling including all command
line option directives.

Addresses: https://github.com/karelzak/util-linux/issues/422
Fixes: b6b5272b03ea9d3fa15601801d4d0f76ea4440f1
Signed-off-by: Sami Kerola <kerolasa@iki.fi>