### PR TITLE
agetty: Allow --init-string on a virtual console

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -439,7 +439,7 @@ int main(int argc, char **argv)
 	termio_init(&options, &termios);
 
 	/* Write the modem init string and DO NOT flush the buffers. */
-	if (serial_tty_option(&options, F_INITSTRING) &&
+	if (options.flags & F_INITSTRING &&
 	    options.initstring && *options.initstring != '\0') {
 		debug("writing init string\n");
 		write_all(STDOUT_FILENO, options.initstring,


### PR DESCRIPTION
This option has valid use cases on virtual consoles. Example:
enabling screen blanking in the same way as `setterm --blank ...`
does.