### PR TITLE
tests: mkfs-endianness test use iflag=fullblock to fill block complet…

### DIFF
--- a/tests/ts/cramfs/mkfs-endianness
+++ b/tests/ts/cramfs/mkfs-endianness
@@ -45,9 +45,9 @@ test_image() {
 rm -rf "$IMAGE_DATA"
 mkdir -p $IMAGE_DATA/dirA/dirB
 yes "Testing cramfs 1234567890 Endianness check 1234567890 Endianness check" \
-	| dd of=$IMAGE_DATA/dirA/dirB/a bs=512 count=1 &> /dev/null
+	| dd of=$IMAGE_DATA/dirA/dirB/a iflag=fullblock bs=512 count=1 &> /dev/null
 yes "Testing cramfs 1234567890 Endianness check 1234567890 Endianness check" \
-	| dd of=$IMAGE_DATA/dirA/dirB/b bs=512 count=30 &> /dev/null
+	| dd of=$IMAGE_DATA/dirA/dirB/b iflag=fullblock bs=512 count=30 &> /dev/null
 # sudo may use whatever group
 chgrp -R 0 $IMAGE_DATA
 


### PR DESCRIPTION
When run mkfs-endianness test on lowend machine, sometimes dd didn't
fill block with string then test failed.
So, it's nice to add iflag=fullblock option to fill a block with
string read from stdin.

Tested on Raspberry Pi 3 B+(using 1core to simulate lowend environment)
 with iflag=fullblock option didn't get test failure.

Without iflag=fullblock option.
```
$ sudo sh -c 'for i in $(seq 1 500); do taskset -c 0 ./ts/cramfs/mkfs-endianness ;  done' | grep FAILED | wc -l
49
```

With iflag=fullblock option.
```
$ sudo sh -c 'for i in $(seq 1 500); do taskset -c 0 ./ts/cramfs/mkfs-endianness ;  done' | grep FAILED | wc -l
0
```