### PR TITLE
Fix terminal special character handling in scriptreplay

### DIFF
--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -130,6 +130,7 @@ static int termraw(struct termios *backup)
 
 	tattr = *backup;
 	cfmakeraw(&tattr);
+	tattr.c_lflag |= ISIG;
 	if (tcsetattr(STDOUT_FILENO, TCSANOW, &tattr) != 0)
 		return -1;
 


### PR DESCRIPTION
Making scriptreplay call cfmakeraw fixed the output thereof, but it disabled terminal special character handling. For example, Ctrl-C does not send SIGINT to scriptreplay anymore; this is inconvenient. The following fixes this.

tattr.c_lflag |= ISIG;

where tattr is the struct termios with which we are working.