### PR TITLE
stable/2.36: cherry-picking capability fixes

### DIFF
--- a/include/procutils.h
+++ b/include/procutils.h
@@ -2,6 +2,7 @@
 #define UTIL_LINUX_PROCUTILS
 
 #include <dirent.h>
+#include <sys/types.h>
 
 struct proc_tasks {
 	DIR *dir;
@@ -30,5 +31,7 @@ extern int proc_next_pid(struct proc_processes *ps, pid_t *pid);
 
 extern char *proc_get_command(pid_t pid);
 extern char *proc_get_command_name(pid_t pid);
+
+extern int proc_is_procfs(int fd);
 
 #endif /* UTIL_LINUX_PROCUTILS */

--- a/lib/procutils.c
+++ b/lib/procutils.c
@@ -13,11 +13,13 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <sys/vfs.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include <ctype.h>
 
 #include "procutils.h"
+#include "statfs_magic.h"
 #include "fileutils.h"
 #include "all-io.h"
 #include "c.h"
@@ -233,6 +235,23 @@ int proc_next_pid(struct proc_processes *ps, pid_t *pid)
 	} while (1);
 
 	return 0;
+}
+
+/* checks if fd is file in a procfs;
+ * returns 1 if true, 0 if false or couldn't determine */
+int proc_is_procfs(int fd)
+{
+	struct statfs st;
+	int ret;
+
+	do {
+		ret = fstatfs(fd, &st);
+	} while (ret == -1 && errno == EINTR);
+
+	if (ret == 0)
+		return st.f_type == STATFS_PROC_MAGIC;
+	else
+		return 0;
 }
 
 #ifdef TEST_PROGRAM_PROCUTILS

--- a/sys-utils/setpriv.c
+++ b/sys-utils/setpriv.c
@@ -532,12 +532,9 @@ static void do_caps(enum cap_type type, const char *caps)
 
 		if (!strcmp(c + 1, "all")) {
 			int i;
-			/* It would be really bad if -all didn't drop all
-			 * caps.  It's better to just fail. */
-			if (cap_last_cap() > CAP_LAST_CAP)
-				errx(SETPRIV_EXIT_PRIVERR,
-				     _("libcap-ng is too old for \"all\" caps"));
-			for (i = 0; i <= CAP_LAST_CAP; i++)
+			/* We can trust the return value from cap_last_cap(),
+			 * so use that directly. */
+			for (i = 0; i <= cap_last_cap(); i++)
 				cap_update(action, type, i);
 		} else {
 			int cap = capng_name_to_capability(c + 1);


### PR DESCRIPTION
This MR contains a few cherry-picks of the capability fixes from master.

In particular, without these setpriv will fail when the CAP_LAST_CAP isn't greater than the procfs entry.
This can happen, as one is using a kernel newer than the one providing the UAPI headers. After all, can have more than one kernel installed on their system.

Hope I didn't miss anything from the instructions at Documentation/howto-pull-request.txt. Please shout otherwise ;-)

Note: For some reason `make check` fails on "column: invalid multibyte" test. The failure happens even without this MR.