### PR TITLE
do not require sys/syscall.h on non-linux platforms

### DIFF
--- a/lib/randutils.c
+++ b/lib/randutils.c
@@ -13,9 +13,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
-
+#ifdef __linux__
 #include <sys/syscall.h>
-
+#endif
 #include "c.h"
 #include "randutils.h"
 #include "nls.h"


### PR DESCRIPTION
In order to build util-linux on other platforms (such as IBM i), do not require the linux-specific sys/syscall.h.