### PR TITLE
[PATCH] scriptreplay(1): Minor modification to tcgetattr error handling.

### DIFF
--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -128,9 +128,8 @@ setterm(struct termios *backup)
 	struct termios tattr;
 
 	if (tcgetattr(STDOUT_FILENO, backup) != 0) {
-		if (errno == EBADF)
-			err(EXIT_FAILURE, _("%d not valid fd"), STDOUT_FILENO);
-		/* errno == ENOTTY */
+		if (errno != ENOTTY) /* For debugger. */
+			err(EXIT_FAILURE, _("unexpected tcgetattr failure"));
 		return 0;
 	}
 	tattr = *backup;


### PR DESCRIPTION
Upon more testing, it was found that the way tcgetattr is called in "setterm()", it cannot fail with errno == EBADF under normal circumstances (*): scriptreplay(1) of course does not close its own stdout voluntarily mid execution.

(*) The only way I was able to force an EBADF was by using [ p close(1) ] in gdb. Therefore, the EBADF error handling is not removed by this patch, it is only changed to errno != ENOTTY.