### PR TITLE
hexdump: correctly display signed single byte integers

### DIFF
--- a/text-utils/hexdump-display.c
+++ b/text-utils/hexdump-display.c
@@ -145,13 +145,15 @@ print(struct hexdump_pr *pr, unsigned char *bp) {
 	    }
 	case F_INT:
 	    {
+		char cval;	/* int8_t */
 		short sval;	/* int16_t */
 		int ival;	/* int32_t */
 		long long Lval;	/* int64_t, int64_t */
 
 		switch(pr->bcnt) {
 		case 1:
-			printf(pr->fmt, (unsigned long long) *bp);
+			memmove(&cval, bp, sizeof(cval));
+			printf(pr->fmt, (unsigned long long) cval);
 			break;
 		case 2:
 			memmove(&sval, bp, sizeof(sval));


### PR DESCRIPTION
When using the format string '/1 "%d"', the byte did not display as a
signed integer as expected, it was interpreted as unsigned.

Mainly inspired by https://unix.stackexchange.com/questions/304446/print-one-byte-signed-number-with-hexdump