### PR TITLE
hwclock: do not assume __NR_settimeofday_time32

### DIFF
--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -678,7 +678,7 @@ display_time(struct timeval hwctime)
 #ifndef SYS_settimeofday
 # ifdef __NR_settimeofday
 #  define SYS_settimeofday	__NR_settimeofday
-# else
+# elif defined(__NR_settimeofday_time32)
 #  define SYS_settimeofday	__NR_settimeofday_time32
 # endif
 #endif


### PR DESCRIPTION
Check that `__NR_settimeofday_time32` exists before trying to use it as
syscall number.

Signed-off-by: Pino Toscano <toscano.pino@tiscali.it>