### PR TITLE
fstrim: do not start the timer in initrd

### DIFF
--- a/sys-utils/fstrim.timer
+++ b/sys-utils/fstrim.timer
@@ -2,6 +2,7 @@
 Description=Discard unused blocks once a week
 Documentation=man:fstrim
 ConditionVirtualization=!container
+ConditionPathExists=!/etc/initrd-release
 
 [Timer]
 OnCalendar=weekly


### PR DESCRIPTION
I'm working on building initramfs images directly from normal
packages, which means that the pristine system rpms should behave
correctly as much as possible also in the initrd. There usually isn't
enough time for the timer to actually fire, but starting it gives a
line on the console and generally looks confusing and sloppy. So let's
skip the timer if it ever ends up being enabled in the initrd.

Checking for /etc/initrd-release is the standard condition that
systemd's initrd units use.