### PR TITLE
build-sys: do not build plymouth-ctrl.c w/ disabled plymouth

### DIFF
--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -31,8 +31,10 @@ dist_man_MANS += login-utils/sulogin.8
 sulogin_SOURCES = \
 	login-utils/sulogin.c \
 	login-utils/sulogin-consoles.c \
-	login-utils/sulogin-consoles.h \
-	lib/plymouth-ctrl.c
+	login-utils/sulogin-consoles.h
+if USE_PLYMOUTH_SUPPORT
+sulogin_SOURCES += lib/plymouth-ctrl.c
+endif
 sulogin_LDADD = $(LDADD) libcommon.la
 
 if HAVE_LIBCRYPT

--- a/term-utils/Makemodule.am
+++ b/term-utils/Makemodule.am
@@ -42,8 +42,10 @@ endif # BUILD_SCRIPTLIVE
 if BUILD_AGETTY
 sbin_PROGRAMS += agetty
 dist_man_MANS += term-utils/agetty.8
-agetty_SOURCES = term-utils/agetty.c \
-		 lib/plymouth-ctrl.c
+agetty_SOURCES = term-utils/agetty.c
+if USE_PLYMOUTH_SUPPORT
+agetty_SOURCES += lib/plymouth-ctrl.c
+endif
 agetty_LDADD = $(LDADD) libcommon.la
 if BSD
 agetty_LDADD += -lutil


### PR DESCRIPTION
Do not build plymouth-ctrl.c in agetty and sulogin in case the plymouth
support is disabled.

Signed-off-by: Pino Toscano <toscano.pino@tiscali.it>