### PR TITLE
lscpu-virt: fix return type of read_hypervisor_cpuid for non x86.

### DIFF
--- a/sys-utils/lscpu-virt.c
+++ b/sys-utils/lscpu-virt.c
@@ -377,8 +377,9 @@ none:
 }
 
 #else /* ! (__x86_64__ || __i386__) */
-static void read_hypervisor_cpuid(void)
+static int read_hypervisor_cpuid(void)
 {
+	return 0;
 }
 #endif
 


### PR DESCRIPTION
An alternate fix is `#ifdefing` around the block that uses the value, but that would be a more intrusive code change.