### PR TITLE
Forward value of sector_size instead of its address in blkdev_get_phy…

### DIFF
--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -226,8 +226,10 @@ int blkdev_get_sector_size(int fd __attribute__((__unused__)), int *sector_size)
 #ifdef BLKPBSZGET
 int blkdev_get_physector_size(int fd, int *sector_size)
 {
-	if (ioctl(fd, BLKPBSZGET, &sector_size) >= 0)
+	if (ioctl(fd, BLKPBSZGET, sector_size) >= 0)
+    {
 		return 0;
+    }
 	return -1;
 }
 #else


### PR DESCRIPTION
This is a fix for [issue 1402](https://github.com/karelzak/util-linux/issues/1402). With this patch, `blkdev_get_physector_size` forwards the value of `sector_size` to `ioctl()` instead of sending its address.