### PR TITLE
ci: trigger CiFuzz for the master branch only

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
     paths:
       - '**'
 jobs:


### PR DESCRIPTION
CIFuzz and OSS-Fuzz are in sync with the master branch so it would
probably make sense to avoid running it for long-lived branches.

Inspired by https://github.com/karelzak/util-linux/pull/1248#issuecomment-776342252

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>