### PR TITLE
test/eject: guard asan LD_PRELOAD with use-system-commands check

### DIFF
--- a/tests/ts/eject/umount
+++ b/tests/ts/eject/umount
@@ -60,13 +60,15 @@ function deinit_device {
 	ts_scsi_debug_rmmod
 }
 
-# As the eject binary execl()s an uninstrumented /bin/umount binary, we need
-# to explicitly $LD_PRELOAD the ASan's runtime DSO, otherwise ASan will complain.
-# Since all three utilities used by this test (eject, fdisk, mount) are just
-# libtool wrappers, let's check the kill binary instead, which should have
-# the needed DSO information.
-ASAN_RT_PATH="$(ts_get_asan_rt_path "$TS_CMD_KILL")"
-[ -n "$ASAN_RT_PATH" ] && export LD_PRELOAD="$ASAN_RT_PATH:$LD_PRELOAD"
+if [ "$TS_USE_SYSTEM_COMMANDS" != "yes" ]; then
+	# As the eject binary execl()s an uninstrumented /bin/umount binary, we need
+	# to explicitly $LD_PRELOAD the ASan's runtime DSO, otherwise ASan will complain.
+	# Since all three utilities used by this test (eject, fdisk, mount) are just
+	# libtool wrappers, let's check the kill binary instead, which should have
+	# the needed DSO information.
+	ASAN_RT_PATH="$(ts_get_asan_rt_path "$TS_CMD_KILL")"
+	[ -n "$ASAN_RT_PATH" ] && export LD_PRELOAD="$ASAN_RT_PATH:$LD_PRELOAD"
+fi
 
 ts_init_subtest "by-disk"
 init_device


### PR DESCRIPTION
This test tries to add asan to LD_PRELOAD because the just-built eject
will call the host /bin/umount, and apparently asan doesn't like this.

However, if ldd isn't present, this fails as the path to asan is the
error message saying that ldd isn't present.

As the asan workaround is only needed when executing the binaries that
have just been built and not the system binaries, only use it if the
test is on the built binaries.

Closes #1373.

Signed-off-by: Ross Burton <ross.burton@arm.com>