### PR TITLE
agetty: tty eol defaults to REPRINT

### DIFF
--- a/include/ttyutils.h
+++ b/include/ttyutils.h
@@ -73,7 +73,7 @@ struct chardata {
 #define INIT_CHARDATA(ptr) do {              \
 		(ptr)->erase    = DEF_ERASE; \
 		(ptr)->kill     = DEF_KILL;  \
-		(ptr)->eol      = CTRL('r'); \
+		(ptr)->eol      = CR;        \
 	        (ptr)->parity   = 0;         \
 	        (ptr)->capslock = 0;         \
 	} while (0)


### PR DESCRIPTION
Adapting tty eol settings from defaults misbehaves as CTRL('r') aka
REPRINT is confused with CR. Consequently --skip-login does not set
tty CR<->NL translations and thus acts against advertised CR as eol
default.