### PR TITLE
login(1) maintenance changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -497,6 +497,7 @@ AC_CHECK_DECL([SO_PASSCRED],
 
 AC_CHECK_FUNCS([ \
 	clearenv \
+	close_range \
 	__fpurge \
 	fpurge \
 	__fpending \
@@ -571,6 +572,7 @@ AS_IF([test "x$ul_cv_syscall_setns" = xno], [
 
 UL_CHECK_SYSCALL([pidfd_open])
 UL_CHECK_SYSCALL([pidfd_send_signal])
+UL_CHECK_SYSCALL([close_range])
 
 AC_CHECK_FUNCS([isnan], [],
 	[AC_CHECK_LIB([m], [isnan], [MATH_LIBS="-lm"])]

--- a/include/fileutils.h
+++ b/include/fileutils.h
@@ -53,7 +53,7 @@ static inline int is_same_inode(const int fd, const struct stat *st)
 }
 
 extern int dup_fd_cloexec(int oldfd, int lowfd);
-extern int get_fd_tabsize(void);
+extern unsigned int get_fd_tabsize(void);
 
 extern int mkdir_p(const char *path, mode_t mode);
 extern char *stripoff_last_component(char *path);
@@ -86,7 +86,9 @@ static inline int close_range(unsigned int first, unsigned int last)
 # endif	/* SYS_close_range */
 #endif	/* __linux__ */
 
-extern void close_all_fds(const int exclude[], size_t exsz);
+#ifndef HAVE_CLOSE_RANGE
+extern void close_all_fds(unsigned int first, unsigned int last);
+#endif
 
 #define UL_COPY_READ_ERROR (-1)
 #define UL_COPY_WRITE_ERROR (-2)

--- a/include/fileutils.h
+++ b/include/fileutils.h
@@ -72,6 +72,20 @@ static inline struct dirent *xreaddir(DIR *dp)
 	return d;
 }
 
+#if defined(__linux__)
+# include <sys/syscall.h>
+# if defined(SYS_close_range)
+#  include <sys/types.h>
+#  ifndef HAVE_CLOSE_RANGE
+static inline int close_range(unsigned int first, unsigned int last)
+{
+	return syscall(SYS_close_range, first, last);
+}
+#  endif
+#  define HAVE_CLOSE_RANGE 1
+# endif	/* SYS_close_range */
+#endif	/* __linux__ */
+
 extern void close_all_fds(const int exclude[], size_t exsz);
 
 #define UL_COPY_READ_ERROR (-1)

--- a/login-utils/login.1
+++ b/login-utils/login.1
@@ -1,6 +1,6 @@
 .\" Copyright 1993 Rickard E. Faith (faith@cs.unc.edu)
 .\" May be distributed under the GNU General Public License
-.TH LOGIN "1" "June 2012" "util-linux" "User Commands"
+.TH LOGIN "1" "November 2020" "util-linux" "User Commands"
 .SH NAME
 login \- begin session on the system
 .SH SYNOPSIS
@@ -25,24 +25,25 @@ is used when signing onto a system.  If no argument is given,
 prompts for the username.
 .PP
 The user is then prompted for a password, where appropriate.  Echoing
-is disabled to prevent revealing the password.  Only a small number
+is disabled to prevent revealing the password.  Only a number
 of password failures are permitted before
 .B login
-exits and the communications link is severed.
+exits and the communications link is severed.  See
+.B LOGIN_RETRIES
+in CONFIG FILE ITEMS section.
 .PP
-If password aging has been enabled for the account, the user may be
-prompted for a new password before proceeding.  They will be forced to
-provide their old password and the new password before continuing.
-Please refer to
+If password aging has been enabled for the account, the user may be prompted
+for a new password before proceeding.  In such case old password must be
+provided and the new password entered before continuing.  Please refer to
 .BR passwd (1)
 for more information.
 .PP
 The user and group ID will be set according to their values in the
 .I /etc/passwd
-file.  There is one exception if the user ID is zero: in this case,
+file.  There is one exception if the user ID is zero.  In this case,
 only the primary group ID of the account is set.  This should allow
 the system administrator to login even in case of network problems.
-The value for
+The environment variable values for
 .BR $HOME ,
 .BR $USER ,
 .BR $SHELL ,
@@ -60,32 +61,29 @@ for root, if not otherwise configured.
 .P
 The environment variable
 .B $TERM
-will be preserved, if it exists (other environment variables are
-preserved if the
+will be preserved, if it exists, else it will be initialized to the terminal
+type on your tty.  Other environment variables are preserved if the
 .B \-p
-option is given), else it will be initialized to the terminal type on your tty.
+option is given.
 .PP
-Then the user's shell is started.  If no shell is specified for the
-user in
+Then the user's shell is started.  If no shell is specified for the user in
 .IR /etc\:/passwd ,
 then
 .I /bin\:/sh
-is used.  If there is no directory specified in
+is used.  If there is no home directory specified in
 .IR /etc\:/passwd ,
 then
 .I /
-is used (the home directory is checked for the
+is used, followed by
 .I .hushlogin
-file described below).
+check as described below.
 .PP
 If the file
 .I .hushlogin
-exists, then a "quiet" login is performed (this disables the checking
-of mail and the printing of the last login time and message of the
-day).  Otherwise, if
+exists, then a "quiet" login is performed.  This disables the checking of mail
+and the printing of the last login time and message of the day.  Otherwise, if
 .I /var\:/log\:/lastlog
-exists, the last login time is printed (and the current login is
-recorded).
+exists, the last login time is printed, and the current login is recorded.
 .SH OPTIONS
 .TP
 .B \-p
@@ -93,21 +91,20 @@ Used by
 .BR getty (8)
 to tell
 .B login
-not to destroy the environment.
+to preserve the environment.
 .TP
 .B \-f
-Used to skip a login authentication.  This option is usually
-used by the
+Used to skip a login authentication.  This option is usually used by the
 .BR getty (8)
 autologin feature.
 .TP
 .B \-h
-Used by other servers (i.e.,
+Used by other servers (such as
 .BR telnetd (8))
 to pass the name of the remote host to
 .B login
-so that it may be placed in utmp and wtmp.  Only the superuser may
-use this option.
+so that it can be placed in utmp and wtmp.  Only the superuser is
+allowed use this option.
 .IP
 Note that the
 .B \-h
@@ -120,35 +117,32 @@ but with the
 .B \-h
 option, the name is
 .IR remote .
-It is necessary to create proper PAM config files (e.g.,
+It is necessary to create proper PAM config files (for example,
 .I /etc\:/pam.d\:/login
 and
 .IR /etc\:/pam.d\:/remote ).
 .TP
 .B \-H
-Used by other servers (i.e.,
+Used by other servers (for example,
 .BR telnetd (8))
 to tell
 .B login
-that printing the hostname should be suppressed in the login: prompt.
-See also
+that printing the hostname should be suppressed in the login: prompt.  See also
 .B LOGIN_PLAIN_PROMPT
-below if your server does not allow the
-.B login
-command line to be configured.
+below.
 .TP
-\fB\-\-help\fR
+.B \-\-help
 Display help text and exit.
 .TP
-\fB\-V\fR, \fB\-\-version\fR
+.BR \-V ", " \-\-version
 Display version information and exit.
 .SH CONFIG FILE ITEMS
 .B login
 reads the
 .IR /etc\:/login.defs (5)
-configuration file.  Note that the configuration file could be
-distributed with another package (e.g., shadow-utils).  The following
-configuration items are relevant for
+configuration file.  Note that the configuration file could be distributed with
+another package (usually shadow-utils).  The following configuration items are
+relevant for
 .BR login :
 .PP
 .B MOTD_FILE
@@ -159,12 +153,11 @@ to be displayed upon login.  If the specified path is a directory then displays
 all files with .motd file extension in version-sort order from the directory.
 .PP
 The default value is
-.IR "/usr/share/misc/motd:/run/motd:/etc/motd" .
+.IR "/usr\:/share\:/misc\:/motd:\:/run\:/motd:\:/etc\:/motd" .
 If the
 .B MOTD_FILE
-item is empty or a quiet login is enabled, then the message of the day
-is not displayed.  Note that the same functionality is also provided
-by the
+item is empty or a quiet login is enabled, then the message of the day is not
+displayed.  Note that the same functionality is also provided by the
 .BR pam_motd (8)
 PAM module.
 .PP
@@ -174,14 +167,12 @@ are supported since version 2.36.
 .PP
 Note that
 .B login
-does not implement any filenames overriding behavior like pam_motd
-(see also
+does not implement any filenames overriding behavior like pam_motd (see also
 .BR MOTD_FIRSTONLY ),
-but all content from all files is displayed.  It is
-recommended to keep extra logic in content generators and use
+but all content from all files is displayed.  It is recommended to
+keep extra logic in content generators and use
 .I /run/motd.d
-rather
-than rely on overriding behavior hardcoded in system tools.
+rather than rely on overriding behavior hardcoded in system tools.
 .RE
 .PP
 .B MOTD_FIRSTONLY
@@ -191,11 +182,12 @@ Forces
 .B login
 to stop display content specified by
 .B MOTD_FILE
-after the first accessible item in the list.
-Note that a directory is one item in this case.
-This option allows
+after the first accessible item in the list.  Note that a directory
+is one item in this case.  This option allows
 .B login
-semantics to be configured to be more compatible with pam_motd.
+semantics to be configured to be more compatible with pam_motd.  The
+default value is
+.IR no .
 .RE
 .PP
 .B LOGIN_PLAIN_PROMPT
@@ -203,10 +195,10 @@ semantics to be configured to be more compatible with pam_motd.
 .RS 4
 Tell
 .B login
-that printing the hostname should be suppressed in the login:
-prompt.
-This is an alternative to the \fB\-H\fR command line option.  The default
-value is
+that printing the hostname should be suppressed in the login: prompt.
+This is an alternative to the
+.B \-H
+command line option.  The default value is
 .IR no .
 .RE
 .PP
@@ -230,7 +222,8 @@ value is
 .RS 4
 Tell
 .B login
-to only re-prompt for the password if authentication failed, but the username is valid. The default value is
+to only re-prompt for the password if authentication failed, but the
+username is valid.  The default value is
 .IR no .
 .RE
 .PP
@@ -273,7 +266,7 @@ can be either the name of a group or a numeric group identifier.
 (string)
 .RS 4
 If defined, this file can inhibit all the usual chatter during the
-login sequence.  If a full pathname (e.g.,
+login sequence.  If a full pathname (for example,
 .IR /etc\:/hushlogins )
 is specified, then hushed mode will be enabled if the user\'s name or
 shell are found in the file.  If this global hush login file is empty
@@ -308,16 +301,15 @@ to change directory to their home.  The default value is
 .RS 4
 Highest user ID number for which the
 .I lastlog
-entries should be
-updated.  As higher user IDs are usually tracked by remote user
-identity and authentication services there is no need to create
-a huge sparse
+entries should be updated.  As higher user IDs are usually tracked by
+remote user identity and authentication services there is no need to
+create a huge sparse
 .I lastlog
-file for them.  No LASTLOG_UID_MAX option
-present in the configuration means that there is no user ID limit
-for writing
+file for them.  No LASTLOG_UID_MAX option present in the
+configuration means that there is no user ID limit for writing
 .I lastlog
-entries.
+entries.  The default value is
+.IR ULONG_MAX .
 .RE
 .PP
 .B LOG_UNKFAIL_ENAB
@@ -336,8 +328,7 @@ user enters their password instead of their login name.
 .RS 4
 If set, it will be used to define the
 .B PATH
-environment variable when
-a regular user logs in.  The default value is
+environment variable when a regular user logs in.  The default value is
 .I /usr\:/local\:/bin:\:/bin:\:/usr\:/bin
 .RE
 .PP
@@ -347,8 +338,8 @@ a regular user logs in.  The default value is
 .B ENV_SUPATH
 (string)
 .RS 4
-If set, it will be used to define the PATH environment variable when
-the superuser logs in.  ENV_ROOTPATH takes precedence.  The default value is
+If set, it will be used to define the PATH environment variable when the
+superuser logs in.  ENV_ROOTPATH takes precedence.  The default value is
 .I /usr\:/local\:/sbin:\:/usr\:/local\:/bin:\:/sbin:\:/bin:\:/usr\:/sbin:\:/usr\:/bin
 .RE
 .SH FILES
@@ -363,7 +354,7 @@ the superuser logs in.  ENV_ROOTPATH takes precedence.  The default value is
 .I /etc/pam.d/login
 .I /etc/pam.d/remote
 .I /etc/hushlogins
-.I .hushlogin
+.I $HOME/.hushlogin
 .fi
 .SH BUGS
 The undocumented BSD
@@ -379,14 +370,12 @@ is a satisfactory substitute.  Indeed, for security reasons,
 .B login
 does a
 .BR vhangup (2)
-system call to remove any possible listening
-processes on the tty.  This is to avoid password sniffing.  If one
-uses the command
+system call to remove any possible listening processes on the tty.  This is to
+avoid password sniffing.  If one uses the command
 .BR login ,
 then the surrounding shell gets killed by
 .BR vhangup (2)
-because it's no
-longer the true owner of the tty.  This can be avoided by using
+because it's no longer the true owner of the tty.  This can be avoided by using
 .B exec login
 in a top-level shell or xterm.
 .SH AUTHORS
@@ -416,8 +405,7 @@ Karel Zak
 .BR lastlog (8)
 .BR shutdown (8)
 .SH AVAILABILITY
-The login command is part of the util-linux package and is
-available from
+The login command is part of the util-linux package and is available from
 .UR https://\:www.kernel.org\:/pub\:/linux\:/utils\:/util-linux/
 Linux Kernel Archive
 .UE .

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1294,11 +1294,6 @@ static void initialize(int argc, char **argv, struct login_context *cxt)
 		{"version", no_argument, NULL, 'V'},
 		{NULL, 0, NULL, 0}
 	};
-#ifndef HAVE_CLOSE_RANGE
-	const int wanted_fds[] = {
-		STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO
-	};
-#endif
 
 	timeout = (unsigned int)getlogindefs_num("LOGIN_TIMEOUT", LOGIN_TIMEOUT);
 
@@ -1370,7 +1365,7 @@ static void initialize(int argc, char **argv, struct login_context *cxt)
 #ifdef HAVE_CLOSE_RANGE
 	close_range(STDERR_FILENO + 1, ~0U);
 #else
-	close_all_fds(wanted_fds, ARRAY_SIZE(wanted_fds));
+	close_all_fds(STDERR_FILENO + 1, ~0U);
 #endif
 }
 

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -91,10 +91,6 @@
 # define TTY_MODE 0600
 #endif
 
-#ifndef SPT_BUFSIZE
-# define SPT_BUFSIZE     2048
-#endif
-
 static char **argv0;
 static size_t argv_lth;
 
@@ -260,18 +256,19 @@ static void process_title_init (int argc, char **argv)
 		argv0 = argv;
 }
 
-static void process_title_update (const char *prog, const char *txt)
+static void process_title_update(const char *username)
 {
         size_t i;
-        char buf[SPT_BUFSIZE];
+        const char prefix[] = "login -- ";
+        char buf[sizeof(prefix) + LOGIN_NAME_MAX];
 
         if (!argv0)
                 return;
 
-	if (strlen(prog) + strlen(txt) + 5 > SPT_BUFSIZE)
+	if (sizeof(buf) < (sizeof(prefix) + strlen(username) + 1))
 		return;
 
-	sprintf(buf, "%s -- %s", prog, txt);
+	snprintf(buf, sizeof(buf), "%s%s", prefix, username);
 
         i = strlen(buf);
         if (i > argv_lth - 2) {
@@ -1452,7 +1449,7 @@ int main(int argc, char **argv)
 
 	init_environ(&cxt);		/* init $HOME, $TERM ... */
 
-	process_title_update("login", cxt.username);
+	process_title_update(cxt.username);
 
 	log_syslog(&cxt);
 

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1294,9 +1294,11 @@ static void initialize(int argc, char **argv, struct login_context *cxt)
 		{"version", no_argument, NULL, 'V'},
 		{NULL, 0, NULL, 0}
 	};
+#ifndef HAVE_CLOSE_RANGE
 	const int wanted_fds[] = {
 		STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO
 	};
+#endif
 
 	timeout = (unsigned int)getlogindefs_num("LOGIN_TIMEOUT", LOGIN_TIMEOUT);
 
@@ -1365,8 +1367,11 @@ static void initialize(int argc, char **argv, struct login_context *cxt)
 			*p++ = ' ';
 #endif
 	}
-
+#ifdef HAVE_CLOSE_RANGE
+	close_range(STDERR_FILENO + 1, ~0U);
+#else
 	close_all_fds(wanted_fds, ARRAY_SIZE(wanted_fds));
+#endif
 }
 
 int main(int argc, char **argv)

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1336,8 +1336,12 @@ static void initialize(int argc, char **argv, struct login_context *cxt)
 
 		/* Wipe the name - some people mistype their password here. */
 		/* (Of course we are too late, but perhaps this helps a little...) */
+#ifdef HAVE_EXPLICIT_BZERO
+		explicit_bzero(p, strlen(p));
+#else
 		while (*p)
 			*p++ = ' ';
+#endif
 	}
 
 	close_all_fds(wanted_fds, ARRAY_SIZE(wanted_fds));

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -153,7 +153,7 @@ struct login_context {
  */
 static unsigned int timeout = LOGIN_TIMEOUT;
 static int child_pid = 0;
-static volatile int got_sig = 0;
+static volatile sig_atomic_t got_sig = 0;
 static char timeout_msg[128];
 
 #ifdef LOGIN_CHOWN_VCS

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1159,10 +1159,8 @@ static void init_environ(struct login_context *cxt)
 		termenv = xstrdup(termenv);
 
 	/* destroy environment unless user has requested preservation (-p) */
-	if (!cxt->keep_env) {
-		environ = xmalloc(sizeof(char *));
-		memset(environ, 0, sizeof(char *));
-	}
+	if (!cxt->keep_env)
+		environ = xcalloc(1, sizeof(char *));
 
 	xsetenv("HOME", pwd->pw_dir, 0);	/* legal to override */
 	xsetenv("USER", pwd->pw_name, 1);

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -151,7 +151,6 @@ struct login_context {
  * This bounds the time given to login.  Not a define, so it can
  * be patched on machines where it's too small.
  */
-static unsigned int timeout = LOGIN_TIMEOUT;
 static int child_pid = 0;
 static volatile sig_atomic_t got_sig = 0;
 static char *timeout_msg;
@@ -1260,6 +1259,7 @@ int main(int argc, char **argv)
 	char *buff;
 	int childArgc = 0;
 	int retcode;
+	unsigned int timeout;
 	struct sigaction act;
 	struct passwd *pwd;
 	static const int wanted_fds[] = {

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1284,11 +1284,11 @@ int main(int argc, char **argv)
 		{NULL, 0, NULL, 0}
 	};
 
-	timeout = (unsigned int)getlogindefs_num("LOGIN_TIMEOUT", LOGIN_TIMEOUT);
-
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
+
+	timeout = (unsigned int)getlogindefs_num("LOGIN_TIMEOUT", LOGIN_TIMEOUT);
 
 	/* TRANSLATORS: The standard value for %u is 60. */
 	xasprintf(&timeout_msg, _("%s: timed out after %u seconds"),

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -242,13 +242,10 @@ static void process_title_init(int argc, char **argv)
 	for (i = 0; envp[i] != NULL; i++)
 		continue;
 
-	environ = malloc(sizeof(char *) * (i + 1));
-	if (environ == NULL)
-		return;
+	environ = xmalloc(sizeof(char *) * (i + 1));
 
 	for (i = 0; envp[i] != NULL; i++)
-		if ((environ[i] = strdup(envp[i])) == NULL)
-			return;
+		environ[i] = xstrdup(envp[i]);
 	environ[i] = NULL;
 
 	if (i > 0)

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -46,16 +46,21 @@
 #include <grp.h>
 #include <pwd.h>
 #include <utmpx.h>
+
 #ifdef HAVE_LASTLOG_H
 # include <lastlog.h>
 #endif
+
 #include <stdlib.h>
 #include <sys/syslog.h>
+
 #ifdef HAVE_LINUX_MAJOR_H
 # include <linux/major.h>
 #endif
+
 #include <netdb.h>
 #include <security/pam_appl.h>
+
 #ifdef HAVE_SECURITY_PAM_MISC_H
 # include <security/pam_misc.h>
 #elif defined(HAVE_SECURITY_OPENPAM_H)
@@ -79,7 +84,6 @@
 #include "pwdutils.h"
 
 #include "logindefs.h"
-
 
 #define LOGIN_MAX_TRIES        3
 #define LOGIN_EXIT_TIMEOUT     5
@@ -115,7 +119,6 @@ struct login_context {
 
 	const char	*username;	/* points to PAM, pwd or cmd_username */
 	char            *cmd_username;	/* username specified on command line */
-
 
 	struct passwd	*pwd;		/* user info */
 	char		*pwdbuf;	/* pwd strings */
@@ -174,8 +177,8 @@ static int is_consoletty(int fd)
  * What I did was add a second timeout while trying to write the message, so
  * the process just exits if the second timeout expires.
  */
-static void __attribute__ ((__noreturn__))
-timedout2(int sig __attribute__ ((__unused__)))
+static void __attribute__((__noreturn__))
+    timedout2(int sig __attribute__((__unused__)))
 {
 	struct termios ti;
 
@@ -186,7 +189,7 @@ timedout2(int sig __attribute__ ((__unused__)))
 	_exit(EXIT_SUCCESS);	/* %% */
 }
 
-static void timedout(int sig __attribute__ ((__unused__)))
+static void timedout(int sig __attribute__((__unused__)))
 {
 	signal(SIGALRM, timedout2);
 	alarm(10);
@@ -219,13 +222,13 @@ static void sig_handler(int signal)
  * Let us delay all exit() calls when the user is not authenticated
  * or the session not fully initialized (loginpam_session()).
  */
-static void __attribute__ ((__noreturn__)) sleepexit(int eval)
+static void __attribute__((__noreturn__)) sleepexit(int eval)
 {
 	sleep((unsigned int)getlogindefs_num("FAIL_DELAY", LOGIN_EXIT_TIMEOUT));
 	exit(eval);
 }
 
-static void process_title_init (int argc, char **argv)
+static void process_title_init(int argc, char **argv)
 {
 	int i;
 	char **envp = environ;
@@ -249,36 +252,36 @@ static void process_title_init (int argc, char **argv)
 	environ[i] = NULL;
 
 	if (i > 0)
-		argv_lth = envp[i-1] + strlen(envp[i-1]) - argv[0];
+		argv_lth = envp[i - 1] + strlen(envp[i - 1]) - argv[0];
 	else
-		argv_lth = argv[argc-1] + strlen(argv[argc-1]) - argv[0];
+		argv_lth = argv[argc - 1] + strlen(argv[argc - 1]) - argv[0];
 	if (argv_lth > 1)
 		argv0 = argv;
 }
 
 static void process_title_update(const char *username)
 {
-        size_t i;
-        const char prefix[] = "login -- ";
-        char buf[sizeof(prefix) + LOGIN_NAME_MAX];
+	size_t i;
+	const char prefix[] = "login -- ";
+	char buf[sizeof(prefix) + LOGIN_NAME_MAX];
 
-        if (!argv0)
-                return;
+	if (!argv0)
+		return;
 
 	if (sizeof(buf) < (sizeof(prefix) + strlen(username) + 1))
 		return;
 
 	snprintf(buf, sizeof(buf), "%s%s", prefix, username);
 
-        i = strlen(buf);
-        if (i > argv_lth - 2) {
-                i = argv_lth - 2;
-                buf[i] = '\0';
-        }
-	memset(argv0[0], '\0', argv_lth);       /* clear the memory area */
-        strcpy(argv0[0], buf);
+	i = strlen(buf);
+	if (i > argv_lth - 2) {
+		i = argv_lth - 2;
+		buf[i] = '\0';
+	}
+	memset(argv0[0], '\0', argv_lth);	/* clear the memory area */
+	strcpy(argv0[0], buf);
 
-        argv0[1] = NULL;
+	argv0[1] = NULL;
 }
 
 static const char *get_thishost(struct login_context *cxt, const char **domain)
@@ -323,10 +326,10 @@ static int motddir_filter(const struct dirent *d)
 
 static int motddir(const char *dirname)
 {
-        int dd, nfiles, i, done = 0;
-        struct dirent **namelist = NULL;
+	int dd, nfiles, i, done = 0;
+	struct dirent **namelist = NULL;
 
-	dd = open(dirname, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+	dd = open(dirname, O_RDONLY | O_CLOEXEC | O_DIRECTORY);
 	if (dd < 0)
 		return 0;
 
@@ -338,7 +341,7 @@ static int motddir(const char *dirname)
 		struct dirent *d = namelist[i];
 		int fd;
 
-		fd = openat(dd, d->d_name, O_RDONLY|O_CLOEXEC);
+		fd = openat(dd, d->d_name, O_RDONLY | O_CLOEXEC);
 		if (fd >= 0) {
 			ul_copy_file(fd, fileno(stdout));
 			close(fd);
@@ -554,7 +557,6 @@ static void init_tty(struct login_context *cxt)
 	tcsetattr(0, TCSAFLUSH, &tt);
 }
 
-
 /*
  * Logs failed login attempts in _PATH_BTMP, if it exists.
  * Must be called only with username the name of an actual user.
@@ -593,7 +595,6 @@ static void log_btmp(struct login_context *cxt)
 	updwtmpx(_PATH_BTMP, &ut);
 }
 
-
 #ifdef HAVE_LIBAUDIT
 static void log_audit(struct login_context *cxt, int status)
 {
@@ -611,7 +612,7 @@ static void log_audit(struct login_context *cxt, int status)
 			       NULL,
 			       "login",
 			       cxt->username ? cxt->username : "(unknown)",
-			       pwd ? pwd->pw_uid : (unsigned int) -1,
+			       pwd ? pwd->pw_uid : (unsigned int)-1,
 			       cxt->hostname,
 			       NULL,
 			       cxt->tty_name,
@@ -656,7 +657,7 @@ static void log_lastlog(struct login_context *cxt)
 			char time_string[CTIME_BUFSIZ];
 			char buf[sizeof(ll.ll_host) + 1];
 
-			time_t ll_time = (time_t) ll.ll_time;
+			time_t ll_time = (time_t)ll.ll_time;
 
 			ctime_r(&ll_time, time_string);
 			printf(_("Last login: %.*s "), 24 - 5, time_string);
@@ -695,9 +696,9 @@ done:
  */
 static void log_utmp(struct login_context *cxt)
 {
-	struct utmpx ut = {0};
+	struct utmpx ut = { 0 };
 	struct utmpx *utp = NULL;
-	struct timeval tv = {0};
+	struct timeval tv = { 0 };
 
 	utmpxname(_PATH_UTMP);
 	setutxent();
@@ -728,10 +729,10 @@ static void log_utmp(struct login_context *cxt)
 	/* If we can't find a pre-existing entry by pid and line, try it by id.
 	 * Very stupid telnetd daemons don't set up utmp at all. (kzak) */
 	if (utp == NULL && cxt->tty_number) {
-	     setutxent();
-	     ut.ut_type = DEAD_PROCESS;
-	     str2memcpy(ut.ut_id, cxt->tty_number, sizeof(ut.ut_id));
-	     utp = getutxid(&ut);
+		setutxent();
+		ut.ut_type = DEAD_PROCESS;
+		str2memcpy(ut.ut_id, cxt->tty_number, sizeof(ut.ut_id));
+		utp = getutxid(&ut);
 	}
 
 	if (utp)
@@ -797,6 +798,7 @@ static int loginpam_get_username(pam_handle_t *pamh, const char **name)
 {
 	const void *item = (const void *)*name;
 	int rc;
+
 	rc = pam_get_item(pamh, PAM_USER, &item);
 	*name = (const char *)item;
 	return rc;
@@ -936,7 +938,6 @@ static void loginpam_auth(struct login_context *cxt)
 
 		log_btmp(cxt);
 		log_audit(cxt, 0);
-
 
 		if (!keep_username || rc == PAM_USER_UNKNOWN) {
 			pam_set_item(pamh, PAM_USER, NULL);
@@ -1094,9 +1095,9 @@ static void fork_session(struct login_context *cxt)
 		/*
 		 * parent - wait for child to finish, then clean up session
 		 */
-		close(0);
-		close(1);
-		close(2);
+		close(STDIN_FILENO);
+		close(STDOUT_FILENO);
+		close(STDERR_FILENO);
 		free_getlogindefs_data();
 
 		sa.sa_handler = SIG_IGN;
@@ -1176,7 +1177,7 @@ static void init_environ(struct login_context *cxt)
 
 	/* mailx will give a funny error msg if you forget this one */
 	len = snprintf(tmp, sizeof(tmp), "%s/%s", _PATH_MAILDIR, pwd->pw_name);
-	if (len > 0 && (size_t) len < sizeof(tmp))
+	if (len > 0 && (size_t)len < sizeof(tmp))
 		xsetenv("MAIL", tmp, 0);
 
 	/* LOGNAME is not documented in login(1) but HP-UX 6.5 does it. We'll
@@ -1215,17 +1216,17 @@ static void init_remote_info(struct login_context *cxt, char *remotehost)
 	if (getaddrinfo(cxt->hostname, NULL, &hints, &info) == 0 && info) {
 		if (info->ai_family == AF_INET) {
 			struct sockaddr_in *sa =
-				    (struct sockaddr_in *) info->ai_addr;
+				    (struct sockaddr_in *)info->ai_addr;
 
 			memcpy(cxt->hostaddress, &(sa->sin_addr), sizeof(sa->sin_addr));
 
 		} else if (info->ai_family == AF_INET6) {
 			struct sockaddr_in6 *sa =
-				     (struct sockaddr_in6 *) info->ai_addr;
+				     (struct sockaddr_in6 *)info->ai_addr;
 #ifdef IN6_IS_ADDR_V4MAPPED
 			if (IN6_IS_ADDR_V4MAPPED(&sa->sin6_addr)) {
 				const uint8_t *bytes = sa->sin6_addr.s6_addr;
-				struct in_addr addr = { *(const in_addr_t *) (bytes + 12) };
+				struct in_addr addr = { *(const in_addr_t *)(bytes + 12) };
 
 				memcpy(cxt->hostaddress, &addr, sizeof(struct in_addr));
 			} else
@@ -1344,8 +1345,8 @@ static void initialize(int argc, char **argv, struct login_context *cxt)
 
 int main(int argc, char **argv)
 {
-	char *childArgv[10];
-	int childArgc = 0;
+	char *child_argv[10];
+	int child_argc = 0;
 	struct passwd *pwd;
 	struct login_context cxt = {
 		.tty_mode = TTY_MODE,		  /* tty chmod() */
@@ -1355,7 +1356,6 @@ int main(int argc, char **argv)
 #elif defined(HAVE_SECURITY_OPENPAM_H)
 		.conv = { openpam_ttyconv, NULL } /* OpenPAM conversation function */
 #endif
-
 	};
 
 	setlocale(LC_ALL, "");
@@ -1410,7 +1410,7 @@ int main(int argc, char **argv)
 		int retcode;
 
 		retcode = pwd->pw_uid ? initgroups(cxt.username, pwd->pw_gid) :	/* user */
-				        setgroups(0, NULL);			/* root */
+					setgroups(0, NULL);			/* root */
 		if (retcode < 0) {
 			syslog(LOG_ERR, _("groups initialization failed: %m"));
 			warnx(_("\nSession setup problem, abort."));
@@ -1507,10 +1507,10 @@ int main(int argc, char **argv)
 		char *buff;
 
 		xasprintf(&buff, "exec %s", pwd->pw_shell);
-		childArgv[childArgc++] = "/bin/sh";
-		childArgv[childArgc++] = "-sh";
-		childArgv[childArgc++] = "-c";
-		childArgv[childArgc++] = buff;
+		child_argv[child_argc++] = "/bin/sh";
+		child_argv[child_argc++] = "-sh";
+		child_argv[child_argc++] = "-c";
+		child_argv[child_argc++] = buff;
 	} else {
 		char tbuf[PATH_MAX + 2], *p;
 
@@ -1518,15 +1518,15 @@ int main(int argc, char **argv)
 		xstrncpy(tbuf + 1, ((p = strrchr(pwd->pw_shell, '/')) ?
 				    p + 1 : pwd->pw_shell), sizeof(tbuf) - 1);
 
-		childArgv[childArgc++] = pwd->pw_shell;
-		childArgv[childArgc++] = xstrdup(tbuf);
+		child_argv[child_argc++] = pwd->pw_shell;
+		child_argv[child_argc++] = xstrdup(tbuf);
 	}
 
-	childArgv[childArgc++] = NULL;
+	child_argv[child_argc++] = NULL;
 
-	execvp(childArgv[0], childArgv + 1);
+	execvp(child_argv[0], child_argv + 1);
 
-	if (!strcmp(childArgv[0], "/bin/sh"))
+	if (!strcmp(child_argv[0], "/bin/sh"))
 		warn(_("couldn't exec shell script"));
 	else
 		warn(_("no shell"));

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -80,7 +80,6 @@
 
 #include "logindefs.h"
 
-#define is_pam_failure(_rc)	((_rc) != PAM_SUCCESS)
 
 #define LOGIN_MAX_TRIES        3
 #define LOGIN_EXIT_TIMEOUT     5
@@ -444,12 +443,15 @@ static void open_tty(const char *tty)
 		close(fd);
 }
 
-#define chown_err(_what, _uid, _gid) \
-		syslog(LOG_ERR, _("chown (%s, %lu, %lu) failed: %m"), \
-			(_what), (unsigned long) (_uid), (unsigned long) (_gid))
+static inline void chown_err(const char *what, uid_t uid, gid_t gid)
+{
+	syslog(LOG_ERR, _("chown (%s, %u, %u) failed: %m"), what, uid, gid);
+}
 
-#define chmod_err(_what, _mode) \
-		syslog(LOG_ERR, _("chmod (%s, %u) failed: %m"), (_what), (_mode))
+static inline void chmod_err(const char *what, mode_t mode)
+{
+	syslog(LOG_ERR, _("chmod (%s, %u) failed: %m"), what, mode);
+}
 
 static void chown_tty(struct login_context *cxt)
 {
@@ -839,6 +841,11 @@ static const char *loginpam_get_prompt(struct login_context *cxt)
 	snprintf(prompt, sz, "%s %s", host, dflt_prompt);
 
 	return prompt;
+}
+
+static inline int is_pam_failure(int rc)
+{
+	return rc != PAM_SUCCESS;
 }
 
 static pam_handle_t *init_loginpam(struct login_context *cxt)


### PR DESCRIPTION
This change set was originally inspired the recent uuidd(8) work I did where I thought it would be quite good idea to keep memory allocations of an executable that stays running minimal. There are not many such commands in util-linux, but login definitely is one of them. Most of the changes in this pull are about the objective of making login smaller. 

While looking into the source couple other things seemed like good ideas to fix so they were added as well, such as use  of close_range() that hopefully will speed up getting onto a system. And I went through the manual page that is hopefully a tiny bit better, though I am sure it could still be made better.

This is obviously not an urgent change, as no bugs (apart maybe ad3ad51be6fc1c3dcc13ed8a77e703d97c72ff3d) were fixed. Everything should fall either to category of minor improvement or cosmetic.