### PR TITLE
sfdisk: correct --json --dump false exclusive

### DIFF
--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -2165,7 +2165,8 @@ int main(int argc, char *argv[])
 		{ NULL, 0, NULL, 0 },
 	};
 	static const ul_excl_t excl[] = {	/* rows and cols in ASCII order */
-		{ 'F','J','d'},                 /* --list-free --json --dump */
+		{ 'F','d'},                     /* --list-free --dump */
+		{ 'F','J'},                     /* --list-free --json */
 		{ 's','u'},			/* --show-size --unit */
 		{ 0 }
 	};


### PR DESCRIPTION
`--json` implies `--dump`, thus `--json --dump` must be
allowed. `--list-free` is incompatible with `--dump`, and thus also
with `--json`. Currently `--json --dump` is prohibited, even though
`--list-free` is not specified at all.

Regression introduced in 03154d2cf25c1d5ce908da9e72d324004b8d5722.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>