### PR TITLE
more - Bug Resolve - new line separated command re execution

### DIFF
--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -1285,7 +1285,7 @@ static void run_shell(struct more_control *ctl, char *filename)
 	putchar('!');
 	fflush(NULL);
 	if (ctl->previous_command.key == more_kc_run_shell && ctl->shell_line)
-		fputs(ctl->shell_line, stdout);
+		fputs(ctl->shell_line, stderr);
 	else {
 		ttyin(ctl, cmdbuf, sizeof(cmdbuf) - 2, '!');
 		if (strpbrk(cmdbuf, "%!\\"))


### PR DESCRIPTION
Closes #1448 

it was the following line which was actually sending shell_line to `stdout` instead of `stderr`
https://github.com/karelzak/util-linux/blob/78001b7af36f685265e21feaf384a4be12118c64/text-utils/more.c#L1288

Credits - @Aulonsal

Previous Behaviour
![more-prev-bug](https://i.imgur.com/73kjil9.png)

New Behaviour
![more-new](https://i.imgur.com/lvAk7hy.png)
