### PR TITLE
tests: mark ul/ul as a known failure

### DIFF
--- a/tests/ts/ul/ul
+++ b/tests/ts/ul/ul
@@ -20,6 +20,9 @@ ts_init "$*"
 
 ts_check_test_command "$TS_CMD_UL"
 
+# This test provides different result on some terminals and virtual machines
+TS_KNOWN_FAIL="yes"
+
 printf "a\x08ab\x5F\x08c\\n\\ttab\\f\\b\\r" |
 	$TS_CMD_UL -t xterm >> $TS_OUTPUT 2>> $TS_ERRLOG
 


### PR DESCRIPTION
As with ul/basic, this test produces different output when ran under
different terminals, which isn't very useful.

Set TS_KNOWN_FAIL so that these problems don't cause the test to fail.

Signed-off-by: Ross Burton <ross.burton@arm.com>