### PR TITLE
asciidoc: fix quoted message in fsck.minix

### DIFF
--- a/disk-utils/fsck.minix.8.adoc
+++ b/disk-utils/fsck.minix.8.adoc
@@ -36,7 +36,7 @@ ____
 |===
 ____
 
-If the filesystem was changed, i.e., repaired, then *fsck.minix* will print "FILE SYSTEM HAS CHANGED" and will *sync*(2) three times before exiting. There is _no_ need to reboot after check.
+If the filesystem was changed, i.e., repaired, then *fsck.minix* will print "FILE SYSTEM HAS BEEN CHANGED" and will *sync*(2) three times before exiting. There is _no_ need to reboot after check.
 
 == WARNING
 


### PR DESCRIPTION
The printed message is `FILE SYSTEM HAS BEEN CHANGED`, according to [disk-utils/fsck.minix.c line 1418](https://github.com/karelzak/util-linux/blob/master/disk-utils/fsck.minix.c#L1418)