### PR TITLE
lsns: interpolate missing namespaces for converting forests to a tree

### DIFF
--- a/sys-utils/lsns.8.adoc
+++ b/sys-utils/lsns.8.adoc
@@ -69,7 +69,6 @@ If *process* is given as _rel_, print proecss tree(s) in each name space. This i
 If *parent* is given, print tree(s) constructed by the parent/child relationship.
 If *owner* is given, print tree(s) constructed by the owner/owned relationship.
 *owner* is used as default when _rel_ is omitted.
-The result of *parent* and *owner* can be forests because *lsns* cannot track a namespace having no process.
 
 
 *-V*, *--version*::

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -810,7 +810,7 @@ static void add_scols_line(struct lsns *ls, struct libscols_table *table,
 	assert(table);
 
 	line = scols_table_new_line(table,
-			(ls->tree == LSNS_TREE_PROCESS) && proc->parent ? proc->parent->outline:
+			(ls->tree == LSNS_TREE_PROCESS && proc) && proc->parent ? proc->parent->outline:
 			(ls->tree == LSNS_TREE_PARENT)  && ns->parentns ? ns->parentns->ns_outline:
 			(ls->tree == LSNS_TREE_OWNER)   && ns->ownerns  ? ns->ownerns->ns_outline:
 			NULL);
@@ -827,10 +827,12 @@ static void add_scols_line(struct lsns *ls, struct libscols_table *table,
 			xasprintf(&str, "%ju", (uintmax_t)ns->id);
 			break;
 		case COL_PID:
-			xasprintf(&str, "%d", (int) proc->pid);
+			if (proc)
+				xasprintf(&str, "%d", (int) proc->pid);
 			break;
 		case COL_PPID:
-			xasprintf(&str, "%d", (int) proc->ppid);
+			if (proc)
+				xasprintf(&str, "%d", (int) proc->ppid);
 			break;
 		case COL_TYPE:
 			xasprintf(&str, "%s", ns_names[ns->type]);
@@ -839,20 +841,30 @@ static void add_scols_line(struct lsns *ls, struct libscols_table *table,
 			xasprintf(&str, "%d", ns->nprocs);
 			break;
 		case COL_COMMAND:
+			if (!proc)
+				break;
 			str = proc_get_command(proc->pid);
 			if (!str)
 				str = proc_get_command_name(proc->pid);
 			break;
 		case COL_PATH:
+			if (!proc)
+				break;
 			xasprintf(&str, "/proc/%d/ns/%s", (int) proc->pid, ns_names[ns->type]);
 			break;
 		case COL_UID:
+			if (!proc)
+				break;
 			xasprintf(&str, "%d", (int) proc->uid);
 			break;
 		case COL_USER:
+			if (!proc)
+				break;
 			xasprintf(&str, "%s", get_id(uid_cache, proc->uid)->name);
 			break;
 		case COL_NETNSID:
+			if (!proc)
+				break;
 			if (ns->type == LSNS_ID_NET)
 				netnsid_xasputs(&str, proc->netnsid);
 			break;
@@ -875,7 +887,7 @@ static void add_scols_line(struct lsns *ls, struct libscols_table *table,
 
 	if (ls->tree == LSNS_TREE_OWNER || ls->tree == LSNS_TREE_PARENT)
 		ns->ns_outline = line;
-	else
+	else if (proc)
 		proc->outline = line;
 }
 

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -755,7 +755,7 @@ static struct lsns_namespace *add_namespace_for_nsfd(struct lsns *ls, int fd, in
 	return ns;
 }
 
-static void interpolate_missing_namespaces (struct lsns *ls, struct lsns_namespace *orphan, int rela)
+static void interpolate_missing_namespaces(struct lsns *ls, struct lsns_namespace *orphan, int rela)
 {
 	const int cmd[MAX_RELA] = {
 		[RELA_PARENT] = NS_GET_PARENT,
@@ -769,24 +769,24 @@ static void interpolate_missing_namespaces (struct lsns *ls, struct lsns_namespa
 	if (orphan->related_ns[rela])
 		return;
 
-	snprintf(buf, sizeof(buf), "/proc/%d/ns/%s", orphan->proc->pid, ns_names [orphan->type]);
+	snprintf(buf, sizeof(buf), "/proc/%d/ns/%s", orphan->proc->pid, ns_names[orphan->type]);
 	fd_orphan = open(buf, O_RDONLY);
 	if (fd_orphan < 0)
 		return;
 
-	fd_missing = ioctl (fd_orphan, cmd[rela]);
-	close (fd_orphan);
+	fd_missing = ioctl(fd_orphan, cmd[rela]);
+	close(fd_orphan);
 	if (fd_missing < 0)
 		return;
 
 	if (fstat(fd_missing, &st) < 0
 	    || st.st_ino != orphan->related_id[rela]) {
-		close (fd_missing);
+		close(fd_missing);
 		return;
 	}
 
 	orphan->related_ns[rela] = add_namespace_for_nsfd(ls, fd_missing, orphan->related_id[rela]);
-	close (fd_missing);
+	close(fd_missing);
 }
 
 static int read_namespaces(struct lsns *ls)
@@ -861,7 +861,7 @@ static int read_namespaces(struct lsns *ls)
 			struct lsns_namespace *current = orphan[rela];
 			orphan[rela] = orphan[rela]->related_ns[rela];
 			current->related_ns[rela] = NULL;
-			interpolate_missing_namespaces (ls, current, rela);
+			interpolate_missing_namespaces(ls, current, rela);
 		}
 	}
 


### PR DESCRIPTION
lsns: interpolate missing namespaces for converting forests to a tree

The tree of *parent* and *owner* could be forests because *lsns*
cannot track a namespace having no process.

This change tries interpolating the missing namespaces by calling
ioctl(NS_GET_PARENT) and ioctl(NS_GET_USERNS) recursively.

The original output for -Tparent:

    # ./lsns -Tparent
    NS             TYPE   NPROCS   PID USER   COMMAND
    4026531837     user      404     1 root   /usr/lib/systemd/sy
    ├─4026532508   user        1 29376 yamato /usr/lib64/firefox/
    ...
    └─4026533513   user        1 24245 yamato /usr/lib64/firefox/
    ...
    4026533733     user        1 30839 yamato /opt/google/chrome-
    4026533734     user       15 10076 yamato /opt/google/chrome-

user namespaces 4026533733 and 4026533734 are orphans.
lsns could not find their parents.

With this change:

    # ./lsns-with-changes -Tparent
    NS               TYPE   NPROCS   PID USER   COMMAND
    4026531837       user      404     1 root   /usr/lib/systemd/
    ├─4026532508     user        1 29376 yamato /usr/lib64/firefo
    ...
    ├─4026532639     user        0              
    │ ├─4026532637   user        0              
    │ │ └─4026533733 user        1 30839 yamato /opt/google/chrom
    │ └─4026533734   user       14 10076 yamato /opt/google/chrom

Now user namespaces 4026533733 and 4026533734 are integrated to the
tree. lsns interpolates the missing namespace 4026532639 and
4026532637 for the integration.

The original output for -Towner:

    # ./lsns -Towner
    NS             TYPE   NPROCS   PID USER   COMMAND
    4026531837     user      405     1 root   /usr/lib/systemd/s
    ├─4026531835   cgroup    431     1 root   /usr/lib/systemd/s
    ...
    4026532638     pid         1 30839 yamato /opt/google/chrome
    4026532640     pid         2 30837 yamato /opt/google/chrome
    ...

pid namespaces 4026532638 and 4026532640 are orphans.
lsns could not find their owners.

With this change:

    # ./lsns-with-changes -Towner
    NS               TYPE   NPROCS   PID USER   COMMAND
    4026531837       user      403     1 root   /usr/lib/systemd
    ├─4026531835     cgroup    429     1 root   /usr/lib/systemd
    ...
    ├─4026532639     user        0
    ...
    │ ├─4026532637   user        0              
    │ │ ├─4026532638 pid         1 30839 yamato /opt/google/chro
    │ │ ├─4026533638 net         1 30839 yamato /opt/google/chro
    │ │ └─4026533733 user        1 30839 yamato /opt/google/chro
    │ ├─4026532640   pid         2 30837 yamato /opt/google/chro

Now pid namespaces 4026532638 and 4026532640 are integrated to the
tree. lsns interpolates the missing namespace 4026532639 and
4026532637 for the integration.
