### PR TITLE
whereis: use commands for Bash completions

### DIFF
--- a/bash-completion/whereis
+++ b/bash-completion/whereis
@@ -22,7 +22,7 @@ _whereis_module()
 			return 0
 			;;
 	esac
-	COMPREPLY=( $(compgen -W "file" -- $cur) )
+	COMPREPLY=( $(compgen -c -- $cur) )
 	return 0
 }
 complete -F _whereis_module whereis


### PR DESCRIPTION
Currently, the Bash completions for `whereis <TAB>` gives `whereis file` ("file" is not a placeholder here, it literally expands to that). This fixes that by passing the `-c` flag to `compgen` to request completions for command names.