### PR TITLE
mount.pc: fix bad pkgconfig variable

### DIFF
--- a/libmount/mount.pc.in
+++ b/libmount/mount.pc.in
@@ -17,7 +17,7 @@ includedir=@includedir@
 Name: mount
 Description: mount library
 Version: @LIBMOUNT_VERSION@
-Requires.private: blkid @LIBSELINUX@ @LIBCRYPTSETUP@
+Requires.private: blkid @SELINUX_LIBS@ @CRYPTSETUP_LIBS@
 Cflags: -I${includedir}/libmount
 Libs: -L${libdir} -lmount
 Libs.private: @LIBDL@


### PR DESCRIPTION
Because of the lib prefix, it's not getting substituted properly and
breaks compilation of other packages.

Fixes error with at least btrfs-progs:

Package '@LIBSELINUX@', required by 'mount', not found
Package '@LIBCRYPTSETUP@', required by 'mount', not found

Signed-off-by: Rosen Penev <rosenp@gmail.com>