### PR TITLE
fdisk: Add support for fixing MBR partitions CHS values

### DIFF
--- a/disk-utils/fdisk-menu.c
+++ b/disk-utils/fdisk-menu.c
@@ -221,6 +221,7 @@ static const struct menu menu_dos = {
 		MENU_ENT('c', N_("toggle the dos compatibility flag")),
 
 		MENU_XENT('b', N_("move beginning of data in a partition")),
+		MENU_XENT('F', N_("fix partitions C/H/S values")),
 		MENU_XENT('i', N_("change the disk identifier")),
 
 		MENU_BENT_NEST_H('M', N_("return from protective/hybrid MBR to GPT"), FDISK_DISKLABEL_DOS, FDISK_DISKLABEL_GPT),
@@ -868,6 +869,13 @@ static int dos_menu_cb(struct fdisk_context **cxt0,
 			fdisk_info(cxt, _("Leaving nested disklabel."));
 			fdisk_unref_context(cxt);
 		}
+		break;
+	case 'F':
+		rc = fdisk_dos_fix_chs(cxt);
+		if (rc)
+			fdisk_info(cxt, _("C/H/S values fixed."));
+		else
+			fdisk_info(cxt, _("Nothing to do. C/H/S values are correct already."));
 		break;
 	}
 	return rc;

--- a/libfdisk/docs/libfdisk-sections.txt
+++ b/libfdisk/docs/libfdisk-sections.txt
@@ -220,6 +220,7 @@ DOS_FLAG_ACTIVE
 fdisk_dos_enable_compatible
 fdisk_dos_is_compatible
 fdisk_dos_move_begin
+fdisk_dos_fix_chs
 </SECTION>
 
 <SECTION>

--- a/libfdisk/src/libfdisk.h.in
+++ b/libfdisk/src/libfdisk.h.in
@@ -619,6 +619,7 @@ extern int fdisk_iter_get_direction(struct fdisk_iter *itr);
 /* dos.c */
 #define DOS_FLAG_ACTIVE	1
 
+extern int fdisk_dos_fix_chs(struct fdisk_context *cxt);
 extern int fdisk_dos_move_begin(struct fdisk_context *cxt, size_t i);
 extern int fdisk_dos_enable_compatible(struct fdisk_label *lb, int enable);
 extern int fdisk_dos_is_compatible(struct fdisk_label *lb);

--- a/libfdisk/src/libfdisk.sym
+++ b/libfdisk/src/libfdisk.sym
@@ -316,3 +316,7 @@ FDISK_2.36 {
 	fdisk_label_advparse_parttype;
 	fdisk_label_get_parttype_shortcut;
 } FDISK_2.35;
+
+FDISK_2.38 {
+	fdisk_dos_fix_chs;
+} FDISK_2.36;


### PR DESCRIPTION
Add a new extended option 'F' to fdisk which recalculates and fixes CHS
values for each partition in MBR table according to current fdisk settings
for number of heads and sectors per track.

This allows in interactive mode to repair existing partitions to be
compatible with CHS addressing after changing extended option 'h' (number
of heads) or 's' (sectors per track) as these options do not modify content
of existing partitions.