### PR TITLE
Fix misspellings

### DIFF
--- a/Documentation/TODO
+++ b/Documentation/TODO
@@ -85,7 +85,7 @@ libmount (mount/umount)
 -----------------------
 
  - mnt_context_get_excode() does not return error messages from /sbin/[u]mount.<type>
-   external helpers. It is disadvantages in same cases (non-terminal progarms).
+   external helpers. It is disadvantages in same cases (non-terminal programs).
    The solution is to use pipe(), keep output from helper in memory and return it later
    by mnt_context_get_excode() (or mnt_context_get_helper_output(), etc.). This feature
    should be optional and disabled by default.

--- a/Documentation/howto-contribute.txt
+++ b/Documentation/howto-contribute.txt
@@ -31,7 +31,7 @@ Sending Patches
 	* don't include generated (autotools) files in your patches.
 	  Hint: use 'git clean -Xd'.
 
-        * don't include po/ (tranlations) changes to the upstream patches.
+        * don't include po/ (translations) changes to the upstream patches.
           The po/ stuff is maintained on http://translationproject.org/domain/util-linux.html
           and updated always before the next release.
 

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -14,7 +14,7 @@ struct ul_buffer {
 	size_t encoded_sz;	/* space allocated for encoded data */
 
 	char **ptrs;		/* saved pointers */
-	size_t nptrs;		/* number of saved poiters */
+	size_t nptrs;		/* number of saved pointers */
 };
 
 #define UL_INIT_BUFFER { .begin = NULL }

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -388,7 +388,7 @@ int ul_strtou32(const char *str, uint32_t *num, int base)
 }
 
 /*
- * Covert strings to numbers in defined range and print message on error.
+ * Convert strings to numbers in defined range and print message on error.
  *
  * These functions are used when we read input from users (getopt() etc.). It's
  * better to consolidate the code and keep it all based on 64-bit numbers then

--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -151,7 +151,7 @@ struct blkid_idmag
 	long		kboff;		/* kilobyte offset of superblock */
 	unsigned int	sboff;		/* byte offset within superblock */
 
-	int		is_zoned;	/* indicate magic location is calcluated based on zone position  */
+	int		is_zoned;	/* indicate magic location is calculated based on zone position  */
 	long		zonenum;	/* zone number which has superblock */
 	long		kboff_inzone;	/* kilobyte offset of superblock in a zone */
 };

--- a/libblkid/src/superblocks/btrfs.c
+++ b/libblkid/src/superblocks/btrfs.c
@@ -103,7 +103,7 @@ static int sb_write_pointer(blkid_probe pr, struct blk_zone *zones, uint64_t *wp
 	 *   *: Special case, no superblock is written
 	 *   0: Use write pointer of zones[0]
 	 *   1: Use write pointer of zones[1]
-	 *   C: Compare super blcoks from zones[0] and zones[1], use the latest
+	 *   C: Compare super blocks from zones[0] and zones[1], use the latest
 	 *      one determined by generation
 	 *   x: Invalid state
 	 */

--- a/libmount/src/optstr.c
+++ b/libmount/src/optstr.c
@@ -806,7 +806,7 @@ int mnt_optstr_apply_flags(char **optstr, unsigned long flags,
 		}
 	}
 
-	/* remove from flags options which are alowed more than once */
+	/* remove from flags options which are allowed more than once */
 	fl &= ~multi;
 
 	/* add missing options (but ignore fl if contains MS_REC only) */

--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -287,7 +287,7 @@ static int is_different_cputype(struct lscpu_cputype *ct, size_t offset, const c
 	return 0;
 }
 
-/* cannonicalize @str -- remove number at the end return the
+/* canonicalize @str -- remove number at the end return the
  * number by @keynum. This is usable for example for "processor 5" or "cache1"
  * cpuinfo lines */
 static char *key_cleanup(char *str, int *keynum)


### PR DESCRIPTION
I ignored misspellings in Release Notes files inside Documentation/releases directory as they seem to come from commit messages (déjà vu: I think I already stumbled upon typos from this directory before).  Let me know if I should target it, and I will improve this PR.