### PR TITLE
libblkid: fix corner case issues

### DIFF
--- a/libblkid/src/config.c
+++ b/libblkid/src/config.c
@@ -95,8 +95,11 @@ static int parse_next(FILE *fd, struct blkid_config *conf)
 			conf->uevent = FALSE;
 	} else if (!strncmp(s, "CACHE_FILE=", 11)) {
 		s += 11;
+		free(conf->cachefile);
 		if (*s)
 			conf->cachefile = strdup(s);
+		else
+			conf->cachefile = NULL;
 	} else if (!strncmp(s, "EVALUATE=", 9)) {
 		s += 9;
 		if (*s && parse_evaluate(conf, s) == -1)

--- a/libblkid/src/dev.c
+++ b/libblkid/src/dev.c
@@ -87,8 +87,8 @@ void blkid_debug_dump_dev(blkid_dev dev)
 	}
 
 	fprintf(stderr, "  dev: name = %s\n", dev->bid_name);
-	fprintf(stderr, "  dev: DEVNO=\"0x%0llx\"\n", (long long)dev->bid_devno);
-	fprintf(stderr, "  dev: TIME=\"%ld.%ld\"\n", (long)dev->bid_time, (long)dev->bid_utime);
+	fprintf(stderr, "  dev: DEVNO=\"0x%0lx\"\n", (unsigned long)dev->bid_devno);
+	fprintf(stderr, "  dev: TIME=\"%lld.%lld\"\n", (long long)dev->bid_time, (long long)dev->bid_utime);
 	fprintf(stderr, "  dev: PRI=\"%d\"\n", dev->bid_pri);
 	fprintf(stderr, "  dev: flags = 0x%08X\n", dev->bid_flags);
 

--- a/libblkid/src/devname.c
+++ b/libblkid/src/devname.c
@@ -92,7 +92,7 @@ blkid_dev blkid_get_dev(blkid_cache cache, const char *devname, int flags)
 		dev = blkid_new_dev();
 		if (!dev)
 			goto done;
-		dev->bid_time = INT_MIN;
+		dev->bid_time = (uintmax_t)1 << (sizeof(time_t) * 8 - 1);
 		if (cn) {
 			dev->bid_name = cn;
 			dev->bid_xname = strdup(devname);

--- a/libblkid/src/partitions/atari.c
+++ b/libblkid/src/partitions/atari.c
@@ -141,12 +141,16 @@ static int parse_extended(blkid_probe pr, blkid_partlist ls,
 	blkid_parttable tab, struct atari_part_def *part)
 {
 	uint32_t x0start, xstart;
-	unsigned i = 0;
+	unsigned ct = 0, i = 0;
 	int rc;
 
 	x0start = xstart = be32_to_cpu(part->start);
 	while (1) {
 		struct atari_rootsector *xrs;
+
+		if (++ct > 100)
+			break;
+
 		xrs = (struct atari_rootsector *) blkid_probe_get_sector(pr, xstart);
 		if (!xrs) {
 			if (errno)

--- a/libblkid/src/partitions/mac.c
+++ b/libblkid/src/partitions/mac.c
@@ -123,12 +123,12 @@ static int probe_mac_pt(blkid_probe pr,
 	ssf = block_size / 512;
 	nblks = be32_to_cpu(p->map_count);
 
-	for (i = 1; i <= nblks; ++i) {
+	for (i = 0; i < nblks; ++i) {
 		blkid_partition par;
 		uint32_t start;
 		uint32_t size;
 
-		p = (struct mac_partition *) get_mac_block(pr, block_size, i);
+		p = (struct mac_partition *) get_mac_block(pr, block_size, i + 1);
 		if (!p) {
 			if (errno)
 				return -errno;
@@ -141,7 +141,7 @@ static int probe_mac_pt(blkid_probe pr,
 			DBG(LOWPROBE, ul_debug(
 				"mac: inconsistent map_count in partition map, "
 				"entry[0]: %d, entry[%d]: %d",
-				nblks, i - 1,
+				nblks, i,
 				be32_to_cpu(p->map_count)));
 		}
 

--- a/libblkid/src/partitions/mac.c
+++ b/libblkid/src/partitions/mac.c
@@ -79,7 +79,7 @@ static int probe_mac_pt(blkid_probe pr,
 	blkid_partlist ls;
 	uint16_t block_size;
 	uint16_t ssf;	/* sector size fragment */
-	uint32_t nblks, i;
+	uint32_t nblks, nprts, i;
 
 
 	/* The driver descriptor record is always located at physical block 0,
@@ -122,8 +122,15 @@ static int probe_mac_pt(blkid_probe pr,
 
 	ssf = block_size / 512;
 	nblks = be32_to_cpu(p->map_count);
+	if (nblks > 256) {
+		nprts = 256;
+		DBG(LOWPROBE, ul_debug(
+			"mac: map_count too large, entry[0]: %u, "
+			"enforcing limit of %u", nblks, nprts));
+	} else
+		nprts = nblks;
 
-	for (i = 0; i < nblks; ++i) {
+	for (i = 0; i < nprts; ++i) {
 		blkid_partition par;
 		uint32_t start;
 		uint32_t size;
@@ -140,7 +147,7 @@ static int probe_mac_pt(blkid_probe pr,
 		if (be32_to_cpu(p->map_count) != nblks) {
 			DBG(LOWPROBE, ul_debug(
 				"mac: inconsistent map_count in partition map, "
-				"entry[0]: %d, entry[%d]: %d",
+				"entry[0]: %u, entry[%u]: %u",
 				nblks, i,
 				be32_to_cpu(p->map_count)));
 		}

--- a/libblkid/src/save.c
+++ b/libblkid/src/save.c
@@ -52,10 +52,10 @@ static int save_dev(blkid_dev dev, FILE *file)
 	DBG(SAVE, ul_debug("device %s, type %s", dev->bid_name, dev->bid_type ?
 		   dev->bid_type : "(null)"));
 
-	fprintf(file, "<device DEVNO=\"0x%04lx\" TIME=\"%ld.%ld\"",
+	fprintf(file, "<device DEVNO=\"0x%04lx\" TIME=\"%lld.%lld\"",
 			(unsigned long) dev->bid_devno,
-			(long) dev->bid_time,
-			(long) dev->bid_utime);
+			(long long) dev->bid_time,
+			(long long) dev->bid_utime);
 
 	if (dev->bid_pri)
 		fprintf(file, " PRI=\"%d\"", dev->bid_pri);

--- a/libblkid/src/verify.c
+++ b/libblkid/src/verify.c
@@ -70,7 +70,7 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 		return NULL;
 
 	now = time(NULL);
-	diff = now - dev->bid_time;
+	diff = (uintmax_t)now - dev->bid_time;
 
 	if (stat(dev->bid_name, &st) < 0) {
 		DBG(PROBE, ul_debug("blkid_verify: error %s (%d) while "
@@ -95,23 +95,23 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 #else
 	    st.st_mtime <= dev->bid_time &&
 #endif
-	    diff < BLKID_PROBE_MIN) {
+	    diff >= 0 && diff < BLKID_PROBE_MIN) {
 		dev->bid_flags |= BLKID_BID_FL_VERIFIED;
 		return dev;
 	}
 
 #ifndef HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC
-	DBG(PROBE, ul_debug("need to revalidate %s (cache time %lu, stat time %lu,\t"
-		   "time since last check %lu)",
-		   dev->bid_name, (unsigned long)dev->bid_time,
-		   (unsigned long)st.st_mtime, (unsigned long)diff));
+	DBG(PROBE, ul_debug("need to revalidate %s (cache time %lld, stat time %lld,\t"
+		   "time since last check %lld)",
+		   dev->bid_name, (long long)dev->bid_time,
+		   (long long)st.st_mtime, (long long)diff));
 #else
-	DBG(PROBE, ul_debug("need to revalidate %s (cache time %lu.%lu, stat time %lu.%lu,\t"
-		   "time since last check %lu)",
+	DBG(PROBE, ul_debug("need to revalidate %s (cache time %lld.%lld, stat time %lld.%lld,\t"
+		   "time since last check %lld)",
 		   dev->bid_name,
-		   (unsigned long)dev->bid_time, (unsigned long)dev->bid_utime,
-		   (unsigned long)st.st_mtime, (unsigned long)st.st_mtim.tv_nsec / 1000,
-		   (unsigned long)diff));
+		   (long long)dev->bid_time, (long long)dev->bid_utime,
+		   (long long)st.st_mtime, (long long)st.st_mtim.tv_nsec / 1000,
+		   (long long)diff));
 #endif
 
 	if (sysfs_devno_is_dm_private(st.st_rdev, NULL)) {


### PR DESCRIPTION
This pull request fixes some issues in corner cases:

- A blkid.conf with multiple CACHE_FILE lines leads to memory leaks
- A weird mac partition layout cannot be parsed
- A 32 bit time_t system can trigger signed integer overflows

The second issue (mac partition) should receive a bit more refactoring. I think that it makes sense to have an upper limit of partitions allowed. The same is true for atari. Otherwise such a disk could consume a lot of memory which eventually leads to out of memory conditions on pretty much every system.

I lack proper documentation of old macOS and atari systems though. Do you know where real partition limits are?