### PR TITLE
fstrim: remove fstab condition from fstrim.timer

### DIFF
--- a/sys-utils/fstrim.timer
+++ b/sys-utils/fstrim.timer
@@ -1,7 +1,6 @@
 [Unit]
 Description=Discard unused blocks once a week
 Documentation=man:fstrim
-ConditionPathExists=/etc/fstab
 ConditionVirtualization=!container
 
 [Timer]


### PR DESCRIPTION
In 9995da0 we added support to fstrim to be able to fall back to
`/proc/self/mountinfo` if `/etc/fstab` didn't exist, but we forgot
to remove the `/etc/fstab` condition from the timer. Let's remove
that condition from the timer so we can go back to periodically
running `fstrim.service`.