### PR TITLE
verity: add support for corruption action flag and fix roothashsig parsing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2690,6 +2690,7 @@ AC_MSG_RESULT([
         libeconf support:          ${have_econf}
         Btrfs support:             ${have_btrfs}
         Wide-char support:         ${build_widechar}
+        libcryptsetup support:     ${have_cryptsetup}
 
         Manual pages:              ${build_asciidoc}
         Manual pages translated:   ${build_poman}

--- a/libmount/src/context_veritydev.c
+++ b/libmount/src/context_veritydev.c
@@ -78,7 +78,8 @@ int mnt_context_setup_veritydev(struct libmnt_context *cxt)
 	const char *backing_file, *optstr;
 	char *val = NULL, *key = NULL, *root_hash_binary = NULL, *mapper_device = NULL,
 		*mapper_device_full = NULL, *backing_file_basename = NULL, *root_hash = NULL,
-		*hash_device = NULL, *root_hash_file = NULL, *fec_device = NULL, *hash_sig = NULL;
+		*hash_device = NULL, *root_hash_file = NULL, *fec_device = NULL, *hash_sig = NULL,
+		*root_hash_sig_file = NULL;
 	size_t len, hash_size, hash_sig_size = 0, keysize = 0;
 	struct crypt_params_verity crypt_params = {};
 	struct crypt_device *crypt_dev = NULL;
@@ -219,7 +220,10 @@ int mnt_context_setup_veritydev(struct libmnt_context *cxt)
 	 */
 	if (rc == 0 && (cxt->user_mountflags & MNT_MS_ROOT_HASH_SIG) &&
 	    mnt_optstr_get_option(optstr, "verity.roothashsig", &val, &len) == 0 && val) {
-		rc = ul_path_stat(NULL, &hash_sig_st, val);
+		root_hash_sig_file = strndup(val, len);
+		rc = root_hash_sig_file ? 0 : -ENOMEM;
+		if (rc == 0)
+			rc = ul_path_stat(NULL, &hash_sig_st, root_hash_sig_file);
 		if (rc == 0)
 			rc = !S_ISREG(hash_sig_st.st_mode) || !hash_sig_st.st_size ? -EINVAL : 0;
 		if (rc == 0) {
@@ -228,7 +232,7 @@ int mnt_context_setup_veritydev(struct libmnt_context *cxt)
 			rc = hash_sig ? 0 : -ENOMEM;
 		}
 		if (rc == 0) {
-			rc = ul_path_read(NULL, hash_sig, hash_sig_size, val);
+			rc = ul_path_read(NULL, hash_sig, hash_sig_size, root_hash_sig_file);
 			rc = rc < (int)hash_sig_size ? -1 : 0;
 		}
 	}
@@ -434,6 +438,7 @@ done:
 	free(hash_device);
 	free(root_hash);
 	free(root_hash_file);
+	free(root_hash_sig_file);
 	free(fec_device);
 	free(hash_sig);
 	free(key);

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -917,6 +917,7 @@ extern int mnt_context_set_syscall_status(struct libmnt_context *cxt, int status
 #define MNT_MS_FEC_OFFSET (1 << 23)
 #define MNT_MS_FEC_ROOTS (1 << 24)
 #define MNT_MS_ROOT_HASH_SIG (1 << 25)
+#define MNT_MS_VERITY_ON_CORRUPTION (1 << 26)
 
 /*
  * mount(2) MS_* masks (MNT_MAP_LINUX map)

--- a/libmount/src/optmap.c
+++ b/libmount/src/optmap.c
@@ -191,6 +191,7 @@ static const struct libmnt_optmap userspace_opts_map[] =
    { "verity.fecoffset=", MNT_MS_FEC_OFFSET, MNT_NOHLPS | MNT_NOMTAB },	      /* verity FEC area offset */
    { "verity.fecroots=", MNT_MS_FEC_ROOTS, MNT_NOHLPS | MNT_NOMTAB },	      /* verity FEC roots */
    { "verity.roothashsig=",    MNT_MS_ROOT_HASH_SIG, MNT_NOHLPS | MNT_NOMTAB },	/* verity device root hash signature file */
+   { "verity.oncorruption=",   MNT_MS_VERITY_ON_CORRUPTION, MNT_NOHLPS | MNT_NOMTAB },	/* verity: action the kernel takes on corruption */
 
    { NULL, 0, 0 }
 };

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1405,6 +1405,9 @@ Parity bytes for FEC (default: 2). Optional.
 **verity.roothashsig=**__path__::
 Path to *pkcs7*(1ssl) signature of root hash hex string. Requires crypt_activate_by_signed_key() from cryptsetup and kernel built with *CONFIG_DM_VERITY_VERIFY_ROOTHASH_SIG*. For device reuse, signatures have to be either used by all mounts of a device or by none. Optional.
 
+**verity.oncorruption=**__ignore__|__restart__|__panic__::
+Instruct the kernel to ignore, reboot or panic when corruption is detected. By default the I/O operation simply fails. Requires Linux 4.1 or newer, and libcrypsetup 2.3.4 or newer. Optional.
+
 Supported since util-linux v2.35.
 
 For example commands:


### PR DESCRIPTION
Add verity.oncorruption= to let users override the default kernel
behaviour, using libcrypsetup's relevant flags.