### PR TITLE
fdisk: do not print error message when partition reordering is not needed

### DIFF
--- a/disk-utils/fdisk-menu.c
+++ b/disk-utils/fdisk-menu.c
@@ -636,17 +636,6 @@ static int generic_menu_cb(struct fdisk_context **cxt0,
 			break;
 		case 'f':
 			rc = fdisk_reorder_partitions(cxt);
-			switch (rc) {
-			default:
-				fdisk_warnx(cxt, _("Failed to fix partitions order."));
-				break;
-			case 0:
-				fdisk_info(cxt, _("Partitions order fixed."));
-				break;
-			case 1:
-				fdisk_info(cxt, _("Nothing to do. Ordering is correct already."));
-				break;
-			}
 			break;
 		case 'r':
 			rc = fdisk_enable_details(cxt, 0);

--- a/disk-utils/fdisk-menu.c
+++ b/disk-utils/fdisk-menu.c
@@ -636,10 +636,17 @@ static int generic_menu_cb(struct fdisk_context **cxt0,
 			break;
 		case 'f':
 			rc = fdisk_reorder_partitions(cxt);
-			if (rc)
+			switch (rc) {
+			default:
 				fdisk_warnx(cxt, _("Failed to fix partitions order."));
-			else
+				break;
+			case 0:
 				fdisk_info(cxt, _("Partitions order fixed."));
+				break;
+			case 1:
+				fdisk_info(cxt, _("Nothing to do. Ordering is correct already."));
+				break;
+			}
 			break;
 		case 'r':
 			rc = fdisk_enable_details(cxt, 0);

--- a/libfdisk/src/dos.c
+++ b/libfdisk/src/dos.c
@@ -2442,10 +2442,8 @@ static int dos_reorder(struct fdisk_context *cxt)
 	struct pte *pei, *pek;
 	size_t i,k;
 
-	if (!wrong_p_order(cxt, NULL)) {
-		fdisk_info(cxt, _("Nothing to do. Ordering is correct already."));
+	if (!wrong_p_order(cxt, NULL))
 		return 1;
-	}
 
 	while ((i = wrong_p_order(cxt, &k)) != 0 && i < 4) {
 		/* partition i should have come earlier, move it */

--- a/libfdisk/src/gpt.c
+++ b/libfdisk/src/gpt.c
@@ -3097,10 +3097,8 @@ static int gpt_reorder(struct fdisk_context *cxt)
 				(const void *) gpt_get_entry(gpt, i),
 				(const void *) gpt_get_entry(gpt, i + 1)) > 0;
 
-	if (!mess) {
-		fdisk_info(cxt, _("Nothing to do. Ordering is correct already."));
+	if (!mess)
 		return 1;
-	}
 
 	qsort(gpt->ents, nparts, sizeof(struct gpt_entry),
 			gpt_entry_cmp_start);

--- a/libfdisk/src/label.c
+++ b/libfdisk/src/label.c
@@ -583,12 +583,28 @@ int fdisk_toggle_partition_flag(struct fdisk_context *cxt,
  */
 int fdisk_reorder_partitions(struct fdisk_context *cxt)
 {
+	int rc;
+
 	if (!cxt || !cxt->label)
 		return -EINVAL;
 	if (!cxt->label->op->reorder)
 		return -ENOSYS;
 
-	return cxt->label->op->reorder(cxt);
+	rc = cxt->label->op->reorder(cxt);
+
+	switch (rc) {
+	case 0:
+		fdisk_info(cxt, _("Partitions order fixed."));
+		break;
+	case 1:
+		fdisk_info(cxt, _("Nothing to do. Ordering is correct already."));
+		break;
+	default:
+		fdisk_warnx(cxt, _("Failed to fix partitions order."));
+		break;
+	}
+
+	return rc;
 }
 
 /*


### PR DESCRIPTION
Option 'f' currently prints following RED error message:

    Nothing to do. Ordering is correct already.
    Failed to fix partitions order.

This change removes RED error message when ordering is already correct.