### PR TITLE
Revert "libmount: (parser) fix memory leak on error before end-of-file"

### DIFF
--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -39,7 +39,7 @@ struct libmnt_fs *mnt_new_fs(void)
 
 	fs->refcount = 1;
 	INIT_LIST_HEAD(&fs->ents);
-	DBG(FS, ul_debugobj(fs, "alloc"));
+	/*DBG(FS, ul_debugobj(fs, "alloc"));*/
 	return fs;
 }
 


### PR DESCRIPTION
This reverts commit fe0d12d4f82269096f8d0cffc51ca9590814c284.

just to make sure CIFuzz can catch it