### PR TITLE
Find last caps through prctl instead of procfs or guess

### DIFF
--- a/include/procutils.h
+++ b/include/procutils.h
@@ -2,6 +2,7 @@
 #define UTIL_LINUX_PROCUTILS
 
 #include <dirent.h>
+#include <sys/types.h>
 
 struct proc_tasks {
 	DIR *dir;
@@ -30,5 +31,7 @@ extern int proc_next_pid(struct proc_processes *ps, pid_t *pid);
 
 extern char *proc_get_command(pid_t pid);
 extern char *proc_get_command_name(pid_t pid);
+
+extern int proc_is_procfs(int fd);
 
 #endif /* UTIL_LINUX_PROCUTILS */

--- a/lib/procutils.c
+++ b/lib/procutils.c
@@ -13,11 +13,13 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <sys/vfs.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include <ctype.h>
 
 #include "procutils.h"
+#include "statfs_magic.h"
 #include "fileutils.h"
 #include "all-io.h"
 #include "c.h"
@@ -233,6 +235,23 @@ int proc_next_pid(struct proc_processes *ps, pid_t *pid)
 	} while (1);
 
 	return 0;
+}
+
+/* checks if fd is file in a procfs;
+ * returns 1 if true, 0 if false or couldn't determine */
+int proc_is_procfs(int fd)
+{
+	struct statfs st;
+	int ret;
+
+	do {
+		ret = fstatfs(fd, &st);
+	} while (ret == -1 && errno == EINTR);
+
+	if (ret == 0)
+		return st.f_type == STATFS_PROC_MAGIC;
+	else
+		return 0;
 }
 
 #ifdef TEST_PROGRAM_PROCUTILS


### PR DESCRIPTION
First step for #1179, should make any usage of the value returned by `cap_last_cap` completely safe.

I can remove the caching, but thought it would be nice to have. Alternatively, applications that use `caps_last_cap`  multiple times can cache it themselves.