### PR TITLE
[PATCH] script(1): Let "--echo" behavior be consistent

### DIFF
--- a/include/pty-session.h
+++ b/include/pty-session.h
@@ -81,7 +81,7 @@ struct ul_pty {
 	struct timeval	next_callback_time;
 
 	unsigned int isterm:1,		/* is stdin terminal? */
-		     slave_echo:1;	/* keep ECHO on stdin */
+		     slave_echo:1;	/* keep ECHO on pty slave */
 };
 
 void ul_pty_init_debug(int mask);

--- a/term-utils/script.1
+++ b/term-utils/script.1
@@ -91,20 +91,20 @@ the output of a program that behaves differently when its stdout is not a
 tty.
 .TP
 \fB\-E\fR, \fB\-\-echo\fR \fIwhen\fR
-This option controls the ECHO flag for the pseudoterminal within the session.
+This option controls the ECHO flag for the slave end of the session's pseudoterminal.
 The supported modes are
-.IR always ,
-.IR never ,
-or
-.IR auto .
+.IR on ,
+.IR off .
 The default is
-.I auto
--- in this case, ECHO is disabled if the current standard input is a
-terminal iin order to avoid double-echo,
-and enabled if standard input is not a terminal
+.I on
+-- in this case, ECHO is enabled for the pseudoterminal slave; if
+the current standard input is a terminal, ECHO is disabled for it
+to prevent double echo; if the current standard input is not a terminal
 (for example pipe:
 .BR "echo date | script" )
-to avoid missing input in the session log.
+then keeping ECHO enabled for the pseudoterminal slave enables the standard
+input data to be viewed on screen while being recorded to session log
+simultaneously.
 .TP
 \fB\-e\fR, \fB\-\-return\fR
 Return the exit status of the child process.  Uses the same format as bash


### PR DESCRIPTION
Currently, there are 3 peculiar behaviors when current stdin is a tty.

1. "-E never" still echoes input data. 

2. "-E always" leads to generation of unnecessary ^M symbols (carriage-return).

3. Additionally, if current stdin has ECHO turned on before script(1) is run [ this is usually the case ], "-E always" leads to double echoing.

Reason:
```
if (current stdin tty)
       turn on/off ECHO in current stdin;
else
       turn on/off ECHO in slave;
```
Fix:
```
if (current stdin tty) {
       turn on/off ECHO in slave;
       turn off ECHO in current stdin; [ cfmakeraw does this automatically ]
} else {
       turn on/off ECHO in slave;
}
```
Keeping in mind the original purpose of "--echo" [ commit 1eee1acb245a8b724e441778dfa9b858465bf7e5 ], behavior is unchanged when current stdin is not a tty.

Now only two args for -E make sense, so they were changed from always/never/auto to on/off with "on" as default. Now, "-E off" never shows input data and "-E on" always does. This makes the option slightly more user-friendly [ opinion ].

Note: with stdin a tty, "-E off" now does not even echo newlines.