### PR TITLE
Documentation/TODO: Minor update and fix typo

### DIFF
--- a/Documentation/TODO
+++ b/Documentation/TODO
@@ -103,11 +103,11 @@ getopt
 docs
 ----
 
- - (!) use something better than gtk-doc for libmount and libblkid (doxyden?)
+ - (!) use something better than gtk-doc for libmount and libblkid (doxygen?)
 
  - (!) add API documentation to libuuid
 
- - (!) rewrite man pages to AsciiDoc and generate final man pages by Asciidoctor & Docbook
+ - Improve line breaks in man pages and review markup
 
 
 login-utils:


### PR DESCRIPTION
Hello Karel,

now the initial Asciidoc import of the man pages is done, I've changed the TODO list and fixed a typo.

Until v2.38, I hope to figure out how to improve the line breaks to get a view similar to the old man pages. Example from findfs.8, old appearance:
```
EXIT STATUS
              0      success
              1      label or uuid cannot be found
              2      usage error, wrong number of arguments or unknown option
```
And here the new appearance:
```
EXIT STATUS
              0
                     success
              1
                     label or uuid cannot be found
              2
                     usage error, wrong number of arguments or unknown option
```
The old version is better readable. Well, the Asciidoc code is similar to the asciidoctor(1) man page, and such listings appear there the same as here, but this is not yet what I really want.
