### PR TITLE
losetup: directly set dio instead of afterwards

### DIFF
--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -728,6 +728,8 @@ int main(int argc, char **argv)
 			use_dio = set_dio = 1;
 			if (optarg)
 				use_dio = parse_switch(optarg, _("argument error"), "on", "off", NULL);
+			if (use_dio)
+				lo_flags |= LO_FLAGS_DIRECT_IO;
 			break;
 		case 'v':
 			break;
@@ -847,8 +849,6 @@ int main(int argc, char **argv)
 			if (showdev)
 				printf("%s\n", loopcxt_get_device(&lc));
 			warn_size(file, sizelimit, offset, flags);
-			if (set_dio)
-				goto lo_set_dio;
 		}
 		break;
 	case A_DELETE:
@@ -901,7 +901,6 @@ int main(int argc, char **argv)
 			        loopcxt_get_device(&lc));
 		break;
 	case A_SET_DIRECT_IO:
-lo_set_dio:
 		res = loopcxt_ioctl_dio(&lc, use_dio);
 		if (res)
 			warn(_("%s: set direct io failed"),


### PR DESCRIPTION
This avoids an extra syscall, and allows the kernel to automatically set
block size [0], avoiding unnecessary failure with 4096-byte devices.

This changes the observable behavior of losetup --direct-io in the case
where DIO is not supported to fully fail, instead of creating a
non-direct-io device. If the user explicitly specifies --direct-io, then
they should get either a DIO loopdev or no loopdev, not a non-DIO
loopdev and a misleading error.

Additionally, loopcxt_setup_device now uses O_CLOEXEC in the read-only
fallback.

[0] https://github.com/torvalds/linux/commit/85560117d00f5d528e928918b8f61cadcefff98b