### PR TITLE
cal: fix invalid use of putp()

### DIFF
--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -110,12 +110,7 @@ static int setup_terminal(char *term
 
 static void my_putstring(const char *s)
 {
-#if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBNCURSESW)
-	if (has_term)
-		putp(s);
-	else
-#endif
-		fputs(s, stdout);
+	fputs(s, stdout);
 }
 
 static const char *my_tgetstr(char *ss


### PR DESCRIPTION
according to documentation, putp() is supposed to be only used with:

> ... a terminfo string variable or the return value from tparm, tgetstr, or
> tgoto.

for arbitrary strings, standard libc output routines need to be used.

this caused strings like "11 12 13"... to be truncated to "12 13" in the output
when built with netbsd-curses.