### PR TITLE
losetup: fix wrong printf() format specifier for ino_t data type

### DIFF
--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -144,8 +144,8 @@ static int printf_loopdev(struct loopdev_cxt *lc)
 		goto done;
 	}
 
-	printf("%s: [%04d]:%" PRIu64 " (%s)",
-		loopcxt_get_device(lc), (int) dev, ino, fname);
+	printf("%s: [%04jd]:%ju (%s)",
+		loopcxt_get_device(lc), (intmax_t) dev, (uintmax_t) ino, fname);
 
 	if (loopcxt_get_offset(lc, &x) == 0 && x)
 			printf(_(", offset %ju"), x);


### PR DESCRIPTION
Since the range of the ino_t data type is platform-specific (depending on the wordsize), a usage of the fixed format specifier `%PRIu64` is not correct for ino_t on some 32-bit architectures, eg. ARM (Raspberry Pi 1). This issue may lead to undefinied output and is not reported by gcc (in version 10.2.0 and 8.3.0-6+rpi1) even though `-Wformat` is enabled by `-Wall`. Therefore it is most likely that it seems to be a false negative error in gcc's format specifier check, so that this issue was never detected before.

This change fixes the issue by the use of a cast, since there is no platform-independent format specifier for ino_t available. The wrong format specifier `%PRIu64` is replaced by `%ju`, where its corresponding variable of type ino_t is casted to uintmax_t. The type uintmax_t represents the largest platform-specific unsigned integer, so that all integer values are preserved for a platform-independent printing.

Fixes: https://github.com/karelzak/util-linux/issues/1211
Signed-off-by: Manuel Bentele <development@manuel-bentele.de>