### PR TITLE
po: Update translations after changes to HiFive partition names

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -5707,12 +5707,12 @@ msgstr "Introduïu el tipus del sistema de fitxers: "
 msgid "Plan 9 partition"
 msgstr "   d   suprimeix una partició"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/cs.po
+++ b/po/cs.po
@@ -5448,13 +5448,13 @@ msgstr "Souborový systém QNX6"
 msgid "Plan 9 partition"
 msgstr "Oddíl Plan 9"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "FSBL HiFive Unleashed"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "FSBL HiFive"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "BBL HiFive Unleashed"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "BBL HiFive"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/da.po
+++ b/po/da.po
@@ -5474,13 +5474,13 @@ msgstr "QNX6-filsystem"
 msgid "Plan 9 partition"
 msgstr "Plan 9-partition"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/de.po
+++ b/po/de.po
@@ -5491,13 +5491,13 @@ msgstr "QNX6-Dateisystem"
 msgid "Plan 9 partition"
 msgstr "Plan 9-Partition"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/es.po
+++ b/po/es.po
@@ -5392,13 +5392,13 @@ msgstr "Sistema de ficheros de QNX6"
 msgid "Plan 9 partition"
 msgstr "Partición del plan 9"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/et.po
+++ b/po/et.po
@@ -5652,12 +5652,12 @@ msgstr "Sisestage failisüsteemi tüübi number: "
 msgid "Plan 9 partition"
 msgstr "   d   kustutada partitsioon"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/eu.po
+++ b/po/eu.po
@@ -5605,12 +5605,12 @@ msgstr "Sartu fitxategi sistema moeta: "
 msgid "Plan 9 partition"
 msgstr "  d          Uneko partizioa ezabatu"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/fi.po
+++ b/po/fi.po
@@ -5616,12 +5616,12 @@ msgstr "Anna tiedostojärjestelmän tyyppi: "
 msgid "Plan 9 partition"
 msgstr "poista osio"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/fr.po
+++ b/po/fr.po
@@ -5354,13 +5354,13 @@ msgstr "Système de fichiers QNX6"
 msgid "Plan 9 partition"
 msgstr "Partition Plan 9"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/gl.po
+++ b/po/gl.po
@@ -5528,12 +5528,12 @@ msgstr "Estado do sistema de ficheriso=%d\n"
 msgid "Plan 9 partition"
 msgstr "   d   eliminar a partición BSD"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/hr.po
+++ b/po/hr.po
@@ -5422,13 +5422,13 @@ msgstr "QNX6 file system"
 msgid "Plan 9 partition"
 msgstr "Plan 9 partition"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "FSBL HiFive Unleashed"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "FSBL HiFive"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "BBL HiFive Unleashed"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "BBL HiFive"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/hu.po
+++ b/po/hu.po
@@ -5680,12 +5680,12 @@ msgstr "Adja meg a fájlrendszer típusát: "
 msgid "Plan 9 partition"
 msgstr "   d   partíció törlése"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/id.po
+++ b/po/id.po
@@ -5677,12 +5677,12 @@ msgstr "Masukkan tipe filesystem: "
 msgid "Plan 9 partition"
 msgstr "   d   hapus sebuah partisi"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/it.po
+++ b/po/it.po
@@ -5705,12 +5705,12 @@ msgstr "Immettere il tipo di filesystem: "
 msgid "Plan 9 partition"
 msgstr "   d   cancellazione di una partizione"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/ja.po
+++ b/po/ja.po
@@ -5366,13 +5366,13 @@ msgstr "QNX6 ファイルシステム"
 msgid "Plan 9 partition"
 msgstr "Plan 9 パーティション"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/ko.po
+++ b/po/ko.po
@@ -5326,13 +5326,13 @@ msgstr "QNX6 파일 시스템"
 msgid "Plan 9 partition"
 msgstr "Plan 9 분할 영역"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5474,12 +5474,12 @@ msgstr "QNX6 bestandssysteem"
 msgid "Plan 9 partition"
 msgstr "Plan-9 partitie"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/pl.po
+++ b/po/pl.po
@@ -5342,13 +5342,13 @@ msgstr "System plików QNX6"
 msgid "Plan 9 partition"
 msgstr "Partycja Plan 9"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/pt.po
+++ b/po/pt.po
@@ -5334,13 +5334,13 @@ msgstr "Sistema de ficheiros QNX6"
 msgid "Plan 9 partition"
 msgstr "Partição Plan 9"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5426,13 +5426,13 @@ msgstr "Sistema de arquivos QNX6"
 msgid "Plan 9 partition"
 msgstr "Plan 9 partição"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5469,12 +5469,12 @@ msgstr "Файловая система QNX6"
 msgid "Plan 9 partition"
 msgstr "   d   удаление раздела"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/sl.po
+++ b/po/sl.po
@@ -5694,12 +5694,12 @@ msgstr "Vnesite vrsto datoteènega sistema: "
 msgid "Plan 9 partition"
 msgstr "   d   zbri¹i razdelek"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/sr.po
+++ b/po/sr.po
@@ -5354,12 +5354,12 @@ msgid "Plan 9 partition"
 msgstr "План 9 партиција"
 
 #: include/pt-gpt-partnames.h:156
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
 #: include/pt-gpt-partnames.h:157
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5408,13 +5408,13 @@ msgstr "QNX6-filsystem"
 msgid "Plan 9 partition"
 msgstr "Plan 9-partition"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5409,12 +5409,12 @@ msgstr "QNX6 dosya sistemi"
 msgid "Plan 9 partition"
 msgstr "Plan 9 disk bölümü"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/uk.po
+++ b/po/uk.po
@@ -5338,13 +5338,13 @@ msgstr "Файлова система QNX6"
 msgid "Plan 9 partition"
 msgstr "Розділ Plan 9"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "FSBL HiFive Unleashed"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "FSBL HiFive"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "BBL HiFive Unleashed"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "BBL HiFive"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/util-linux.pot
+++ b/po/util-linux.pot
@@ -5277,12 +5277,12 @@ msgstr ""
 msgid "Plan 9 partition"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/vi.po
+++ b/po/vi.po
@@ -5501,12 +5501,12 @@ msgstr "Hệ thống tập tin Linux"
 msgid "Plan 9 partition"
 msgstr "xóa một phân vùng"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5367,13 +5367,13 @@ msgstr "QNX6 文件系统"
 msgid "Plan 9 partition"
 msgstr "Plan 9 分区"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
-msgstr "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
+msgstr "HiFive FSBL"
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
-msgstr "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
+msgstr "HiFive BBL"
 
 #: include/pt-mbr-partnames.h:1
 msgid "Empty"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5699,12 +5699,12 @@ msgstr "檔案系統型態"
 msgid "Plan 9 partition"
 msgstr "刪除分割"
 
-#: include/pt-gpt-partnames.h:169
-msgid "HiFive Unleashed FSBL"
+#: include/pt-gpt-partnames.h:181
+msgid "HiFive FSBL"
 msgstr ""
 
-#: include/pt-gpt-partnames.h:170
-msgid "HiFive Unleashed BBL"
+#: include/pt-gpt-partnames.h:182
+msgid "HiFive BBL"
 msgstr ""
 
 #: include/pt-mbr-partnames.h:1


### PR DESCRIPTION
Commit 6dc36290326c ("include: Rename HiFive partition UUIDs")
changed the HiFive partition names but did not update the translation
files accordingly: fix that now.

Fixes: 6dc36290326c ("include: Rename HiFive partition UUIDs")
Signed-off-by: Alexandre Ghiti <alexandre.ghiti@canonical.com>