### PR TITLE
setpriv: allow using [-+]all for capabilities.

### DIFF
--- a/sys-utils/setpriv.c
+++ b/sys-utils/setpriv.c
@@ -532,12 +532,9 @@ static void do_caps(enum cap_type type, const char *caps)
 
 		if (!strcmp(c + 1, "all")) {
 			int i;
-			/* It would be really bad if -all didn't drop all
-			 * caps.  It's better to just fail. */
-			if (cap_last_cap() > CAP_LAST_CAP)
-				errx(SETPRIV_EXIT_PRIVERR,
-				     _("libcap-ng is too old for \"all\" caps"));
-			for (i = 0; i <= CAP_LAST_CAP; i++)
+			/* We can trust the return value from cap_last_cap(),
+			 * so use that directly. */
+			for (i = 0; i <= cap_last_cap(); i++)
 				cap_update(action, type, i);
 		} else {
 			int cap = capng_name_to_capability(c + 1);


### PR DESCRIPTION
The initial change to lib/caputils that allowed this was commit
5d95818757941bc609e5aeec5e2218f7d35a6e19, which made it possible to
trust the value returned by cap_last_cap().

The error message was also somewhat misleading, since cap_last_cap()
being smaller than CAP_LAST_CAP happens when setpriv itself is built
with kernel headers older than the currently running kernel, not due to
libcap-ng.