### PR TITLE
mount.8.adoc: Remove context options exclusion

### DIFF
--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -470,8 +470,6 @@ The *context=* option is useful when mounting filesystems that do not support ex
 +
 A commonly used option for removable media is *context="system_u:object_r:removable_t*.
 +
-Two other options are *fscontext=* and *defcontext=*, both of which are mutually exclusive of the *context=* option. This means you can use fscontext and defcontext with each other, but neither can be used with context.
-+
 The *fscontext=* option works for all filesystems, regardless of their xattr support. The fscontext option sets the overarching filesystem label to a specific security context. This filesystem label is separate from the individual labels on the files. It represents the entire filesystem for certain kinds of permission checks, such as during mount or file creation. Individual file labels are still obtained from the xattrs on the files themselves. The context option actually sets the aggregate context that fscontext provides, in addition to supplying the same label for individual files.
 +
 You can set the default security context for unlabeled files using *defcontext=* option. This overrides the value set for unlabeled files in the policy and requires a filesystem that supports xattr labeling.


### PR DESCRIPTION
The exclusivity between the {fscontext, defcontext} and context options
was removed in kernel 2.6.25[1]. No specific verification on these
options is done in mount(8)[2].

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c9180a57a9ab2d5525faf8815a332364ee9e89b7
[2] https://github.com/karelzak/util-linux/blob/master/libmount/src/context_mount.c#L202

@pcmoore FYI