### PR TITLE
build-system: stop looking for %ms and %as

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -17,7 +17,7 @@ jobs:
    strategy:
      fail-fast: false
      matrix:
-       sanitizer: [address, undefined]
+       sanitizer: [address, undefined, memory]
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build

--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -256,6 +256,7 @@ function osx_install_script
 	OSX_CONFOPTS="
 		--disable-ipcrm \
 		--disable-ipcs \
+		--disable-libmount \
 	"
 
 	# workaround: glibtoolize could not find sed

--- a/configure.ac
+++ b/configure.ac
@@ -694,69 +694,6 @@ AS_CASE([$enable_all_programs],
 
 AX_CHECK_TLS
 
-AC_DEFUN([UL_SCANF_TYPE_MODIFIER], [dnl
-# include <stdio.h>
-# include <stdlib.h>
-int main()
-{
-	int i;
-	int rc = 1;
-	char *s;
-	i = sscanf("x", $1, &s);
-	if (i == 1  && *s == 'x')
-		rc = 0;
-	free(s);
-	return rc;
-}])
-
-AC_CACHE_VAL([scanf_cv_alloc_modifier],
-  AC_RUN_IFELSE([AC_LANG_SOURCE([UL_SCANF_TYPE_MODIFIER(["%ms"])])],
-    [scanf_cv_alloc_modifier=ms],
-    AC_RUN_IFELSE([AC_LANG_SOURCE([UL_SCANF_TYPE_MODIFIER(["%as"])])],
-      [scanf_cv_alloc_modifier=as],
-      [scanf_cv_alloc_modifier=no]
-    )
-    ,
-
-    [AC_COMPILE_IFELSE([AC_LANG_SOURCE([
-     #include <stdio.h>
-     #include <unistd.h>
-
-     #if defined(__GLIBC__) && !defined(__UCLIBC__)
-
-     #if !(__GLIBC_PREREQ(2, 7))
-     #error %m is not available
-     #endif
-
-     #elif defined(_POSIX_VERSION)
-
-     #if _POSIX_VERSION < 200809L
-     #error %m is not available
-     #endif
-
-     #else
-     #error Your C-library is not supported.
-     #endif
-     ])],
-    [scanf_cv_alloc_modifier=ms],
-    [scanf_cv_alloc_modifier=no])]
-  )
-)
-
-AC_MSG_CHECKING([scanf string alloc modifiers])
-AS_CASE([$scanf_cv_alloc_modifier],
-  [ms],
-    [AC_MSG_RESULT([(%ms) yes])
-     AC_DEFINE([HAVE_SCANF_MS_MODIFIER], [1], [scanf %ms modifier])
-     have_scanf_alloc_modifier=yes],
-  [as],
-    [AC_MSG_RESULT([(%as) yes])
-     have_scanf_alloc_modifier=yes
-     AC_DEFINE([HAVE_SCANF_AS_MODIFIER], [1], [scanf %as modifier])],
-  [AC_MSG_RESULT([no])
-   have_scanf_alloc_modifier=no]
-)
-
 have_pty=no
 AC_ARG_WITH([util], AS_HELP_STRING([--without-util], [compile without libutil]),
   [], [with_util=auto]
@@ -1131,7 +1068,6 @@ AC_ARG_ENABLE([libmount],
 )
 UL_BUILD_INIT([libmount])
 UL_REQUIRES_BUILD([libmount], [libblkid])
-UL_REQUIRES_HAVE([libmount], [scanf_alloc_modifier], [scanf string alloc modifier])
 UL_REQUIRES_HAVE([libmount], [dirfd,ddfd], [dirfd or ddfd function])
 AM_CONDITIONAL([BUILD_LIBMOUNT], [test "x$build_libmount" = xyes])
 AM_CONDITIONAL([BUILD_LIBMOUNT_TESTS], [test "x$build_libmount" = xyes -a "x$enable_static" = xyes])

--- a/include/c.h
+++ b/include/c.h
@@ -378,15 +378,6 @@ static inline int xusleep(useconds_t usec)
 })
 
 /*
- * scanf modifiers for "strings allocation"
- */
-#ifdef HAVE_SCANF_MS_MODIFIER
-#define UL_SCNsA	"%ms"
-#elif defined(HAVE_SCANF_AS_MODIFIER)
-#define UL_SCNsA	"%as"
-#endif
-
-/*
  * seek stuff
  */
 #ifndef SEEK_DATA


### PR DESCRIPTION
Looks like those specifiers haven't been used since 6c9ab254aefb6ce7e0e
(where sscanf was removed) was merged. This should help to get
util-linux to compile with MSan. Currently it's failing with
```
    ...
    configure: error: libmount selected, but required scanf string alloc modifier not available
    ...
    configure:20240: ./conftest
    ==116617==WARNING: MemorySanitizer: use-of-uninitialized-value
        #0 0x496fd6 in main /home/vagrant/util-linux/conftest.c:171:6
        #1 0x7f5eb85ea1a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)
        #2 0x41c2cd in _start (/home/vagrant/util-linux/conftest+0x41c2cd)

    SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/vagrant/util-linux/conftest.c:171:6 in main
    Exiting
    configure:20240: $? = 77
    ...
    configure:20265: $? = 0
    configure:20265: ./conftest
    MemorySanitizer: bad pointer 0x000000496e60
    ==116627==MemorySanitizer CHECK failed: /builddir/build/BUILD/compiler-rt-9.0.1.src/lib/msan/../sanitizer_common/sanitizer_allocator_secondary.h:177 "((IsAligned(reinterpret_cast<uptr>(p), page_size_))) != (0)" (0x0, 0x0)
        #0 0x41d1d8 in MsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/home/vagrant/util-linux/conftest+0x41d1d8)
        #1 0x484e1e in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/home/vagrant/util-linux/conftest+0x484e1e)
        #2 0x42066c in __msan::MsanDeallocate(__sanitizer::StackTrace*, void*) (/home/vagrant/util-linux/conftest+0x42066c)
        #3 0x424bc9 in free (/home/vagrant/util-linux/conftest+0x424bc9)
        #4 0x496fae in main /home/vagrant/util-linux/conftest.c:173:2
        #5 0x7f2245f311a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)
        #6 0x41c2cd in _start (/home/vagrant/util-linux/conftest+0x41c2cd)

    configure:20265: $? = 77
    configure: program exited with status 77
    ...
    | }
    configure:22568: result: no
    configure:22926: error: libmount selected, but required scanf string alloc modifier not available
```