### PR TITLE
Make scriptreplay set terminal to raw mode

### DIFF
--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <sys/time.h>
+#include <termios.h>
 
 #include "c.h"
 #include "xalloc.h"
@@ -120,11 +121,29 @@ static void appendchr(char *buf, size_t bufsz, int c)
 		buf[sz] = c;
 }
 
+static int termraw(struct termios *backup)
+{
+	struct termios tattr;
+
+	if (tcgetattr(STDOUT_FILENO, backup) != 0)
+		return -1;
+
+	tattr = *backup;
+	cfmakeraw(&tattr);
+	if (tcsetattr(STDOUT_FILENO, TCSANOW, &tattr) != 0)
+		return -1;
+
+	return 0;
+}
+
 int
 main(int argc, char *argv[])
 {
 	static const struct timeval mindelay = { .tv_sec = 0, .tv_usec = 100 };
 	struct timeval maxdelay;
+
+	char isterm;
+	struct termios saved;
 
 	struct replay_setup *setup = NULL;
 	struct replay_step *step = NULL;
@@ -286,6 +305,10 @@ main(int argc, char *argv[])
 		replay_set_delay_max(setup, &maxdelay);
 	replay_set_delay_min(setup, &mindelay);
 
+	isterm = isatty(STDOUT_FILENO);
+	if (isterm && termraw(&saved) != 0)
+		err(EXIT_FAILURE, _("failed to set terminal to raw mode"));
+
 	do {
 		rc = replay_get_next_step(setup, streams, &step);
 		if (rc)
@@ -299,6 +322,9 @@ main(int argc, char *argv[])
 		}
 		rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
 	} while (rc == 0);
+
+	if (isterm)
+		tcsetattr(STDOUT_FILENO, TCSADRAIN, &saved);
 
 	if (step && rc < 0)
 		err(EXIT_FAILURE, _("%s: log file error"), replay_step_get_filename(step));


### PR DESCRIPTION
scriptreplay produces garbled output while replaying certain curses
sessions. script(1) from util-linux is able to record the sessions
correctly.

The following programs can be used to demonstrate this.

1. A curses-based game called "greed"; a Debian 10 package named
"greed" is available.

2. This Python implementation of Conway's game of life: https://github.com/iiSeymour/game-of-life

Expected output is obtained by making scriptreplay call cfmakeraw.

An almost identical message was also sent to the official mailing list for
convenience of the maintainer.