### PR TITLE
lscpu: avoid segfault on PowerPC systems with valid hardware configur…

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -440,8 +440,6 @@ static void read_physical_info_powerpc(struct lscpu_desc *desc)
 		return;
 
 	ntypes = strbe16toh(buf, 2);
-
-	assert(ntypes <= 1);
 	if (!ntypes)
 		return;
 


### PR DESCRIPTION
…ations

ntypes greater than 1 is valid in some hardware configurations, and an assert()
on the value isn't necessary or very future proof