### PR TITLE
 When the query disk fails, reset cxt->dev_fd.

### DIFF
--- a/libfdisk/src/context.c
+++ b/libfdisk/src/context.c
@@ -636,6 +636,7 @@ static int fdisk_assign_fd(struct fdisk_context *cxt, int fd,
 fail:
 	{
 		int rc = -errno;
+		cxt->dev_fd = -1；
 		DBG(CXT, ul_debugobj(cxt, "failed to assign device [rc=%d]", rc));
 		return rc;
 	}

--- a/libfdisk/src/context.c
+++ b/libfdisk/src/context.c
@@ -636,7 +636,7 @@ static int fdisk_assign_fd(struct fdisk_context *cxt, int fd,
 fail:
 	{
 		int rc = -errno;
-		cxt->dev_fd = -1；
+		cxt->dev_fd = -1;
 		DBG(CXT, ul_debugobj(cxt, "failed to assign device [rc=%d]", rc));
 		return rc;
 	}


### PR DESCRIPTION
 When the query disk fails, reset cxt->dev_fd.