### PR TITLE
tests: cover the code parsing comments

### DIFF
--- a/libmount/src/fuzz.c
+++ b/libmount/src/fuzz.c
@@ -17,6 +17,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         f = fmemopen((char*) data, size, "re");
         assert(f);
 
+        mnt_table_enable_comments(tb, TRUE);
         (void) mnt_table_parse_stream(tb, f, "mountinfo");
 
         mnt_unref_table(tb);


### PR DESCRIPTION
It seems to be failing with
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==13==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x00000055f428 bp 0x7ffc3743a170 sp 0x7ffc3743a080 T0)
==13==The signal is caused by a WRITE memory access.
==13==Hint: address points to the zero page.
SCARINESS: 10 (null-deref)
    #0 0x55f428 in mnt_table_parse_next /src/util-linux/libmount/src/tab_parse.c:587:6
    #1 0x55c200 in __table_parse_stream /src/util-linux/libmount/src/tab_parse.c:737:8
    #2 0x55be38 in mnt_table_parse_stream /src/util-linux/libmount/src/tab_parse.c:809:8
    #3 0x5511ff in LLVMFuzzerTestOneInput /src/util-linux/libmount/src/fuzz.c:21:16
    #4 0x458a31 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:558:15
    #5 0x458175 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:470:3
    #6 0x45a117 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:770:7
    #7 0x45a319 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:799:3
    #8 0x44a055 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:846:6
    #9 0x471bf2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:19:10
    #10 0x7fe3bd93b83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
    #11 0x41f208 in _start (/out/test_mount_fuzz+0x41f208)

DEDUP_TOKEN: mnt_table_parse_next--__table_parse_stream--mnt_table_parse_stream
```