### PR TITLE
verity: remove experimental tag from mount manpage

### DIFF
--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1377,7 +1377,7 @@ Set the owner and group and mode of the bus directories in the usbfs filesystem 
 **listuid=**__uid__ and **listgid=**__gid__ and **listmode=**__mode__::
 Set the owner and group and mode of the file _devices_ (default: uid=gid=0, mode=0444). The mode is given in octal.
 
-== DM-VERITY SUPPORT (experimental)
+== DM-VERITY SUPPORT
 
 The device-mapper verity target provides read-only transparent integrity checking of block devices using kernel crypto API. The *mount* command can open the dm-verity device and do the integrity verification before on the device filesystem is mounted. Requires libcryptsetup with in libmount (optionally via *dlopen*(3)). If libcryptsetup supports extracting the root hash of an already mounted device, existing devices will be automatically reused in case of a match. Mount options for dm-verity:
 


### PR DESCRIPTION
It has been around for a year and a half, and 3 releases.

@karelzak what do you think? It seems stable enough to me by now, and I will try to get it enabled by default for Debian 12, if we can unmark it as experimental.