### PR TITLE
libmount: add vboxsf, virtiofs to pseudo filesystems

### DIFF
--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -332,7 +332,9 @@ int mnt_fstype_is_pseudofs(const char *type)
 		"spufs",
 		"sysfs",
 		"tmpfs",
-		"tracefs"
+		"tracefs",
+		"vboxsf",
+		"virtiofs"
 	};
 
 	assert(type);


### PR DESCRIPTION
Filesystems provided by a hypervisor for guest kernels:
* vboxsf: Linux 5.6
* virtiofs: Linux 5.4

Signed-off-by: Shahid Laher <govellius@gmail.com>