### PR TITLE
travis: integrate util-linux with Coverity Scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,13 @@ env:
   - MAKE_CHECK="root"
   - MAKE_CHECK="dist"
 
-matrix:
+stages:
+  - name: Coverity
+    if: type = cron
+  - name: Test
+    if: type != cron
+
+jobs:
   include:
     # test old Ubuntu 12.04 and OSX for compatibility
     - dist: precise
@@ -34,6 +40,11 @@ matrix:
     - arch: s390x
       compiler: gcc-10
       env: MAKE_CHECK="root"
+    - stage: Coverity
+      compiler: gcc
+      env:
+        # Generated with `travis encrypt -r karelzak/util-linux COVERITY_SCAN_TOKEN=***`
+        - secure: cqwhidkCY+BckuBwmBevstLCHJm9aS2pQnYB3xGiz9JeqwW/x5h9pMElQdTFWw3AD2p5DzKzuW9nUtqNVzMSUWdPBrQGeuBT5tJW5eFeP/9mb5CG1/+w5xzOaZ/+3CK0gtcMSyRhGl2NeuLlimj6hzy37cUTSmBVHzGMZLD51As=
 
 branches:
   only:

--- a/Documentation/howto-tests.txt
+++ b/Documentation/howto-tests.txt
@@ -128,3 +128,11 @@ Travis CI - automatically executed for all github commits.
 lgtm CI - automatically executed security code analysis
 
     URL: https://lgtm.com/projects/g/karelzak/util-linux/
+
+Coverity Scan
+
+    URL: https://scan.coverity.com/projects/karelzak-util-linux
+
+Fossies codespell report
+
+    URL: https://fossies.org/linux/test/util-linux-master.tar.gz/codespell.html


### PR DESCRIPTION
For this to work, a daily cron job running on the master branch should be added: https://docs.travis-ci.com/user/cron-jobs/

The report can be found at https://scan.coverity.com/projects/karelzak-util-linux