### PR TITLE
Avoid building libcommon and libtcolors unless needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,7 @@ bashcompletiondir = @bashcompletiondir@
 
 dist_noinst_HEADERS =
 noinst_PROGRAMS =
-noinst_LTLIBRARIES =
+EXTRA_LTLIBRARIES =
 usrbin_exec_PROGRAMS =
 usrsbin_exec_PROGRAMS =
 dist_man_MANS =

--- a/bash-completion/Makemodule.am
+++ b/bash-completion/Makemodule.am
@@ -189,7 +189,7 @@ endif
 if BUILD_UTMPDUMP
 dist_bashcompletion_DATA += bash-completion/utmpdump
 endif
-if BUILD_LIBUUID
+if BUILD_UUIDGEN
 dist_bashcompletion_DATA += bash-completion/uuidgen
 endif
 if BUILD_UUIDPARSE

--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -9,7 +9,7 @@
 # Note that you need "make install-strip" (or proper rpm / Debian build)
 # to generate binaries with only relevant stuff.
 #
-noinst_LTLIBRARIES += libcommon.la
+EXTRA_LTLIBRARIES += libcommon.la
 libcommon_la_CFLAGS = $(AM_CFLAGS)
 libcommon_la_SOURCES = \
 	lib/blkdev.c \
@@ -60,7 +60,7 @@ libcommon_la_SOURCES += lib/sysfs.c
 endif
 endif
 
-noinst_LTLIBRARIES += libtcolors.la
+EXTRA_LTLIBRARIES += libtcolors.la
 libtcolors_la_CFLAGS = $(AM_CFLAGS)
 libtcolors_la_SOURCES = lib/colors.c lib/color-names.c include/colors.h include/color-names.h
 libtcolors_la_LIBADD =


### PR DESCRIPTION
Saves some build time when configure to build only a small set of libraries.