### PR TITLE
zramctl: add zstd compression algorithm option

### DIFF
--- a/sys-utils/zramctl.8.adoc
+++ b/sys-utils/zramctl.8.adoc
@@ -38,7 +38,7 @@ Note that _zramdev_ node specified on command line has to already exist. The com
 
 == OPTIONS
 
-*-a*, **--algorithm lzo**|**lz4**|**lz4hc**|**deflate**|*842*::
+*-a*, **--algorithm lzo**|**lz4**|**lz4hc**|**deflate**|**842**|**zstd**::
 Set the compression algorithm to be used for compressing data in the zram device.
 
 *-f*, *--find*::

--- a/sys-utils/zramctl.c
+++ b/sys-utils/zramctl.c
@@ -547,7 +547,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Set up and control zram devices.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	fputs(_(" -a, --algorithm lzo|lz4|lz4hc|deflate|842   compression algorithm to use\n"), out);
+	fputs(_(" -a, --algorithm lzo|lz4|lz4hc|deflate|842|zstd   compression algorithm to use\n"), out);
 	fputs(_(" -b, --bytes               print sizes in bytes rather than in human readable format\n"), out);
 	fputs(_(" -f, --find                find a free device\n"), out);
 	fputs(_(" -n, --noheadings          don't print headings\n"), out);


### PR DESCRIPTION
Add information about the possible value 'zstd' for the 'zramctl --algorithm'
option to 'zramctl --help' and zramctl (8) manpage. The kernel supports zram
with zstd compression starting with 4.15 (see
https://lore.kernel.org/lkml/20170912050005.3247-1-sergey.senozhatsky@gmail.com/#r).

Signed-off-by: Jan Samek <samekh@email.cz>