### PR TITLE
lscpu: read current frequency from sysfs

### DIFF
--- a/sys-utils/lscpu-cpu.c
+++ b/sys-utils/lscpu-cpu.c
@@ -35,7 +35,6 @@ void lscpu_unref_cpu(struct lscpu_cpu *cpu)
 		cpu->type = NULL;
 		free(cpu->dynamic_mhz);
 		free(cpu->static_mhz);
-		free(cpu->mhz);
 		free(cpu->bogomips);
 		free(cpu);
 	}

--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -225,7 +225,6 @@ static const struct cpuinfo_pattern cpu_patterns[] =
 {
 	/* Sort by fields name! */
 	DEF_PAT_CPU( "bogomips",	PAT_BOGOMIPS_CPU, bogomips),
-	DEF_PAT_CPU( "cpu MHz",		PAT_MHZ,	  mhz),
 	DEF_PAT_CPU( "cpu MHz dynamic",	PAT_MHZ_DYNAMIC,  dynamic_mhz),	/* s390 */
 	DEF_PAT_CPU( "cpu MHz static",	PAT_MHZ_STATIC,	  static_mhz),	/* s390 */
 	DEF_PAT_CPU( "cpu number",	PAT_PROCESSOR,    logical_id),	/* s390 */

--- a/sys-utils/lscpu-topology.c
+++ b/sys-utils/lscpu-topology.c
@@ -545,6 +545,8 @@ static int read_mhz(struct lscpu_cxt *cxt, struct lscpu_cpu *cpu)
 		cpu->mhz_max_freq = (float) mhz / 1000;
 	if (ul_path_readf_s32(sys, &mhz, "cpu%d/cpufreq/cpuinfo_min_freq", num) == 0)
 		cpu->mhz_min_freq = (float) mhz / 1000;
+	if (ul_path_readf_s32(sys, &mhz, "cpu%d/cpufreq/scaling_cur_freq", num) == 0)
+		cpu->mhz = (float) mhz / 1000;
 
 	if (cpu->type && (cpu->mhz_min_freq || cpu->mhz_max_freq))
 		cpu->type->has_freq = 1;

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -423,7 +423,7 @@ static char *get_cell_data(
 		break;
 	case COL_CPU_MHZ:
 		if (cpu->mhz)
-			xstrncpy(buf, cpu->mhz, bufsz);
+			snprintf(buf, bufsz, "%.4f", cpu->mhz);
 		break;
 	case COL_CPU_MAXMHZ:
 		if (cpu->mhz_max_freq)

--- a/sys-utils/lscpu.h
+++ b/sys-utils/lscpu.h
@@ -127,7 +127,7 @@ struct lscpu_cpu {
 	int logical_id;
 
 	char	*bogomips;	/* per-CPU bogomips */
-	char	*mhz;		/* max freq from cpuinfo */
+	float	mhz;		/* max freq from cpuinfo */
 	char	*dynamic_mhz;   /* from cpuinf for s390 */
 	char	*static_mhz;	/* from cpuinf for s390 */
 	float	mhz_max_freq;	/* realtime freq from /sys/.../cpuinfo_max_freq */


### PR DESCRIPTION
For locale-aware formatting we need MHZ as a number.
/proc/cpuinfo only contains this information in a preformatted way that
would need to be parsed first in a locale-independent way.
By reading the raw number from sysfs we can sidestep this issue.

Fixes #1316