### PR TITLE
Implemented cfdisk's opening in read-only mode

### DIFF
--- a/bash-completion/cfdisk
+++ b/bash-completion/cfdisk
@@ -19,6 +19,7 @@ _cfdisk_module()
 				--zero
 				--lock
 				--help
+				--read-only
 				--version"
 			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
 			return 0

--- a/disk-utils/cfdisk.8
+++ b/disk-utils/cfdisk.8
@@ -69,6 +69,10 @@ environment variable \fB$LOCK_BLOCK_DEVICE\fR.  The default is not to use any
 lock at all, but it's recommended to avoid collisions with udevd or other
 tools.
 .TP
+.BR \-r , " \-\-read-only"
+Forced open in read-only mode.
+.TP
+.TP
 .BR \-V , " \-\-version"
 Display version information and exit.
 .TP

--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -267,6 +267,9 @@ UL_DEBUG_DEFINE_MASKNAMES(cfdisk) = UL_DEBUG_EMPTY_MASKNAMES;
 #define CFDISK_DEBUG_TABLE	(1 << 5)
 #define CFDISK_DEBUG_ALL	0xFFFF
 
+#ifdef DBG
+# undef DBG
+#endif
 #define DBG(m, x)       __UL_DBG(cfdisk, CFDISK_DEBUG_, m, x)
 
 static void cfdisk_init_debug(void)

--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -22,7 +22,7 @@
 #include <libsmartcols.h>
 #include <sys/ioctl.h>
 #include <libfdisk.h>
-#include <fdiskP.h>
+#include <libfdisk/src/fdiskP.h>
 #include <sys/stat.h>
 
 #ifdef HAVE_LIBMOUNT

--- a/libfdisk/src/fdiskP.h
+++ b/libfdisk/src/fdiskP.h
@@ -16,7 +16,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <uuid.h>
+#include <uuid/uuid.h>
 
 #include "c.h"
 #include "libfdisk.h"

--- a/libfdisk/src/fdiskP.h
+++ b/libfdisk/src/fdiskP.h
@@ -16,7 +16,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <uuid/uuid.h>
+#include <libuuid/src/uuid.h>
 
 #include "c.h"
 #include "libfdisk.h"

--- a/po/fr.po
+++ b/po/fr.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: util-linux 2.36-rc2\n"
 "Report-Msgid-Bugs-To: util-linux@vger.kernel.org\n"
-"POT-Creation-Date: 2020-07-09 12:54+0200\n"
+"POT-Creation-Date: 2020-07-22 12:05+0200\n"
 "PO-Revision-Date: 2020-07-23 08:09+0200\n"
 "Last-Translator: Frédéric Marchal <fmarchal@perso.be>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -485,8 +485,7 @@ msgstr "Échec d’écriture du script %s"
 msgid "Select label type"
 msgstr "Sélectionner un type d’étiquette"
 
-#: disk-utils/cfdisk.c:2131 disk-utils/fdisk.c:1158
-#: disk-utils/fdisk-menu.c:489
+#: disk-utils/cfdisk.c:2131 disk-utils/fdisk.c:1158 disk-utils/fdisk-menu.c:489
 msgid "Device does not contain a recognized partition table."
 msgstr "Le périphérique ne contient pas de table de partitions reconnue."
 
@@ -753,8 +752,8 @@ msgstr ""
 "Poursuite du traitement… "
 
 #: disk-utils/fdformat.c:146 disk-utils/fsck.minix.c:183
-#: disk-utils/swaplabel.c:123 misc-utils/wipefs.c:648
-#: sys-utils/blkdiscard.c:86 sys-utils/tunelp.c:95
+#: disk-utils/swaplabel.c:123 misc-utils/wipefs.c:648 sys-utils/blkdiscard.c:86
+#: sys-utils/tunelp.c:95
 #, c-format
 msgid " %s [options] <device>\n"
 msgstr " %s [options] <périphérique>\n"
@@ -1121,21 +1120,21 @@ msgstr "mode nettoyage non pris en charge"
 msgid "The device properties (sector size and geometry) should be used with one specified device only."
 msgstr "Les propriétés du périphérique (taille de secteur et géométrie) ne doivent être utilisées qu’avec un seul périphérique indiqué."
 
-#: disk-utils/fdisk.c:1109 disk-utils/fdisk.c:1124
-#: disk-utils/fsck.cramfs.c:696 disk-utils/mkfs.bfs.c:192
-#: disk-utils/mkfs.cramfs.c:786 disk-utils/partx.c:975 disk-utils/raw.c:136
-#: disk-utils/raw.c:149 disk-utils/raw.c:161 disk-utils/raw.c:202
-#: misc-utils/cal.c:534 misc-utils/findfs.c:58 misc-utils/look.c:149
-#: misc-utils/whereis.c:577 misc-utils/whereis.c:588 misc-utils/whereis.c:599
-#: misc-utils/whereis.c:641 schedutils/chrt.c:513 schedutils/ionice.c:262
-#: schedutils/taskset.c:188 sys-utils/chcpu.c:355 sys-utils/chmem.c:422
-#: sys-utils/dmesg.c:1505 sys-utils/ipcmk.c:138 sys-utils/ldattach.c:320
-#: sys-utils/losetup.c:913 sys-utils/lscpu.c:2426 sys-utils/lsmem.c:643
-#: sys-utils/mount.c:824 sys-utils/mount.c:832 sys-utils/mount.c:879
-#: sys-utils/mount.c:892 sys-utils/mount.c:964 sys-utils/mountpoint.c:189
-#: sys-utils/pivot_root.c:71 sys-utils/swapoff.c:258 sys-utils/swapon.c:992
-#: sys-utils/switch_root.c:249 sys-utils/umount.c:598
-#: term-utils/setterm.c:1197 text-utils/col.c:233 text-utils/more.c:2058
+#: disk-utils/fdisk.c:1109 disk-utils/fdisk.c:1124 disk-utils/fsck.cramfs.c:696
+#: disk-utils/mkfs.bfs.c:192 disk-utils/mkfs.cramfs.c:786
+#: disk-utils/partx.c:975 disk-utils/raw.c:136 disk-utils/raw.c:149
+#: disk-utils/raw.c:161 disk-utils/raw.c:202 misc-utils/cal.c:534
+#: misc-utils/findfs.c:58 misc-utils/look.c:149 misc-utils/whereis.c:577
+#: misc-utils/whereis.c:588 misc-utils/whereis.c:599 misc-utils/whereis.c:641
+#: schedutils/chrt.c:513 schedutils/ionice.c:262 schedutils/taskset.c:188
+#: sys-utils/chcpu.c:355 sys-utils/chmem.c:422 sys-utils/dmesg.c:1505
+#: sys-utils/ipcmk.c:138 sys-utils/ldattach.c:320 sys-utils/losetup.c:913
+#: sys-utils/lscpu.c:2426 sys-utils/lsmem.c:643 sys-utils/mount.c:824
+#: sys-utils/mount.c:832 sys-utils/mount.c:879 sys-utils/mount.c:892
+#: sys-utils/mount.c:964 sys-utils/mountpoint.c:189 sys-utils/pivot_root.c:71
+#: sys-utils/swapoff.c:258 sys-utils/swapon.c:992 sys-utils/switch_root.c:249
+#: sys-utils/umount.c:598 term-utils/setterm.c:1197 text-utils/col.c:233
+#: text-utils/more.c:2058
 msgid "bad usage"
 msgstr "mauvaise utilisation"
 
@@ -1208,7 +1207,7 @@ msgstr "échec d'allocation d'itérateur"
 
 #: disk-utils/fdisk-list.c:126 disk-utils/fdisk-list.c:247
 #: disk-utils/partx.c:669 login-utils/lslogins.c:1066 misc-utils/fincore.c:356
-#: misc-utils/findmnt.c:1634 misc-utils/lsblk.c:2082 misc-utils/lslocks.c:456
+#: misc-utils/findmnt.c:1634 misc-utils/lsblk.c:2083 misc-utils/lslocks.c:456
 #: misc-utils/uuidparse.c:252 misc-utils/wipefs.c:157 sys-utils/losetup.c:325
 #: sys-utils/lscpu.c:1674 sys-utils/lscpu.c:1902 sys-utils/lscpu.c:2034
 #: sys-utils/lsipc.c:351 sys-utils/prlimit.c:297 sys-utils/rfkill.c:459
@@ -3609,11 +3608,11 @@ msgstr "%s : échec de configuration du périphérique boucle"
 
 #: disk-utils/partx.c:161 login-utils/lslogins.c:320 misc-utils/fincore.c:92
 #: misc-utils/findmnt.c:376 misc-utils/lsblk.c:317 misc-utils/lslocks.c:344
-#: misc-utils/uuidparse.c:125 misc-utils/wipefs.c:132
-#: sys-utils/irq-common.c:70 sys-utils/losetup.c:112 sys-utils/lscpu.c:241
-#: sys-utils/lscpu.c:256 sys-utils/lsipc.c:232 sys-utils/lsmem.c:178
-#: sys-utils/lsns.c:225 sys-utils/prlimit.c:277 sys-utils/rfkill.c:159
-#: sys-utils/swapon.c:150 sys-utils/wdctl.c:161 sys-utils/zramctl.c:147
+#: misc-utils/uuidparse.c:125 misc-utils/wipefs.c:132 sys-utils/irq-common.c:70
+#: sys-utils/losetup.c:112 sys-utils/lscpu.c:241 sys-utils/lscpu.c:256
+#: sys-utils/lsipc.c:232 sys-utils/lsmem.c:178 sys-utils/lsns.c:225
+#: sys-utils/prlimit.c:277 sys-utils/rfkill.c:159 sys-utils/swapon.c:150
+#: sys-utils/wdctl.c:161 sys-utils/zramctl.c:147
 #, c-format
 msgid "unknown column: %s"
 msgstr "colonne inconnue : %s"
@@ -3711,7 +3710,7 @@ msgstr[0] "nº %2d : %9ju-%9ju (%9ju secteur, %6ju Mo)\n"
 msgstr[1] "nº %2d : %9ju-%9ju (%9ju secteurs, %6ju Mo)\n"
 
 #: disk-utils/partx.c:680 misc-utils/fincore.c:370 misc-utils/findmnt.c:1662
-#: misc-utils/lsblk.c:2121 misc-utils/lslocks.c:471 sys-utils/losetup.c:339
+#: misc-utils/lsblk.c:2122 misc-utils/lslocks.c:471 sys-utils/losetup.c:339
 #: sys-utils/lscpu.c:1683 sys-utils/lscpu.c:1911 sys-utils/prlimit.c:306
 #: sys-utils/rfkill.c:471 sys-utils/swapon.c:292 sys-utils/wdctl.c:310
 msgid "failed to allocate output column"
@@ -5828,7 +5827,7 @@ msgstr "Étiquette de disque écrite sur %s. (N'oubliez pas d'écrire aussi l'é
 msgid "Disklabel written to %s."
 msgstr "Étiquette de disque écrite sur %s."
 
-#: libfdisk/src/bsd.c:920 libfdisk/src/context.c:751
+#: libfdisk/src/bsd.c:920 libfdisk/src/context.c:753
 msgid "Syncing disks."
 msgstr "Synchronisation des disques."
 
@@ -5857,60 +5856,60 @@ msgstr "TailleB"
 msgid "Cpg"
 msgstr "Cpg"
 
-#: libfdisk/src/context.c:741
+#: libfdisk/src/context.c:743
 #, c-format
 msgid "%s: fsync device failed"
 msgstr "%s : échec de fsync sur le périphérique"
 
-#: libfdisk/src/context.c:746
+#: libfdisk/src/context.c:748
 #, c-format
 msgid "%s: close device failed"
 msgstr "%s : échec de fermeture du périphérique"
 
-#: libfdisk/src/context.c:826
+#: libfdisk/src/context.c:828
 msgid "Calling ioctl() to re-read partition table."
 msgstr "Appel d'ioctl() pour relire la table de partitions."
 
-#: libfdisk/src/context.c:834
+#: libfdisk/src/context.c:836
 msgid "Re-reading the partition table failed."
 msgstr "Échec de relecture de la table de partitions."
 
-#: libfdisk/src/context.c:836
+#: libfdisk/src/context.c:838
 msgid "The kernel still uses the old table. The new table will be used at the next reboot or after you run partprobe(8) or partx(8)."
 msgstr "Le noyau continue à utiliser l'ancienne table. La nouvelle sera utilisée lors du prochain démarrage ou après avoir exécuté partprobe(8) ou partx(8)."
 
-#: libfdisk/src/context.c:926
+#: libfdisk/src/context.c:928
 #, c-format
 msgid "Failed to remove partition %zu from system"
 msgstr "Impossible de retirer la partition %zu du système"
 
-#: libfdisk/src/context.c:935
+#: libfdisk/src/context.c:937
 #, c-format
 msgid "Failed to update system information about partition %zu"
 msgstr "Impossible de mettre à jour les informations du système à propos de la partition %zu"
 
-#: libfdisk/src/context.c:944
+#: libfdisk/src/context.c:946
 #, c-format
 msgid "Failed to add partition %zu to system"
 msgstr "Impossible d'ajouter la partition %zu au système"
 
-#: libfdisk/src/context.c:950
+#: libfdisk/src/context.c:952
 msgid "The kernel still uses the old partitions. The new table will be used at the next reboot. "
 msgstr "Le noyau continue à utiliser les anciennes partitions. La nouvelle table sera utilisée lors du prochain démarrage. "
 
-#: libfdisk/src/context.c:1161
+#: libfdisk/src/context.c:1163
 msgid "cylinder"
 msgid_plural "cylinders"
 msgstr[0] "cylindre"
 msgstr[1] "cylindres"
 
-#: libfdisk/src/context.c:1162
+#: libfdisk/src/context.c:1164
 msgid "sector"
 msgid_plural "sectors"
 msgstr[0] "secteur"
 msgstr[1] "secteurs"
 
-#: libfdisk/src/context.c:1518
+#: libfdisk/src/context.c:1520
 msgid "Incomplete geometry setting."
 msgstr "Configuration incomplète de la géométrie."
 
@@ -7682,9 +7681,9 @@ msgstr ""
 "\n"
 "%s commence %s\n"
 
-#: login-utils/last.c:976 term-utils/scriptlive.c:85
-#: term-utils/scriptlive.c:89 term-utils/scriptreplay.c:79
-#: term-utils/scriptreplay.c:83 text-utils/more.c:280 text-utils/more.c:286
+#: login-utils/last.c:976 term-utils/scriptlive.c:85 term-utils/scriptlive.c:89
+#: term-utils/scriptreplay.c:79 term-utils/scriptreplay.c:83
+#: text-utils/more.c:280 text-utils/more.c:286
 msgid "failed to parse number"
 msgstr "échec d'analyse du numéro"
 
@@ -10717,7 +10716,7 @@ msgstr "     --sysroot <rép.> utiliser ce répertoire comme racine du système\
 msgid "failed to access sysfs directory: %s"
 msgstr "échec d'accès au répertoire de système de fichiers : %s"
 
-#: misc-utils/lsblk.c:2153
+#: misc-utils/lsblk.c:2154
 msgid "failed to allocate device tree"
 msgstr "échec d'allocation l'arbre des périphériques"
 
@@ -11971,9 +11970,8 @@ msgstr "échec d'analyse de position"
 msgid "failed to parse step"
 msgstr "échec d'analyse du pas"
 
-#: sys-utils/blkdiscard.c:219 sys-utils/blkzone.c:463
-#: sys-utils/fallocate.c:379 sys-utils/fsfreeze.c:110 sys-utils/fstrim.c:532
-#: sys-utils/umount.c:588
+#: sys-utils/blkdiscard.c:219 sys-utils/blkzone.c:463 sys-utils/fallocate.c:379
+#: sys-utils/fsfreeze.c:110 sys-utils/fstrim.c:532 sys-utils/umount.c:588
 msgid "unexpected number of arguments"
 msgstr "nombre d'arguments inattendu"
 
@@ -12095,8 +12093,8 @@ msgid "%s: %s ioctl failed"
 msgstr "%s : échec d'ioctl %s"
 
 #: sys-utils/blkzone.c:345
-#, c-format
-msgid "%s: successfull %s of zones in range from %<PRIu64>, to %<PRIu64>"
+#, fuzzy, c-format
+msgid "%s: successful %s of zones in range from %<PRIu64>, to %<PRIu64>"
 msgstr "%s : %s réussi des zones dans la plage de %<PRIu64> à %<PRIu64>"
 
 #: sys-utils/blkzone.c:360
@@ -14811,7 +14809,8 @@ msgid "failed to add line to output"
 msgstr "échec d'ajout d'une ligne en sortie"
 
 #: sys-utils/irq-common.c:348
-msgid "unssupported column name to sort output"
+#, fuzzy
+msgid "unsupported column name to sort output"
 msgstr "nom de colonne non supporté pour trier la sortie"
 
 #: sys-utils/irqtop.c:114


### PR DESCRIPTION
I have implemented opening cfdisk in read-only mode. For this i added "-r" key, if user (even root) will pass this key to cfdisk, then device would be opened in read-only mode. Otherway, if user is root, then device would be opened in writeable mode and if user isn't root, then read-only mode would be forced if this is possible (if 'r' bit is set in permissions of "others", for example, if permissions of device are rw-rw-r--).

Fixed: https://github.com/karelzak/util-linux/issues/1209