### PR TITLE
Fix misspellings

### DIFF
--- a/libfdisk/src/dos.c
+++ b/libfdisk/src/dos.c
@@ -1878,7 +1878,7 @@ static int dos_add_partition(struct fdisk_context *cxt,
 				}
 				fdisk_info(cxt, msg);
 			}
-			DBG(LABEL, ul_debug("DOS: tring logical"));
+			DBG(LABEL, ul_debug("DOS: trying logical"));
 			rc = add_logical(cxt, pa, &res);
 		} else {
 			if (free_primary)

--- a/man-common/manpage-stub.adoc
+++ b/man-common/manpage-stub.adoc
@@ -37,7 +37,7 @@ Describe *foobar* briefly.
 *-o*, *--option* _value_::
 This option has a value.
 +
-For empty lines within a desription (to keep the indentation) you can use the "plus" character at the beginning of an otherwise empty line.
+For empty lines within a description (to keep the indentation) you can use the "plus" character at the beginning of an otherwise empty line.
 
 //Last but not least, don't forget the common options:
 *-V*, *--version*::

--- a/meson.build
+++ b/meson.build
@@ -511,7 +511,7 @@ funcs = '''
 
 foreach func: funcs
   have = cc.has_function(func)
-  # For autotools compatiblity, use either #define FOO 1 or #undef FOO.
+  # For autotools compatibility, use either #define FOO 1 or #undef FOO.
   # This makes little sense, but is necessary to avoid warnings about
   # redefined macros from Python.h, which uses this convention.
   conf.set('HAVE_' + func.to_upper(), have ? 1 : false)

--- a/misc-utils/lsblk-mnt.c
+++ b/misc-utils/lsblk-mnt.c
@@ -112,7 +112,7 @@ struct libmnt_fs **lsblk_device_get_filesystems(struct lsblk_device *dev, size_t
 		add_filesystem(dev, fs);
 	}
 
-	/* Try mnt_table_find_srcpath() which also cannonicalize patchs, etc.
+	/* Try mnt_table_find_srcpath() which also canonicalizes patches, etc.
 	 */
 	if (!dev->nfss) {
 		fs = get_active_swap(dev->filename);

--- a/schedutils/uclampset.c
+++ b/schedutils/uclampset.c
@@ -97,7 +97,7 @@ static void show_uclamp_pid_info(pid_t pid, char *cmd)
 		comm = proc_get_command_name(pid);
 
 	printf(_("%s (%d) util_clamp: min: %d max: %d\n"),
-	       comm ? : "uknown", pid, sa.sched_util_min, sa.sched_util_max);
+	       comm ? : "unknown", pid, sa.sched_util_min, sa.sched_util_max);
 
 	if (!cmd)
 		free(comm);

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -23,7 +23,7 @@
  * Reshuffled things, added sparc code, and re-added alpha stuff
  * by David Mosberger <davidm@azstarnet.com>
  * and Jay Estabrook <jestabro@amt.tay1.dec.com>
- * and Martin Ostermann <ost@coments.rwth-aachen.de>, aeb@cwi.nl, 990212.
+ * and Martin Ostermann <ost@comnets.rwth-aachen.de>, aeb@cwi.nl, 990212.
  *
  * Fix for Award 2094 bug, Dave Coffin (dcoffin@shore.net) 11/12/98
  * Change of local time handling, Stefan Ring <e9725446@stud3.tuwien.ac.at>


### PR DESCRIPTION
Not  much to explain, but just to mention two things:
 - I'm not sure regarding the change on `libfdisk/src/dos.c`
 - The e-mail from `sys-utils/hwclock.c` I found the fix 'comnets' on the web