### PR TITLE
rename: tests: add more symlink checks

### DIFF
--- a/tests/expected/rename/symlink
+++ b/tests/expected/rename/symlink
@@ -1,3 +1,7 @@
 rename_slink.1: `old' -> `new'
 rename_slink.2: `old' -> `new'
 rename_slink.3: `old' -> `new'
+`rename_slink.1' -> `rename_symlink.1'
+target
+`rename_slink.2' -> `rename_symlink.2'
+target

--- a/tests/expected/rename/symlink.err
+++ b/tests/expected/rename/symlink.err
@@ -1,0 +1,1 @@
+rename: rename_slink.3: No such file or directory

--- a/tests/ts/rename/symlink
+++ b/tests/ts/rename/symlink
@@ -38,4 +38,20 @@ for i in rename_slink.{1..3}; do
 	rm -f $i
 done
 
+touch target
+ln -s target rename_slink.1
+$TS_CMD_RENAME -v slink symlink rename_slink.1 >> $TS_OUTPUT 2>> $TS_ERRLOG
+readlink rename_symlink.1 >> $TS_OUTPUT 2>> $TS_ERRLOG
+rm -f rename_slink.1 rename_symlink.1
+
+rm target
+ln -s target rename_slink.2
+$TS_CMD_RENAME -v slink symlink rename_slink.2 >> $TS_OUTPUT 2>> $TS_ERRLOG
+readlink rename_symlink.2 >> $TS_OUTPUT 2>> $TS_ERRLOG
+rm -f rename_slink.2 rename_symlink.2
+
+$TS_CMD_RENAME -v slink symlink rename_slink.3 >> $TS_OUTPUT 2>> $TS_ERRLOG
+# The error may differ on Mac OS X due to faccessat()/lstat(); normalize it.
+sed -i -e 's/\(rename_slink.3\): not accessible/\1/' -e 's/stat of \(rename_slink.3\) failed/\1/' $TS_ERRLOG
+
 ts_finalize


### PR DESCRIPTION
Add a few checks to the symlink test, including for the fix
in commit 477239ce0d60 ("rename: fix regression for symlink
with non-existing target").

Tested with `./tests/run.sh rename/symlink` before/after that
commit with FAILED/OK results (and `--show-diff`) as expected:

After:
`       rename: symlink check                  ... OK`

Before:
`       rename: symlink check                  ... FAILED (rename/symlink)`

With `--show-diff`:
```
    diff-{{{
    --- /home/mfo/git/util-linux/tests/expected/rename/symlink	2020-07-14 15:21:06.412792160 -0300
    +++ /home/mfo/git/util-linux/tests/output/rename/symlink	2020-07-14 15:45:10.980927233 -0300
    @@ -3,5 +3,3 @@
     rename_slink.3: `old' -> `new'
     `rename_slink.1' -> `rename_symlink.1'
     target
    -`rename_slink.2' -> `rename_symlink.2'
    -target
    }}}-diff

    diff-{{{
    --- /home/mfo/git/util-linux/tests/expected/rename/symlink.err	2020-07-14 15:37:42.466207786 -0300
    +++ /home/mfo/git/util-linux/tests/output/rename/symlink.err	2020-07-14 15:45:10.984927251 -0300
    @@ -1 +1,2 @@
    +rename: rename_slink.2: not accessible: No such file or directory
     rename: rename_slink.3: No such file or directory
    }}}-diff
```
Signed-off-by: Mauricio Faria de Oliveira <mfo@canonical.com>