### PR TITLE
vipw: fix short write handling in copyfile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -530,6 +530,7 @@ AC_CHECK_FUNCS([ \
 	qsort_r \
 	rpmatch \
 	scandirat \
+	sendfile \
 	setprogname \
 	setresgid \
 	setresuid \

--- a/include/all-io.h
+++ b/include/all-io.h
@@ -67,13 +67,15 @@ static inline ssize_t read_all(int fd, char *buf, size_t count)
 	memset(buf, 0, count);
 	while (count > 0) {
 		ret = read(fd, buf, count);
-		if (ret <= 0) {
-			if (ret < 0 && (errno == EAGAIN || errno == EINTR) && (tries++ < 5)) {
+		if (ret < 0) {
+			if ((errno == EAGAIN || errno == EINTR) && (tries++ < 5)) {
 				xusleep(250000);
 				continue;
 			}
 			return c ? c : -1;
 		}
+		if (ret == 0)
+			return c;
 		tries = 0;
 		count -= ret;
 		buf += ret;

--- a/include/all-io.h
+++ b/include/all-io.h
@@ -12,6 +12,10 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <sys/types.h>
+#ifdef HAVE_SENDFILE
+#include <sys/sendfile.h>
+#endif
 
 #include "c.h"
 
@@ -76,6 +80,34 @@ static inline ssize_t read_all(int fd, char *buf, size_t count)
 		c += ret;
 	}
 	return c;
+}
+
+static inline ssize_t sendfile_all(int out, int in, off_t *off, size_t count)
+{
+#ifdef HAVE_SENDFILE
+	ssize_t ret;
+	ssize_t c = 0;
+	int tries = 0;
+	while (count) {
+		ret = sendfile(out, in, off, count);
+		if (ret < 0) {
+			if ((errno == EAGAIN || errno == EINTR) && (tries++ < 5)) {
+				xusleep(250000);
+				continue;
+			}
+			return c ? c : -1;
+		}
+		if (ret == 0)
+			return c;
+		tries = 0;
+		count -= ret;
+		c += ret;
+	}
+	return c;
+#else
+	errno = ENOSYS;
+	return -1;
+#endif
 }
 
 #endif /* UTIL_LINUX_ALL_IO_H */

--- a/include/fileutils.h
+++ b/include/fileutils.h
@@ -74,4 +74,6 @@ static inline struct dirent *xreaddir(DIR *dp)
 
 extern void close_all_fds(const int exclude[], size_t exsz);
 
+int ul_copy_file(int from, int to);
+
 #endif /* UTIL_LINUX_FILEUTILS */

--- a/include/fileutils.h
+++ b/include/fileutils.h
@@ -74,6 +74,8 @@ static inline struct dirent *xreaddir(DIR *dp)
 
 extern void close_all_fds(const int exclude[], size_t exsz);
 
+#define UL_COPY_READ_ERROR (-1)
+#define UL_COPY_WRITE_ERROR (-2)
 int ul_copy_file(int from, int to);
 
 #endif /* UTIL_LINUX_FILEUTILS */

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -255,7 +255,7 @@ char *stripoff_last_component(char *path)
 static int copy_file_simple(int from, int to)
 {
 	ssize_t nr, nw, off;
-	char buf[8 * 1024];
+	char buf[BUFSIZ];
 
 	while ((nr = read(from, buf, sizeof(buf))) > 0)
 		for (off = 0; nr > 0; nr -= nw, off += nw)

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -199,9 +199,9 @@ int main(int argc, char *argv[])
 		close_all_fds(wanted_fds, ARRAY_SIZE(wanted_fds));
 	} else if (strcmp(argv[1], "--copy-file") == 0) {
 		int ret = ul_copy_file(STDIN_FILENO, STDOUT_FILENO);
-		if (ret == -1)
+		if (ret == UL_COPY_READ_ERROR)
 			err(EXIT_FAILURE, "read");
-		else if (ret == -2)
+		else if (ret == UL_COPY_WRITE_ERROR)
 			err(EXIT_FAILURE, "write");
 	}
 	return EXIT_SUCCESS;
@@ -263,9 +263,9 @@ static int copy_file_simple(int from, int to)
 
 	while ((nr = read_all(from, buf, sizeof(buf))) > 0)
 		if (write_all(to, buf, nr) == -1)
-			return -2;
+			return UL_COPY_WRITE_ERROR;
 	if (nr < 0)
-		return -1;
+		return UL_COPY_READ_ERROR;
 #ifdef HAVE_EXPLICIT_BZERO
 	explicit_bzero(buf, sizeof(buf));
 #endif
@@ -280,7 +280,7 @@ int ul_copy_file(int from, int to)
 	ssize_t nw;
 
 	if (fstat(from, &st) == -1)
-		return -1;
+		return UL_COPY_READ_ERROR;
 	if (!S_ISREG(st.st_mode))
 		return copy_file_simple(from, to);
 	if (sendfile_all(to, from, NULL, st.st_size) < 0)

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "c.h"
+#include "all-io.h"
 #include "fileutils.h"
 #include "pathnames.h"
 
@@ -254,13 +255,12 @@ char *stripoff_last_component(char *path)
 
 static int copy_file_simple(int from, int to)
 {
-	ssize_t nr, nw, off;
+	ssize_t nr;
 	char buf[BUFSIZ];
 
-	while ((nr = read(from, buf, sizeof(buf))) > 0)
-		for (off = 0; nr > 0; nr -= nw, off += nw)
-			if ((nw = write(to, buf + off, nr)) < 0)
-				return -2;
+	while ((nr = read_all(from, buf, sizeof(buf))) > 0)
+		if (write_all(to, buf, nr) == -1)
+			return -2;
 	if (nr < 0)
 		return -1;
 #ifdef HAVE_EXPLICIT_BZERO

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -11,7 +11,9 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#ifdef HAVE_SENDFILE
 #include <sys/sendfile.h>
+#endif
 #include <string.h>
 
 #include "c.h"
@@ -270,6 +272,7 @@ static int copy_file_simple(int from, int to)
 /* Copies the contents of a file. Returns -1 on read error, -2 on write error. */
 int ul_copy_file(int from, int to)
 {
+#ifdef HAVE_SENDFILE
 	struct stat st;
 	ssize_t nw;
 	off_t left;
@@ -290,4 +293,7 @@ int ul_copy_file(int from, int to)
 		if (nw < 0)
 			return copy_file_simple(from, to);
 	return 0;
+#else
+	return copy_file_simple(from, to);
+#endif
 }

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -177,7 +177,7 @@ void close_all_fds(const int exclude[], size_t exsz)
 int main(int argc, char *argv[])
 {
 	if (argc < 2)
-		errx(EXIT_FAILURE, "Usage %s --{mkstemp,close-fds}", argv[0]);
+		errx(EXIT_FAILURE, "Usage %s --{mkstemp,close-fds,copy-file}", argv[0]);
 
 	if (strcmp(argv[1], "--mkstemp") == 0) {
 		FILE *f;
@@ -197,6 +197,12 @@ int main(int argc, char *argv[])
 		ignore_result( dup(STDIN_FILENO) );
 
 		close_all_fds(wanted_fds, ARRAY_SIZE(wanted_fds));
+	} else if (strcmp(argv[1], "--copy-file") == 0) {
+		int ret = ul_copy_file(STDIN_FILENO, STDOUT_FILENO);
+		if (ret == -1)
+			err(EXIT_FAILURE, "read");
+		else if (ret == -2)
+			err(EXIT_FAILURE, "write");
 	}
 	return EXIT_SUCCESS;
 }

--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -76,6 +76,7 @@ if BUILD_NOLOGIN
 sbin_PROGRAMS += nologin
 dist_man_MANS += login-utils/nologin.8
 nologin_SOURCES = login-utils/nologin.c
+nologin_LDADD = $(LDADD) libcommon.la
 endif
 
 

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -61,7 +61,6 @@
 #elif defined(HAVE_SECURITY_OPENPAM_H)
 # include <security/openpam.h>
 #endif
-#include <sys/sendfile.h>
 
 #ifdef HAVE_LIBAUDIT
 # include <libaudit.h>
@@ -345,9 +344,7 @@ static int motddir(const char *dirname)
 
 		fd = openat(dd, d->d_name, O_RDONLY|O_CLOEXEC);
 		if (fd >= 0) {
-			struct stat st;
-			if (fstat(fd, &st) == 0 && st.st_size > 0)
-				sendfile(fileno(stdout), fd, NULL, st.st_size);
+			ul_copy_file(fd, fileno(stdout));
 			close(fd);
 			done++;
 		}
@@ -396,7 +393,7 @@ static void motd(void)
 		if (S_ISREG(st.st_mode) && st.st_size > 0) {
 			int fd = open(file, O_RDONLY, 0);
 			if (fd >= 0) {
-				sendfile(fileno(stdout), fd, NULL, st.st_size);
+				ul_copy_file(fd, fileno(stdout));
 				close(fd);
 			}
 			done++;

--- a/login-utils/nologin.c
+++ b/login-utils/nologin.c
@@ -14,6 +14,7 @@
 #include "c.h"
 #include "nls.h"
 #include "pathnames.h"
+#include "fileutils.h"
 
 /*
  * Always return EXIT_FAILURE (1), don't try to be smart!
@@ -97,12 +98,7 @@ int main(int argc, char *argv[])
 	if (c < 0 || !S_ISREG(st.st_mode))
 		goto dflt;
 	else {
-		char buf[BUFSIZ];
-		ssize_t rd;
-
-		while ((rd = read(fd, buf, sizeof(buf))) > 0)
-			ignore_result( write(STDOUT_FILENO, buf, rd) );
-
+		ul_copy_file(fd, STDOUT_FILENO);
 		close(fd);
 		return EXIT_FAILURE;
 	}

--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -131,9 +131,9 @@ static FILE * pw_tmpfile(int lockfd)
 
 	tmp_file = tmpname;
 	res = ul_copy_file(lockfd, fileno(fd));
-	if (res == -1)
+	if (res == UL_COPY_READ_ERROR)
 		pw_error(orig_file, 1, 1);
-	else if (res == -2)
+	else if (res == UL_COPY_WRITE_ERROR)
 		pw_error(tmp_file, 1, 1);
 	return fd;
 }

--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -94,7 +94,7 @@ static void copyfile(int from, int to)
 	char buf[8 * 1024];
 
 	while ((nr = read(from, buf, sizeof(buf))) > 0)
-		for (off = 0; off < nr; nr -= nw, off += nw)
+		for (off = 0; nr > 0; nr -= nw, off += nw)
 			if ((nw = write(to, buf + off, nr)) < 0)
 				pw_error(tmp_file, 1, 1);
 


### PR DESCRIPTION
Since `off` and `nr` approach each other, the for-loop ends prematurely when at least half of the buffer was written. I think under certain conditions this could cause the copy to be incomplete.