### PR TITLE
Fix running the test suite with system commands

### DIFF
--- a/tests/ts/blkdiscard/offsets
+++ b/tests/ts/blkdiscard/offsets
@@ -48,7 +48,7 @@ ts_log "testing offsets with full block size"
 run_tscmd $TS_CMD_BLKDISCARD -v $DEVICE
 if [ "$?" != "0" ]; then
 	# Skip the rest? For example loop backing files on NFS seem unsupported.
-	grep -q "BLKDISCARD ioctl failed: Operation not supported" "$TS_OUTPUT" \
+	grep -q "BLKDISCARD ioctl failed: Operation not supported" "$TS_ERRLOG" \
 		&& ts_skip "BLKDISCARD not supported"
 fi
 run_tscmd $TS_CMD_BLKDISCARD -v -o 1 $DEVICE

--- a/tests/ts/kill/all_processes
+++ b/tests/ts/kill/all_processes
@@ -22,7 +22,7 @@ ts_skip_nonroot
 
 # make sure we do not use shell built-in command
 if [ "$TS_USE_SYSTEM_COMMANDS" == "yes" ]; then
-	TS_CMD_KILL="/bin/kill"
+	TS_CMD_KILL="$(which kill)"
 fi
 
 ts_check_test_command "$TS_CMD_KILL"

--- a/tests/ts/kill/name_to_number
+++ b/tests/ts/kill/name_to_number
@@ -20,7 +20,7 @@ ts_init "$*"
 
 # make sure we do not use shell built-in command
 if [ "$TS_USE_SYSTEM_COMMANDS" == "yes" ]; then
-	TS_CMD_KILL="/bin/kill"
+	TS_CMD_KILL="$(which kill)"
 fi
 
 ts_check_test_command "$TS_CMD_KILL"

--- a/tests/ts/kill/options
+++ b/tests/ts/kill/options
@@ -20,7 +20,7 @@ ts_init "$*"
 
 # make sure we do not use shell built-in command
 if [ "$TS_USE_SYSTEM_COMMANDS" == "yes" ]; then
-	TS_CMD_KILL="/bin/kill"
+	TS_CMD_KILL="$(which kill)"
 fi
 
 ts_check_test_command "$TS_CMD_KILL"

--- a/tests/ts/kill/print_pid
+++ b/tests/ts/kill/print_pid
@@ -20,7 +20,7 @@ ts_init "$*"
 
 # make sure we do not use shell built-in command
 if [ "$TS_USE_SYSTEM_COMMANDS" == "yes" ]; then
-	TS_CMD_KILL="/bin/kill"
+	TS_CMD_KILL="$(which kill)"
 fi
 
 ts_check_test_command "$TS_CMD_KILL"

--- a/tests/ts/kill/queue
+++ b/tests/ts/kill/queue
@@ -20,7 +20,7 @@ ts_init "$*"
 
 # make sure we do not use shell built-in command
 if [ "$TS_USE_SYSTEM_COMMANDS" == "yes" ]; then
-	TS_CMD_KILL="/bin/kill"
+	TS_CMD_KILL="$(which kill)"
 fi
 
 ts_check_test_command "$TS_CMD_KILL"


### PR DESCRIPTION
If the 'kill' test is executed with --use-system-commands, it calls
/bin/kill to avoid the shell's own kill command being invoked.

However, this doesn't work if the kill we want to test isn't in fact in
/bin.  Instead, use $(which kill) to find a kill on the PATH and call
that directly.

Signed-off-by: Ross Burton <ross.burton@arm.com>