### PR TITLE
hardlink: fix typo

### DIFF
--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -1072,7 +1072,7 @@ int main(int argc, char *argv[])
 	parse_options(argc, argv);
 
 	if (optind == argc)
-		errx(EXIT_FAILURE, _("no directory of dile specified"));
+		errx(EXIT_FAILURE, _("no directory of file specified"));
 
 	gettime_monotonic(&stats.start_time);
 	stats.started = TRUE;


### PR DESCRIPTION
There's a typo in hardlink.c (dile → file).