### PR TITLE
travis: switch to Bionic

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -130,7 +130,9 @@ function travis_install_script
 	fi
 
 	# install required packages
+	sudo bash -c "echo 'deb-src http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted universe multiverse' >>/etc/apt/sources.list"
 	sudo apt-get -qq update --fix-missing
+	sudo apt-get build-dep -y util-linux
 	sudo apt-get install -qq >/dev/null \
 		bc \
 		btrfs-tools \

--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -132,6 +132,7 @@ function travis_install_script
 
 	# install required packages
 	sudo bash -c "echo 'deb-src http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted universe multiverse' >>/etc/apt/sources.list"
+	sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 	sudo apt-get -qq update --fix-missing
 	sudo apt-get build-dep -y util-linux
 	sudo apt-get install -qq >/dev/null \
@@ -147,6 +148,8 @@ function travis_install_script
 		ntp \
 		socat \
 		|| return
+
+	sudo apt-get install -y gcc-10
 
 	# install only if available (e.g. Ubuntu Trusty)
 	sudo apt-get install -qq >/dev/null \

--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -125,19 +125,30 @@ function check_dist
 
 function travis_install_script
 {
+	local ubuntu_release=$(lsb_release -cs)
+	local additional_packages=()
+	local clang_version gcc_version
+
 	if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 		osx_install_script
 		return
 	fi
 
 	# install required packages
-	sudo bash -c "echo 'deb-src http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted universe multiverse' >>/etc/apt/sources.list"
+	sudo bash -c "echo 'deb-src http://archive.ubuntu.com/ubuntu/ $ubuntu_release main restricted universe multiverse' >>/etc/apt/sources.list"
 
-	# the following snippet was borrowed from https://apt.llvm.org/llvm.sh
-	wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-	add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -cs)/   llvm-toolchain-$(lsb_release -cs)-10  main"
+	if [[ "$CC" =~ ^clang-([0-9]+)$ ]]; then
+		clang_version=${BASH_REMATCH[1]}
+		# the following snippet was borrowed from https://apt.llvm.org/llvm.sh
+		wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+		sudo add-apt-repository -y "deb http://apt.llvm.org/$ubuntu_release/   llvm-toolchain-$ubuntu_release-$clang_version  main"
+		additional_packages+=(clang-$clang_version)
+	elif [[ "$CC" =~ ^gcc-([0-9]+)$ ]]; then
+		gcc_version=${BASH_REMATCH[1]}
+		sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+		additional_packages+=(gcc-$gcc_version)
+	fi
 
-	sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 	sudo apt-get -qq update --fix-missing
 	sudo apt-get build-dep -y util-linux
 	sudo apt-get install -qq >/dev/null \
@@ -152,10 +163,8 @@ function travis_install_script
 		mdadm \
 		ntp \
 		socat \
+		"${additional_packages[@]}" \
 		|| return
-
-	sudo apt-get install -y gcc-10
-	sudo apt-get install -y clang-10
 
 	# install only if available (e.g. Ubuntu Trusty)
 	sudo apt-get install -qq >/dev/null \

--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -132,6 +132,11 @@ function travis_install_script
 
 	# install required packages
 	sudo bash -c "echo 'deb-src http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted universe multiverse' >>/etc/apt/sources.list"
+
+	# the following snippet was borrowed from https://apt.llvm.org/llvm.sh
+	wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+	add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -cs)/   llvm-toolchain-$(lsb_release -cs)-10  main"
+
 	sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 	sudo apt-get -qq update --fix-missing
 	sudo apt-get build-dep -y util-linux
@@ -150,6 +155,7 @@ function travis_install_script
 		|| return
 
 	sudo apt-get install -y gcc-10
+	sudo apt-get install -y clang-10
 
 	# install only if available (e.g. Ubuntu Trusty)
 	sudo apt-get install -qq >/dev/null \

--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -53,7 +53,8 @@ function xconfigure
 function make_checkusage
 {
 	local tmp
-	if ! tmp=$($MAKE checkusage 2>&1) || test -n "$tmp"; then
+	# memory leaks are ignored here. See https://github.com/karelzak/util-linux/issues/1077
+	if ! tmp=$(ASAN_OPTIONS="$ASAN_OPTIONS:detect_leaks=0" $MAKE checkusage 2>&1) || test -n "$tmp"; then
 		echo "$tmp"
 		echo "make checkusage failed" >&2
 		return 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ git:
 
 compiler:
   - gcc-10
-  - clang
+  - clang-10
 
 env:
   - MAKE_CHECK="nonroot"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 
 sudo: required
-dist: trusty
+dist: bionic
 
 git:
   depth: 1500

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ git:
   depth: 1500
 
 compiler:
-  - gcc
+  - gcc-10
   - clang
 
 env:


### PR DESCRIPTION
To judge from fc412fe4cee960, back in 2016 it was the latest version
of Ubuntu available on Travis CI. Now build tools there are too old
for testing purposes.

Other than that, Ubuntu Trusty hasn't been supported at https://apt.llvm.org/
since August 2019, which makes it kind of hard at this point to bring the latest clang
along with ASan, UBsan, Msan and libFuzzer to Travis CI.