### PR TITLE
unshare --fork: Ignore SIGINT and SIGTERM in parent

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -555,6 +555,9 @@ int main(int argc, char *argv[])
 		settime(monotonic, CLOCK_MONOTONIC);
 
 	if (forkit) {
+		signal(SIGINT, SIG_IGN);
+		signal(SIGTERM, SIG_IGN);
+
 		/* force child forking before mountspace binding
 		 * so pid_for_children is populated */
 		pid = fork();
@@ -602,6 +605,10 @@ int main(int argc, char *argv[])
 	if (pid) {
 		if (waitpid(pid, &status, 0) == -1)
 			err(EXIT_FAILURE, _("waitpid failed"));
+
+		signal(SIGINT, SIG_DFL);
+		signal(SIGTERM, SIG_DFL);
+
 		if (WIFEXITED(status))
 			return WEXITSTATUS(status);
 		if (WIFSIGNALED(status))


### PR DESCRIPTION
Fixes #1086.

Tested by running [mkosi](https://github.com/systemd/mkosi.git) with a modified version of pacstrap that uses the unshare command with the changes from this PR. Before, sending SIGINT to the pacstrap process group caused mkosi's cleanup to fail with EBUSY when unmounting because pacman (started by pacstrap via unshare --fork --pid) was still running after unshare exited.

With these changes, the mkosi cleanup succeeds because unshare waits for pacman to exit. A side effect is that pacman receives the SIGINT signal twice (once via SIGINT sent to the process group and once via unshare itself). We could not forward signals but then sending SIGINT/SIGTERM to unshare only wouldn't work because the child process wouldn't receive the signal.