### PR TITLE
more: fix floating point exception core dump

### DIFF
--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -727,7 +727,7 @@ static void output_prompt(struct more_control *ctl, char *filename)
 		ctl->prompt_len += printf(_("--More--"));
 		if (filename != NULL) {
 			ctl->prompt_len += printf(_("(Next file: %s)"), filename);
-		} else if (!ctl->no_tty_in) {
+		} else if (!ctl->no_tty_in && 0 < ctl->file_size) {
 			ctl->prompt_len +=
 			    printf("(%d%%)",
 				   (int)((ctl->file_position * 100) / ctl->file_size));


### PR DESCRIPTION
Make the code avoid divided by zero.  This can happen when file has content
but is zero in size.  Such files can be found from procfs, possibly some
other pseudo-filesystems.  To reproduce the issue run the following.

    $ more /proc/crypto
    ...
    Floating point exception (core dumped)

Signed-off-by: Sami Kerola <kerolasa@iki.fi>