### PR TITLE
libuuid: check quality of random bytes

### DIFF
--- a/include/randutils.h
+++ b/include/randutils.h
@@ -11,7 +11,7 @@ extern int rand_get_number(int low_n, int high_n);
 
 /* /dev/urandom based with fallback to rand() */
 extern int random_get_fd(void);
-extern void ul_random_get_bytes(void *buf, size_t nbytes);
+extern int ul_random_get_bytes(void *buf, size_t nbytes);
 extern const char *random_tell_source(void);
 
 #endif

--- a/lib/randutils.c
+++ b/lib/randutils.c
@@ -102,7 +102,12 @@ int random_get_fd(void)
 #define UL_RAND_READ_ATTEMPTS	8
 #define UL_RAND_READ_DELAY	125000	/* microseconds */
 
-void ul_random_get_bytes(void *buf, size_t nbytes)
+/*
+ * Write @nbytes random bytes into @buf.
+ *
+ * Returns 0 for good quality of random bytes or 1 for weak quality.
+ */
+int ul_random_get_bytes(void *buf, size_t nbytes)
 {
 	unsigned char *cp = (unsigned char *)buf;
 	size_t i, n = nbytes;
@@ -118,7 +123,7 @@ void ul_random_get_bytes(void *buf, size_t nbytes)
 		       n -= x;
 		       cp += x;
 		       lose_counter = 0;
-
+		       errno = 0;
 		} else if (errno == ENOSYS) {	/* kernel without getrandom() */
 			break;
 
@@ -177,6 +182,8 @@ void ul_random_get_bytes(void *buf, size_t nbytes)
 		       sizeof(ul_jrand_seed)-sizeof(unsigned short));
 	}
 #endif
+
+	return n != 0;
 }
 
 

--- a/libuuid/man/uuid_generate.3
+++ b/libuuid/man/uuid_generate.3
@@ -49,7 +49,10 @@ The
 .B uuid_generate
 function creates a new universally unique identifier (UUID).  The uuid will
 be generated based on high-quality randomness from
+.IR getrandom(2) ,
 .IR /dev/urandom ,
+or
+.IR /dev/random
 if available.  If it is not available, then
 .B uuid_generate
 will use an alternative algorithm which uses the current time, the
@@ -59,8 +62,7 @@ using a pseudo-random generator.
 The
 .B uuid_generate_random
 function forces the use of the all-random UUID format, even if
-a high-quality random number generator (i.e.,
-.IR /dev/urandom )
+a high-quality random number generator
 is not available, in which case a pseudo-random
 generator will be substituted.  Note that the use of a pseudo-random
 generator may compromise the uniqueness of UUIDs

--- a/libuuid/src/uuidd.h
+++ b/libuuid/src/uuidd.h
@@ -49,6 +49,6 @@
 #define UUIDD_MAX_OP			UUIDD_OP_BULK_RANDOM_UUID
 
 extern int __uuid_generate_time(uuid_t out, int *num);
-extern void __uuid_generate_random(uuid_t out, int *num);
+extern int __uuid_generate_random(uuid_t out, int *num);
 
 #endif /* _UUID_UUID_H */


### PR DESCRIPTION
If a libuuid application is unable to access /dev/random or /dev/urandom
then uuid generation by uuid_generate falls back to uuid_generate_time.
This could happen in chroot or container environments.

The function ul_random_get_bytes from lib/randutils.c uses getrandom if
it is available. This could either mean that the libuuid application
skips good random bytes because the character special files do not exist
or the application trusts in good random bytes just because these files
are accessible but not necessarily usable, e.g. limit of open file
descriptors reached, lack of data, kernel without getrandom, etc.

This commit modifies ul_random_get_bytes to return an integer which
indicates if random bytes are of good quality (0) or not (1). Callers
can decide based on this information if they want to discard the random
bytes. Only libuuid checks the return value. I decided to return 1
instead of -1 because -1 feels more like an error, but weak random bytes
can be totally fine.

Another issue is that getrandom sets errno to specific values only in
case of an error, i.e. with return value -1. Set errno to 0 explicitly
if getrandom succeeds so we do not enter the fallback routine for
ENOSYS by mistake. I do not think that this is likely to happen, but it
really depends on possible wrapper function supplied by a C library.

Signed-off-by: Samanta Navarro <ferivoz@riseup.net>