### PR TITLE
cast NULL to char * when using execl

### DIFF
--- a/lib/exec_shell.c
+++ b/lib/exec_shell.c
@@ -46,6 +46,6 @@ void __attribute__((__noreturn__)) exec_shell(void)
 	arg0[0] = '-';
 	strcpy(arg0 + 1, shell_basename);
 
-	execl(shell, arg0, NULL);
+	execl(shell, arg0, (char *)NULL);
 	errexec(shell);
 }

--- a/lib/pty-session.c
+++ b/lib/pty-session.c
@@ -699,9 +699,9 @@ int main(int argc, char *argv[])
 		shname = shname ? shname + 1 : shell;
 
 		if (command)
-			execl(shell, shname, "-c", command, NULL);
+			execl(shell, shname, "-c", command, (char *)NULL);
 		else
-			execl(shell, shname, "-i", NULL);
+			execl(shell, shname, "-i", (char *)NULL);
 		err(EXIT_FAILURE, "failed to execute %s", shell);
 		break;
 

--- a/login-utils/newgrp.c
+++ b/login-utils/newgrp.c
@@ -234,6 +234,6 @@ int main(int argc, char *argv[])
 	fflush(NULL);
 	shell = (pw_entry->pw_shell && *pw_entry->pw_shell ?
 				pw_entry->pw_shell : _PATH_BSHELL);
-	execl(shell, shell, (char *)0);
+	execl(shell, shell, (char *)NULL);
 	errexec(shell);
 }

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -789,11 +789,11 @@ static void sushell(struct passwd *pwd)
 		free(level);
 	}
 #endif
-	execl(su_shell, shell, NULL);
+	execl(su_shell, shell, (char *)NULL);
 	warn(_("failed to execute %s"), su_shell);
 
 	xsetenv("SHELL", "/bin/sh", 1);
-	execl("/bin/sh", profile ? "-sh" : "sh", NULL);
+	execl("/bin/sh", profile ? "-sh" : "sh", (char *)NULL);
 	warn(_("failed to execute %s"), "/bin/sh");
 }
 

--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -208,7 +208,7 @@ static void pw_edit(void)
 		err(EXIT_FAILURE, _("fork failed"));
 
 	if (!pid) {
-		execlp(editor, p, tmp_file, NULL);
+		execlp(editor, p, tmp_file, (char *)NULL);
 		errexec(editor);
 	}
 	for (;;) {

--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -663,9 +663,9 @@ static void umount_one(const struct eject_control *ctl, const char *name)
 			err(EXIT_FAILURE, _("cannot set user id"));
 
 		if (ctl->p_option)
-			execl("/bin/umount", "/bin/umount", name, "-n", NULL);
+			execl("/bin/umount", "/bin/umount", name, "-n", (char *)NULL);
 		else
-			execl("/bin/umount", "/bin/umount", name, NULL);
+			execl("/bin/umount", "/bin/umount", name, (char *)NULL);
 
 		errexec("/bin/umount");
 

--- a/sys-utils/setarch.c
+++ b/sys-utils/setarch.c
@@ -469,7 +469,7 @@ set_arch:
 
 	/* Execute shell */
 	if (shell) {
-		execl(shell, shell_arg, NULL);
+		execl(shell, shell_arg, (char *)NULL);
 		errexec(shell);
 	}
 

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -967,14 +967,14 @@ int main(int argc, char **argv)
 
 		if (access(shell, X_OK) == 0) {
 			if (command)
-				execl(shell, shname, "-c", command, NULL);
+				execl(shell, shname, "-c", command, (char *)NULL);
 			else
-				execl(shell, shname, "-i", NULL);
+				execl(shell, shname, "-i", (char *)NULL);
 		} else {
 			if (command)
-				execlp(shname, "-c", command, NULL);
+				execlp(shname, "-c", command, (char *)NULL);
 			else
-				execlp(shname, "-i", NULL);
+				execlp(shname, "-i", (char *)NULL);
 		}
 
 		err(EXIT_FAILURE, "failed to execute %s", shell);

--- a/term-utils/scriptlive.c
+++ b/term-utils/scriptlive.c
@@ -316,14 +316,14 @@ main(int argc, char *argv[])
 
 		if (access(shell, X_OK) == 0) {
 			if (command)
-				execl(shell, shname, "-c", command, NULL);
+				execl(shell, shname, "-c", command, (char *)NULL);
 			else
-				execl(shell, shname, "-i", NULL);
+				execl(shell, shname, "-i", (char *)NULL);
 		} else {
 			if (command)
-				execlp(shname, "-c", command, NULL);
+				execlp(shname, "-c", command, (char *)NULL);
 			else
-				execlp(shname, "-i", NULL);
+				execlp(shname, "-i", (char *)NULL);
 		}
 		err(EXIT_FAILURE, "failed to execute %s", shell);
 		break;

--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -1382,7 +1382,7 @@ static void pgfile(FILE *f, const char *name)
 						my_sigset(SIGQUIT, oldquit);
 						my_sigset(SIGTERM, oldterm);
 						execl(sh, sh, "-c",
-						      cmd.cmdline + 1, NULL);
+						      cmd.cmdline + 1, (char *)NULL);
 						errexec(sh);
 						break;
 					}


### PR DESCRIPTION
When calling variadic functions, NULL must be explicitly cast to a desired type.
This is noted in the [exec(3)](https://man7.org/linux/man-pages/man3/exec.3.html) manpage.

The call in newgrp.c was changed for consistency.