### PR TITLE
irqtop/lsirq: support softirq

### DIFF
--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -188,6 +188,7 @@
 
 /* irqtop paths */
 #define _PATH_PROC_INTERRUPTS	"/proc/interrupts"
+#define _PATH_PROC_SOFTIRQS	"/proc/softirqs"
 #define _PATH_PROC_UPTIME	"/proc/uptime"
 
 /* kernel command line */

--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -195,7 +195,7 @@ static char *remove_repeated_spaces(char *str)
 /*
  * irqinfo - parse the system's interrupts
  */
-static struct irq_stat *get_irqinfo(void)
+static struct irq_stat *get_irqinfo(int softirq)
 {
 	FILE *irqfile;
 	char *line = NULL, *tmp;
@@ -209,7 +209,10 @@ static struct irq_stat *get_irqinfo(void)
 	stat->irq_info = xmalloc(sizeof(*stat->irq_info) * IRQ_INFO_LEN);
 	stat->nr_irq_info = IRQ_INFO_LEN;
 
-	irqfile = fopen(_PATH_PROC_INTERRUPTS, "r");
+	if (softirq)
+		irqfile = fopen(_PATH_PROC_SOFTIRQS, "r");
+	else
+		irqfile = fopen(_PATH_PROC_INTERRUPTS, "r");
 	if (!irqfile) {
 		warn(_("cannot open %s"), _PATH_PROC_INTERRUPTS);
 		goto free_stat;
@@ -368,7 +371,8 @@ void set_sort_func_by_key(struct irq_output *out, char c)
 
 struct libscols_table *get_scols_table(struct irq_output *out,
 					      struct irq_stat *prev,
-					      struct irq_stat **xstat)
+					      struct irq_stat **xstat,
+					      int softirq)
 {
 	struct libscols_table *table;
 	struct irq_info *result;
@@ -377,7 +381,7 @@ struct libscols_table *get_scols_table(struct irq_output *out,
 	size_t i;
 
 	/* the stats */
-	stat = get_irqinfo();
+	stat = get_irqinfo(softirq);
 	if (!stat)
 		return NULL;
 

--- a/sys-utils/irq-common.h
+++ b/sys-utils/irq-common.h
@@ -56,6 +56,7 @@ void set_sort_func_by_key(struct irq_output *out, const char c);
 
 struct libscols_table *get_scols_table(struct irq_output *out,
                                               struct irq_stat *prev,
-                                              struct irq_stat **xstat);
+                                              struct irq_stat **xstat,
+                                              int softirq);
 
 #endif /* UTIL_LINUX_H_IRQ_COMMON */

--- a/sys-utils/irqtop.1
+++ b/sys-utils/irqtop.1
@@ -33,6 +33,9 @@ Specify sort criteria by column name.  See
 output to get column names.  The sort criteria may be changes in interactive
 mode.
 .TP
+.BR \-S , " \-\-softirq "
+Show softirqs information.
+.TP
 .BR \-V ", " \-\-version
 Display version information and exit.
 .TP

--- a/sys-utils/irqtop.c
+++ b/sys-utils/irqtop.c
@@ -294,8 +294,7 @@ static void parse_args(	struct irqtop_ctl *ctl,
 		out->columns[out->ncolumns++] = COL_IRQ;
 		out->columns[out->ncolumns++] = COL_TOTAL;
 		out->columns[out->ncolumns++] = COL_DELTA;
-		if (!ctl->softirq)
-			out->columns[out->ncolumns++] = COL_NAME;
+		out->columns[out->ncolumns++] = COL_NAME;
 	}
 
 	/* add -o [+]<list> to putput */

--- a/sys-utils/lsirq.1
+++ b/sys-utils/lsirq.1
@@ -35,6 +35,9 @@ Use JSON output format.
 Produce output in the form of key="value" pairs.  All potentially unsafe characters
 are hex-escaped (\\x<code>).
 .TP
+.BR \-S , " \-\-softirq "
+Show softirqs information.
+.TP
 .BR \-V ", " \-\-version
 Display version information and exit.
 .TP

--- a/sys-utils/lsirq.c
+++ b/sys-utils/lsirq.c
@@ -138,8 +138,7 @@ int main(int argc, char **argv)
 	if (!out.ncolumns) {
 		out.columns[out.ncolumns++] = COL_IRQ;
 		out.columns[out.ncolumns++] = COL_TOTAL;
-		if (!softirq)
-			out.columns[out.ncolumns++] = COL_NAME;
+		out.columns[out.ncolumns++] = COL_NAME;
 	}
 
 	/* add -o [+]<list> to putput */


### PR DESCRIPTION
Add '-S' or '--softirq' for irqtop/lsirq, instead of interrupts, show
softirqs infomation. Because there is no more description of softirq,
do not show 'NAME' column by default.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>