### PR TITLE
lscpu:Add Phytium aarch64 cpupart

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -188,6 +188,10 @@ static const struct id_part hisi_part[] = {
     { -1, "unknown" },
 };
 
+static const struct id_part ft_part[] = {
+    { -1, "unknown" },
+};
+
 static const struct id_part unknown_part[] = {
     { -1, "unknown" },
 };
@@ -215,6 +219,7 @@ static const struct hw_impl hw_implementer[] = {
     { 0x61, unknown_part, "Apple" },
     { 0x66, faraday_part, "Faraday" },
     { 0x69, intel_part,   "Intel" },
+    { 0x70, ft_part,      "Phytium" },
     { 0xc0, unknown_part, "Ampere" },
     { -1,   unknown_part, "unknown" },
 };


### PR DESCRIPTION
Add an entry for the Phytium aarch64 .

Signed-off-by: panchenbo <panchenbo@uniontech.com>