### PR TITLE
Fix stack overflow when ut_line is not NULL terminated.

### DIFF
--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -627,7 +627,7 @@ static int is_phantom(const struct last_control *ctl, struct utmpx *ut)
 	} else {
 		struct stat st;
 
-		sprintf(path, "/dev/%s", ut->ut_line);
+		snprintf(path, sizeof(ut->ut_line)+6, "/dev/%s", ut->ut_line);
 		if (stat(path, &st))
 			return 1;
 		if (pw->pw_uid != st.st_uid)


### PR DESCRIPTION
Issue:
utmpx->ut_line may not be NULL terminated when read. This allows sprintf to copy beyond ut_line and corrupt the stack. This allows for arbitrary code execution at the same privilege as the executing user on configurations where other mitigation may not be present.

Solution:
Use snprintf to NULL terminate the copy of ut_line to sizeof(ut_line) + 6 ('/dev/'+NULL).

Discovered with AFL