### PR TITLE
2020wk45 bunch of various changes

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -11,32 +11,32 @@ on:
     paths:
       - '**'
 jobs:
- Fuzzing:
-   runs-on: ubuntu-latest
-   if: github.repository == 'karelzak/util-linux'
-   strategy:
-     fail-fast: false
-     matrix:
-       sanitizer: [address, undefined, memory]
-   steps:
-   - name: Build Fuzzers (${{ matrix.sanitizer }})
-     id: build
-     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-     with:
-       oss-fuzz-project-name: 'util-linux'
-       dry-run: false
-       allowed-broken-targets-percentage: 0
-       sanitizer: ${{ matrix.sanitizer }}
-   - name: Run Fuzzers (${{ matrix.sanitizer }})
-     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-     with:
-       oss-fuzz-project-name: 'util-linux'
-       fuzz-seconds: 180
-       dry-run: false
-       sanitizer: ${{ matrix.sanitizer }}
-   - name: Upload Crash
-     uses: actions/upload-artifact@v1
-     if: failure() && steps.build.outcome == 'success'
-     with:
-       name: ${{ matrix.sanitizer }}-artifacts
-       path: ./out/artifacts
+  Fuzzing:
+    runs-on: ubuntu-latest
+    if: github.repository == 'karelzak/util-linux'
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, memory]
+    steps:
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'util-linux'
+          dry-run: false
+          allowed-broken-targets-percentage: 0
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'util-linux'
+          fuzz-seconds: 180
+          dry-run: false
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Upload Crash
+        uses: actions/upload-artifact@v1
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: ${{ matrix.sanitizer }}-artifacts
+          path: ./out/artifacts

--- a/configure.ac
+++ b/configure.ac
@@ -1504,8 +1504,8 @@ AM_CONDITIONAL([BUILD_MINIX], [test "x$build_minix" = xyes])
 
 
 AC_ARG_ENABLE([fdformat],
-  AS_HELP_STRING([--disable-fdformat], [do not build fdformat]),
-  [], [UL_DEFAULT_ENABLE([fdformat], [check])]
+  AS_HELP_STRING([--enable-fdformat], [build fdformat]),
+  [], [UL_DEFAULT_ENABLE([fdformat], [no])]
 )
 UL_BUILD_INIT([fdformat])
 UL_REQUIRES_LINUX([fdformat])

--- a/disk-utils/fdisk.8
+++ b/disk-utils/fdisk.8
@@ -195,7 +195,7 @@ The relative sizes are always aligned according to device I/O limits.  The
 +/-<size>{K,B,M,G,...} notation is recommended.
 
 For backward compatibility fdisk also accepts the suffixes KB=1000,
-MB=1000*1000, and so on for GB, TB, PB, EB, ZB and YB. These 10^N suffixes
+MB=1000*1000, and so on for GB, TB, PB, EB, ZB and YB. These 10\(haN suffixes
 are deprecated.
 
 .SH SCRIPT FILES

--- a/disk-utils/sfdisk.8
+++ b/disk-utils/sfdisk.8
@@ -237,7 +237,7 @@ the partition table.
 .TP
 .BR \-b , " \-\-backup"
 Back up the current partition table sectors before starting the partitioning.
-The default backup file name is ~/sfdisk-<device>-<offset>.bak; to use another
+The default backup file name is \(ti/sfdisk-<device>-<offset>.bak; to use another
 name see option \fB\-O\fR, \fB\-\-backup\-file\fR.
 .TP
 .BR \-\-color [ =\fIwhen ]
@@ -284,7 +284,7 @@ option \fB\-N\fR in order to be processed on one specific partition only.
 
 The optional \fIpath\fR specifies log file name. The log file contains information
 about all read/write operations on the partition data. The word "@default" as
-a \fIpath\fR forces sfdisk to use ~/sfdisk-<devname>.move for the log.  The log is
+a \fIpath\fR forces sfdisk to use \(ti/sfdisk-<devname>.move for the log.  The log is
 optional since v2.35.
 
 Note that this operation is risky and not atomic. \fBDon't forget to backup your data!\fR
@@ -587,7 +587,7 @@ This can later be restored by:
 If you want to do a full (binary) backup of all sectors where the
 partition table is stored,
 then use the \fB\-\-backup\fR option.  It writes the sectors to
-~/sfdisk-<device>-<offset>.bak files.  The default name of the backup file can
+\(ti/sfdisk-<device>-<offset>.bak files.  The default name of the backup file can
 be changed with the \fB\-\-backup\-file\fR option.  The backup files
 contain only raw data from the \fIdevice\fR.
 Note that the same concept of backup files is used by
@@ -602,7 +602,7 @@ The GPT header can later be restored by:
 .RS
 .sp
 .nf
-.B "dd  if=~/sfdisk-sda-0x00000200.bak  of=/dev/sda  \e"
+.B "dd  if=\(ti/sfdisk-sda-0x00000200.bak  of=/dev/sda  \e"
 .B "  seek=$((0x00000200))  bs=1  conv=notrunc"
 .fi
 .sp

--- a/lib/terminal-colors.d.5
+++ b/lib/terminal-colors.d.5
@@ -121,7 +121,7 @@ lb l.
 \e?	Delete (ASCII 127)
 \e_	Space
 \e\e	Backslash (\e)
-\e^	Caret (^)
+\e\(ha	Caret (\(ha)
 \e#	Hash mark (#)
 .TE
 .RE

--- a/login-utils/login.1
+++ b/login-utils/login.1
@@ -285,7 +285,7 @@ if the file exists in the user\'s home directory.
 The default is to check
 .I /etc\:/hushlogins
 and if it does not exist then
-.I ~/.hushlogin
+.I \(ti/.hushlogin
 .PP
 If the
 .B HUSHLOGIN_FILE

--- a/misc-utils/blkid.8
+++ b/misc-utils/blkid.8
@@ -112,7 +112,7 @@ devices previously scanned but not necessarily available at this time), specify
 .TP
 \fB\-d\fR, \fB\-\-no\-encoding\fR
 Don't encode non-printing characters.  The non-printing characters are encoded
-by ^ and M- notation by default.  Note that the \fB\-\-output udev\fR output format uses
+by \(ha and M- notation by default.  Note that the \fB\-\-output udev\fR output format uses
 a different encoding which cannot be disabled.
 .TP
 \fB\-D\fR, \fB\-\-no\-part\-details\fR
@@ -219,7 +219,7 @@ This output format is \fBDEPRECATED\fR.
 print key=value pairs for easy import into the environment; this output format
 is automatically enabled when I/O Limits (\fB\-\-info\fR option) are requested.
 
-The non-printing characters are encoded by ^ and M- notation and all
+The non-printing characters are encoded by \(ha and M- notation and all
 potentially unsafe characters are escaped.
 .RE
 .TP

--- a/misc-utils/hardlink.1
+++ b/misc-utils/hardlink.1
@@ -58,7 +58,7 @@ Historically \fBhardlink\fR silently excluded any names beginning with
 ".in.", as well as any names beginning with "." followed by exactly 6
 other characters. That prior behavior can be achieved by specifying
 .br
-\-x '^(\\.in\\.|\\.[^.]{6}$)'
+\-x '\(ha(\\.in\\.|\\.[\(ha.]{6}$)'
 .SH AUTHORS
 \fBhardlink\fR was written by Jakub Jelinek <jakub@redhat.com> and later modified by
 Ruediger Meier <ruediger.meier@ga-group.nl> and Karel Zak <kzak@redhat.com> for util-linux.

--- a/misc-utils/wipefs.8
+++ b/misc-utils/wipefs.8
@@ -138,10 +138,10 @@ Prints information about sda and all partitions on sda.
 .TP
 .B wipefs \-\-all \-\-backup /dev/sdb
 Erases all signatures from the device /dev/sdb and creates a signature backup
-file ~/wipefs-sdb-<offset>.bak for each signature.
+file \(ti/wipefs-sdb-<offset>.bak for each signature.
 .TP
-.B dd if=~/wipefs-sdb-0x00000438.bak of=/dev/sdb seek=$((0x00000438)) bs=1 conv=notrunc
-Restores an ext2 signature from the backup file  ~/wipefs-sdb-0x00000438.bak.
+.B dd if=\(ti/wipefs-sdb-0x00000438.bak of=/dev/sdb seek=$((0x00000438)) bs=1 conv=notrunc
+Restores an ext2 signature from the backup file \(ti/wipefs-sdb-0x00000438.bak.
 .SH AUTHORS
 Karel Zak <kzak@redhat.com>
 .SH SEE ALSO

--- a/sys-utils/losetup.8
+++ b/sys-utils/losetup.8
@@ -205,8 +205,8 @@ loop control device
 The following commands can be used as an example of using the loop device.
 .nf
 .IP
-# dd if=/dev/zero of=~/file.img bs=1024k count=10
-# losetup \-\-find \-\-show ~/file.img
+# dd if=/dev/zero of=\(ti/file.img bs=1024k count=10
+# losetup \-\-find \-\-show \(ti/file.img
 /dev/loop0
 # mkfs \-t ext2 /dev/loop0
 # mount /dev/loop0 /mnt

--- a/sys-utils/mount.8
+++ b/sys-utils/mount.8
@@ -1716,7 +1716,7 @@ Other users can change timestamp.
 .PP
 The default is set from `dmask' option. (If the directory is writable,
 .BR utime (2)
-is also allowed.  I.e.\& \s+3~\s0dmask & 022)
+is also allowed.  I.e.\& \s+3\(ti\s0dmask & 022)
 
 Normally
 .BR utime (2)
@@ -2512,7 +2512,7 @@ This option is obsolete.
 .B nonumtail
 First try to make a short name without sequence number,
 before trying
-.IR name\s+3~\s0num.ext .
+.IR name\s+3\(ti\s0num.ext .
 .TP
 .B utf8
 UTF8 is the filesystem safe 8-bit encoding of Unicode that is used by the
@@ -2789,7 +2789,7 @@ libmount private runtime directory
 table of mounted filesystems or symlink to
 .I /proc/mounts
 .TP
-.I /etc/mtab\s+3~\s0
+.I /etc/mtab\s+3\(ti\s0
 lock file (unused on systems with
 .I mtab
 symlink)

--- a/sys-utils/readprofile.8
+++ b/sys-utils/readprofile.8
@@ -136,7 +136,7 @@ Look at all the kernel information, with ram addresses:
 .fi
 Browse a `frozen' profile buffer for a non current kernel:
 .nf
-   readprofile \-p ~/profile.freeze \-m /zImage.map.gz
+   readprofile \-p \(ti/profile.freeze \-m /zImage.map.gz
 
 .fi
 Request profiling at 2kHz per CPU, and reset the profiling buffer:

--- a/sys-utils/rfkill.c
+++ b/sys-utils/rfkill.c
@@ -420,6 +420,8 @@ static int rfkill_list_old(const char *param)
 	}
 
 	fd = rfkill_ro_open(1);
+	if (fd < 0)
+		return -errno;
 
 	while (1) {
 		rc = rfkill_read_event(fd, &event);
@@ -492,6 +494,8 @@ static int rfkill_list_fill(struct control const *ctrl, const char *param)
 	}
 
 	fd = rfkill_ro_open(1);
+	if (fd < 0)
+		return -errno;
 
 	while (1) {
 		rc = rfkill_read_event(fd, &event);

--- a/text-utils/colrm.c
+++ b/text-utils/colrm.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
 	close_stdout_atexit();
 
 	while ((opt =
-		getopt_long(argc, argv, "bfhl:pxVH", longopts,
+		getopt_long(argc, argv, "Vh", longopts,
 			    NULL)) != -1)
 		switch (opt) {
 		case 'V':

--- a/text-utils/more.1
+++ b/text-utils/more.1
@@ -63,7 +63,7 @@ the bell when an illegal key is pressed.
 .TP
 .BR \-l , " \-\-logical"
 Do not pause after any line containing a
-.B \&^L
+.B \&\(haL
 (form feed).
 .TP
 .BR \-f , " \-\-no\-pause"
@@ -122,7 +122,7 @@ are based on
 .BR vi (1).
 Some commands may be preceded by a decimal number, called k in the
 descriptions below.  In the following descriptions,
-.B ^X
+.B \(haX
 means
 .BR control-X .
 .PP
@@ -143,7 +143,7 @@ becomes new default.
 .B RETURN
 Display next k lines of text.  Defaults to 1.  Argument becomes new default.
 .TP
-.BR d \ or \ \&^D
+.BR d \ or \ \&\(haD
 Scroll k lines.  Default is current scroll size, initially 11.  Argument
 becomes new default.
 .TP
@@ -156,7 +156,7 @@ Skip forward k lines of text.  Defaults to 1.
 .B f
 Skip forward k screenfuls of text.  Defaults to 1.
 .TP
-.BR b \ or \ \&^B
+.BR b \ or \ \&\(haB
 Skip backwards k screenfuls of text.  Defaults to 1.  Only works with files,
 not pipes.
 .TP
@@ -194,7 +194,7 @@ nor
 .B EDITOR
 is defined.
 .TP
-.B \&^L
+.B \&(haL
 Redraw screen.
 .TP
 .B :n

--- a/text-utils/pg.1
+++ b/text-utils/pg.1
@@ -106,7 +106,7 @@ otherwise relative to the beginning.
 .IB i <Enter>
 Display the next or the indicated page.
 .TP
-\fIi\fR\fBd\fR or \fB^D\fR
+\fIi\fR\fBd\fR or \fB(haD\fR
 Display the next halfpage.  If
 .I i
 is given, it is always interpreted relative to the current position.
@@ -127,7 +127,7 @@ except that
 .I i
 becomes the new page size.
 .TP
-.BR . " or " ^L
+.BR . " or " (haL
 Redraw the screen.
 .TP
 .B $
@@ -143,7 +143,7 @@ No wrap-around is performed.
 .I i
 must be a positive number.
 .TP
-\fIi\fR\fB?\fR\fIpattern\fR\fB?\fR or \fIi\fR\fB^\fR\fIpattern\fR\fB^\fR
+\fIi\fR\fB?\fR\fIpattern\fR\fB?\fR or \fIi\fR\fB(ha\fR\fIpattern\fR\fB(ha\fR
 Search backward until the first or the \fIi\fR-th
 occurrence of the Basic Regular Expression
 .I pattern

--- a/text-utils/ul.c
+++ b/text-utils/ul.c
@@ -482,7 +482,7 @@ static void filter(struct ul_ctl *ctl, struct term_caps const *const tcs, FILE *
 	while ((c = getwc(f)) != WEOF) {
 		switch (c) {
 		case '\b':
-			set_column(ctl, ctl->column && 0 < (ctl->column - 1) ? ctl->column - 1 : 0);
+			set_column(ctl, ctl->column && 0 < ctl->column ? ctl->column - 1 : 0);
 			continue;
 		case '\t':
 			set_column(ctl, (ctl->column + 8) & ~07);


### PR DESCRIPTION
These change are collection of various one off changes that I have collected for a while

The uuidd one is a little bit bigger than other, and it is a piece of work that I did with a specific question in mind; wouldn't it make sense to make long running commands to use as little memory as possible. Especially thing like getopt options are stack allocations that do not need to be in memory after options are parsed. And with uuidd few other allocations can be trimmed as well. When I was done with uuidd I decided to look login(1) that is by far most common util-linux binary that stays longest in memory, and that turned into a change set of it's own right.

Notice that two  of the changes are re-submissions, and can be marked done in email todo queue.

colrm: https://lore.kernel.org/util-linux/20201019205704.6762-1-kerolasa@iki.fi/
rfkill: https://lore.kernel.org/util-linux/20201023200800.7980-1-kerolasa@iki.fi/