### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -845,8 +845,9 @@ char *c = crypt("abc","pw");
   have_libcrypt=no
   have_crypt=yes
 ],[
+  saved_LIBS="$LIBS"
   LIBS="$LIBS -lcrypt"
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   #ifdef HAVE_CRYPT_H
   #include <crypt.h>
   #else
@@ -856,12 +857,12 @@ char *c = crypt("abc","pw");
   ]], [[
   char *c = crypt("abc","pw");
   ]])],[
-  AC_DEFINE([HAVE_LIBCRYPT], [1], [Do we need -lcrypt?])
   have_libcrypt=yes
   have_crypt=yes
   ],[
   AC_MSG_WARN([crypt() is not available])
   ])
+  LIBS="$saved_LIBS"
 ])
 AM_CONDITIONAL([HAVE_LIBCRYPT], [test "x$have_libcrypt" = xyes])
 


### PR DESCRIPTION
1. the test incorrectly used AC_COMPILE_IFELSE instead of AC_LINK_IFELSE, defeating the purpose of checking -lcrypt.
2. the test did not properly restore LIBS, causing later checks to all fail if libcrypt wasn't found.
3. HAVE_LIBCRYPT only controls whether to use -lcrypt, it is not needed or used in any source files.