### PR TITLE
fix minor typo: yourbranch -> yourgit

### DIFF
--- a/Documentation/howto-pull-request.txt
+++ b/Documentation/howto-pull-request.txt
@@ -43,7 +43,7 @@ is needed to stay up to date with upstream.
 git checkout master
 git branch textual
 # spent here most of the effort
-git push yourbranch textual:textual
+git push yourgit textual:textual
 
 5. Do not worry if you used stupid-and-wrong branch name, it can be fixed
 before submission.


### PR DESCRIPTION
Changes

git push yourbranch textual:textual

to

git push yourgit textual:textual

in root/Documentation/howto-pull-request.txt

Reason: The remote was defined as "yourgit", but one command uses the expression "yourbranch".
The latter expression was not used anywhere else in the document.