### PR TITLE
mount: Add support for "nosymfollow" mount option.

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -422,6 +422,8 @@ static int generate_helper_optstr(struct libmnt_context *cxt, char **optstr)
 			mnt_optstr_append_option(optstr, "suid", NULL);
 		if (!(cxt->mountflags & MS_NODEV))
 			mnt_optstr_append_option(optstr, "dev", NULL);
+		if (!(cxt->mountflags & MS_NOSYMFOLLOW))
+			mnt_optstr_append_option(optstr, "symfollow", NULL);
 	}
 
 

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -941,6 +941,9 @@ extern int mnt_context_set_syscall_status(struct libmnt_context *cxt, int status
 #ifndef MS_DIRSYNC
 #define MS_DIRSYNC	128	/* Directory modifications are synchronous */
 #endif
+#ifndef MS_NOSYMFOLLOW
+#define MS_NOSYMFOLLOW	256	/* Don't follow symlinks */
+#endif
 #ifndef MS_NOATIME
 #define MS_NOATIME	0x400	/* 1024: Do not update access times. */
 #endif

--- a/libmount/src/optmap.c
+++ b/libmount/src/optmap.c
@@ -132,6 +132,10 @@ static const struct libmnt_optmap linux_flags_map[] =
    { "shared",      MS_SHARED,              MNT_NOHLPS | MNT_NOMTAB }, /* Shared */
    { "rshared",     MS_SHARED | MS_REC,     MNT_NOHLPS | MNT_NOMTAB },
 #endif
+#ifdef MS_NOSYMFOLLOW
+   { "symfollow", MS_NOSYMFOLLOW, MNT_INVERT }, /* Don't follow symlinks */
+   { "nosymfollow", MS_NOSYMFOLLOW },
+#endif
    { NULL, 0, 0 }
 };
 

--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -1472,6 +1472,16 @@ specifies the filesystem access mode used for
 in octal notation.  The default mode is 0755.  This functionality is supported
 only for root users or when mount executed without suid permissions.  The option
 is also supported as x-mount.mkdir, this notation is deprecated since v2.30.
+.TP
+.B nosymfollow
+Do not follow symlinks when resolving paths.  Symlinks can still be created,
+and
+.BR readlink (1),
+.BR readlink (2),
+.BR realpath (1)
+and
+.BR realpath (3)
+all still work properly.
 
 .SH FILESYSTEM-SPECIFIC MOUNT OPTIONS
 This section lists options that are specific to particular filesystems.


### PR DESCRIPTION
This adds support for the "nosymfollow" mount option, which indicates
that symlinks should not be traversed on the mount this option is
applied to.  Also update the mount(8) man page with information about
this option.

Signed-off-by: Mattias Nissler <mnissler@chromium.org>
Signed-off-by: Ross Zwisler <zwisler@google.com>