### PR TITLE
mount: fix roothash signature extension in manpage

### DIFF
--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1414,9 +1414,9 @@ mksquashfs /etc /tmp/etc.squashfs
 dd if=/dev/zero of=/tmp/etc.hash bs=1M count=10
 veritysetup format /tmp/etc.squashfs /tmp/etc.hash
 openssl smime -sign -in <hash> -nocerts -inkey private.key \
--signer private.crt -noattr -binary -outform der -out /tmp/etc.p7
+-signer private.crt -noattr -binary -outform der -out /tmp/etc.roothash.p7s
 mount -o verity.hashdevice=/tmp/etc.hash,verity.roothash=<hash>,\
-verity.roothashsig=/tmp/etc.p7 /tmp/etc.squashfs /mnt
+verity.roothashsig=/tmp/etc.roothash.p7s /tmp/etc.squashfs /mnt
 ....
 
 create squashfs image from _/etc_ directory, verity hash device and mount verified filesystem image to _/mnt_. The kernel will verify that the root hash is signed by a key from the kernel keyring if roothashsig is used.


### PR DESCRIPTION
The PKCS7 RFC recommends to use .p7s for detached signatures file extensions,
so use that in the example.

https://datatracker.ietf.org/doc/html/rfc5751#section-3.2.1