### PR TITLE
hwclock: fix SYS_settimeofday fallback

### DIFF
--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -675,8 +675,12 @@ display_time(struct timeval hwctime)
  */
 #define __set_time(_tv)		settimeofday(_tv, NULL)
 
-#if !defined(SYS_settimeofday) && defined(__NR_settimeofday)
-# define SYS_settimeofday	__NR_settimeofday
+#ifndef SYS_settimeofday
+# ifdef __NR_settimeofday
+#  define SYS_settimeofday	__NR_settimeofday
+# else
+#  define SYS_settimeofday	__NR_settimeofday_time32
+# endif
 #endif
 
 static inline int __set_timezone(const struct timezone *tz)


### PR DESCRIPTION
turns out this is subtly broken. musl 1.2.x for 64-bit architectures defines __NR_settimeofday but not
for 32-bit ones. For 32-bit, it defines a _time32 variant.