### PR TITLE
lscpu:Add Phytium FT-2000+ & S2500 support

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -189,6 +189,8 @@ static const struct id_part hisi_part[] = {
 };
 
 static const struct id_part ft_part[] = {
+    { 0x662, "FT-2000+" },
+    { 0x663, "S2500" },
     { -1, "unknown" },
 };
 


### PR DESCRIPTION
hi，
I found two Phytium Cpupart，so add them